### PR TITLE
String tensor charsets and raw bytes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
   </modules>
 
   <properties>
+    <project.build.sourceEncoding>ASCII</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <junit.version>4.12</junit.version>

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlowException.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlowException.java
@@ -17,6 +17,9 @@ package org.tensorflow;
 
 /** Unchecked exception thrown when executing TensorFlow Graphs. */
 public final class TensorFlowException extends RuntimeException {
+  TensorFlowException(String message, Throwable cause) {
+    super(message, cause);
+  }
   TensorFlowException(String message) {
     super(message);
   }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/StringTensorBuffer.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/StringTensorBuffer.java
@@ -159,7 +159,7 @@ public class StringTensorBuffer extends AbstractDataBuffer<byte[]> {
     long offsetIndex = 0;
     long dataIndex = 0;
 
-    public void writeNext(byte[] bytes) {
+    void writeNext(byte[] bytes) {
       offsets.setLong(dataIndex, offsetIndex++);
 
       // Encode string length as a varint first

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/TensorBuffers.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/TensorBuffers.java
@@ -34,8 +34,17 @@ import org.tensorflow.tools.buffer.LongDataBuffer;
 import org.tensorflow.tools.buffer.ShortDataBuffer;
 import org.tensorflow.tools.buffer.layout.DataLayouts;
 
+/**
+ * Maps native tensor memory into {@link DataBuffers}, allowing I/O operations from the JVM.
+ */
 public final class TensorBuffers {
 
+  /**
+   * Maps tensor memory as a buffer of bytes.
+   *
+   * @param nativeTensor native reference to the tensor
+   * @return a byte buffer
+   */
   public static ByteDataBuffer toBytes(TF_Tensor nativeTensor) {
     Pointer tensorMemory = tensorMemory(nativeTensor);
     if (TensorRawDataBufferFactory.canBeUsed()) {
@@ -44,6 +53,12 @@ public final class TensorBuffers {
     return DataBuffers.from(tensorMemory.asByteBuffer());
   }
 
+  /**
+   * Maps tensor memory as a buffer of integers.
+   *
+   * @param nativeTensor native reference to the tensor
+   * @return an int buffer
+   */
   public static IntDataBuffer toInts(TF_Tensor nativeTensor) {
     Pointer tensorMemory = tensorMemory(nativeTensor);
     if (TensorRawDataBufferFactory.canBeUsed()) {
@@ -52,6 +67,12 @@ public final class TensorBuffers {
     return DataBuffers.from(tensorMemory.asByteBuffer().asIntBuffer());
   }
 
+  /**
+   * Maps tensor memory as a buffer of longs.
+   *
+   * @param nativeTensor native reference to the tensor
+   * @return a long buffer
+   */
   public static LongDataBuffer toLongs(TF_Tensor nativeTensor) {
     Pointer tensorMemory = tensorMemory(nativeTensor);
     if (TensorRawDataBufferFactory.canBeUsed()) {
@@ -60,6 +81,12 @@ public final class TensorBuffers {
     return DataBuffers.from(tensorMemory.asByteBuffer().asLongBuffer());
   }
 
+  /**
+   * Maps tensor memory as a buffer of floats.
+   *
+   * @param nativeTensor native reference to the tensor
+   * @return a float buffer
+   */
   public static FloatDataBuffer toFloats(TF_Tensor nativeTensor) {
     Pointer tensorMemory = tensorMemory(nativeTensor);
     if (TensorRawDataBufferFactory.canBeUsed()) {
@@ -68,6 +95,12 @@ public final class TensorBuffers {
     return DataBuffers.from(tensorMemory.asByteBuffer().asFloatBuffer());
   }
 
+  /**
+   * Maps tensor memory as a buffer of doubles.
+   *
+   * @param nativeTensor native reference to the tensor
+   * @return a double buffer
+   */
   public static DoubleDataBuffer toDoubles(TF_Tensor nativeTensor) {
     Pointer tensorMemory = tensorMemory(nativeTensor);
     if (TensorRawDataBufferFactory.canBeUsed()) {
@@ -76,6 +109,12 @@ public final class TensorBuffers {
     return DataBuffers.from(tensorMemory.asByteBuffer().asDoubleBuffer());
   }
 
+  /**
+   * Maps tensor memory as a buffer of shorts.
+   *
+   * @param nativeTensor native reference to the tensor
+   * @return a short buffer
+   */
   public static ShortDataBuffer toShorts(TF_Tensor nativeTensor) {
     Pointer tensorMemory = tensorMemory(nativeTensor);
     if (TensorRawDataBufferFactory.canBeUsed()) {
@@ -84,6 +123,12 @@ public final class TensorBuffers {
     return DataBuffers.from(tensorMemory.asByteBuffer().asShortBuffer());
   }
 
+  /**
+   * Maps tensor memory as a buffer of booleans.
+   *
+   * @param nativeTensor native reference to the tensor
+   * @return a boolean buffer
+   */
   public static BooleanDataBuffer toBooleans(TF_Tensor nativeTensor) {
     Pointer tensorMemory = tensorMemory(nativeTensor);
     if (TensorRawDataBufferFactory.canBeUsed()) {
@@ -94,6 +139,12 @@ public final class TensorBuffers {
     return DataLayouts.BOOL.applyTo(DataBuffers.from(tensorMemory.asByteBuffer()));
   }
 
+  /**
+   * Maps tensor memory as a buffer of byte sequences, often used to store string values.
+   *
+   * @param nativeTensor native reference to the tensor
+   * @return a string buffer
+   */
   public static StringTensorBuffer toStrings(TF_Tensor nativeTensor, long numElements) {
     Pointer tensorMemory = tensorMemory(nativeTensor);
     if (TensorRawDataBufferFactory.canBeUsed()) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/TensorRawDataBufferFactory.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/TensorRawDataBufferFactory.java
@@ -59,7 +59,7 @@ class TensorRawDataBufferFactory extends RawDataBufferFactory {
 
   static StringTensorBuffer mapTensorToStrings(Pointer tensorMemory, long numElements) {
     long offsetByteSize = numElements * Long.BYTES;
-    LongDataBuffer offsets = mapNativeLongs(tensorMemory.address(), numElements, false);
+    LongDataBuffer offsets = mapNativeLongs(tensorMemory.address(), offsetByteSize, false);
     ByteDataBuffer data = mapNativeBytes(
         tensorMemory.address() + offsetByteSize,
         tensorMemory.capacity() - offsetByteSize,

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
@@ -56,9 +56,7 @@ public interface TBfloat16 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TBfloat16> scalarOf(float value) {
-    Tensor<TBfloat16> t = ofShape();
-    t.data().setFloat(value);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.scalar(), data -> data.setFloat(value));
   }
 
   /**
@@ -68,9 +66,7 @@ public interface TBfloat16 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TBfloat16> vectorOf(float... values) {
-    Tensor<TBfloat16> t = ofShape(values.length);
-    t.data().write(values);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.make(values.length), data -> data.write(values));
   }
 
   /**
@@ -104,9 +100,7 @@ public interface TBfloat16 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TBfloat16> copyOf(NdArray<Float> src) {
-    Tensor<TBfloat16> t = Tensor.allocate(DTYPE, src.shape());
-    src.copyTo(t.data());
-    return t;
+    return Tensor.allocate(DTYPE, src.shape(), src::copyTo);
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
@@ -48,9 +48,7 @@ public interface TBool extends BooleanNdArray, TType {
    * @return the new tensor
    */
   static Tensor<TBool> scalarOf(boolean value) {
-    Tensor<TBool> t = ofShape();
-    t.data().setBoolean(value);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.scalar(), data -> data.setBoolean(value));
   }
 
   /**
@@ -60,9 +58,7 @@ public interface TBool extends BooleanNdArray, TType {
    * @return the new tensor
    */
   static Tensor<TBool> vectorOf(boolean... values) {
-    Tensor<TBool> t = ofShape(values.length);
-    t.data().write(values);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.make(values.length), data -> data.write(values));
   }
 
   /**
@@ -96,9 +92,7 @@ public interface TBool extends BooleanNdArray, TType {
    * @return the new tensor
    */
   static Tensor<TBool> copyOf(NdArray<Boolean> src) {
-    Tensor<TBool> t = Tensor.allocate(DTYPE, src.shape());
-    src.copyTo(t.data());
-    return t;
+    return Tensor.allocate(DTYPE, src.shape(), src::copyTo);
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
@@ -53,9 +53,7 @@ public interface TFloat16 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat16> scalarOf(float value) {
-    Tensor<TFloat16> t = ofShape();
-    t.data().setFloat(value);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.scalar(), data -> data.setFloat(value));
   }
 
   /**
@@ -65,9 +63,7 @@ public interface TFloat16 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat16> vectorOf(float... values) {
-    Tensor<TFloat16> t = ofShape(values.length);
-    t.data().write(values);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.make(values.length), data -> data.write(values));
   }
 
   /**
@@ -101,9 +97,7 @@ public interface TFloat16 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat16> copyOf(NdArray<Float> src) {
-    Tensor<TFloat16> t = Tensor.allocate(DTYPE, src.shape());
-    src.copyTo(t.data());
-    return t;
+    return Tensor.allocate(DTYPE, src.shape(), src::copyTo);
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
@@ -43,9 +43,7 @@ public interface TFloat32 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat32> scalarOf(float value) {
-    Tensor<TFloat32> t = ofShape();
-    t.data().setFloat(value);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.scalar(), data -> data.setFloat(value));
   }
 
   /**
@@ -55,9 +53,7 @@ public interface TFloat32 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat32> vectorOf(float... values) {
-    Tensor<TFloat32> t = ofShape(values.length);
-    t.data().write(values);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.make(values.length), data -> data.write(values));
   }
 
   /**
@@ -91,9 +87,7 @@ public interface TFloat32 extends FloatNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat32> copyOf(NdArray<Float> src) {
-    Tensor<TFloat32> t = Tensor.allocate(DTYPE, src.shape());
-    src.copyTo(t.data());
-    return t;
+    return Tensor.allocate(DTYPE, src.shape(), src::copyTo);
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
@@ -43,9 +43,7 @@ public interface TFloat64 extends DoubleNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat64> scalarOf(double value) {
-    Tensor<TFloat64> t = ofShape();
-    t.data().setDouble(value);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.scalar(), data -> data.setDouble(value));
   }
 
   /**
@@ -55,9 +53,7 @@ public interface TFloat64 extends DoubleNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat64> vectorOf(double... values) {
-    Tensor<TFloat64> t = ofShape(values.length);
-    t.data().write(values);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.make(values.length), data -> data.write(values));
   }
 
   /**
@@ -91,9 +87,7 @@ public interface TFloat64 extends DoubleNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TFloat64> copyOf(NdArray<Double> src) {
-    Tensor<TFloat64> t = Tensor.allocate(DTYPE, src.shape());
-    src.copyTo(t.data());
-    return t;
+    return Tensor.allocate(DTYPE, src.shape(), src::copyTo);
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
@@ -43,9 +43,7 @@ public interface TInt32 extends IntNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TInt32> scalarOf(int value) {
-    Tensor<TInt32> t = ofShape();
-    t.data().setInt(value);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.scalar(), data -> data.setInt(value));
   }
 
   /**
@@ -55,9 +53,7 @@ public interface TInt32 extends IntNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TInt32> vectorOf(int... values) {
-    Tensor<TInt32> t = ofShape(values.length);
-    t.data().write(values);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.make(values.length), data -> data.write(values));
   }
 
   /**
@@ -91,9 +87,7 @@ public interface TInt32 extends IntNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TInt32> copyOf(NdArray<Integer> src) {
-    Tensor<TInt32> t = Tensor.allocate(DTYPE, src.shape());
-    src.copyTo(t.data());
-    return t;
+    return Tensor.allocate(DTYPE, src.shape(), src::copyTo);
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
@@ -43,9 +43,7 @@ public interface TInt64 extends LongNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TInt64> scalarOf(long value) {
-    Tensor<TInt64> t = ofShape();
-    t.data().setLong(value);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.scalar(), data -> data.setLong(value));
   }
 
   /**
@@ -55,9 +53,7 @@ public interface TInt64 extends LongNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TInt64> vectorOf(long... values) {
-    Tensor<TInt64> t = ofShape(values.length);
-    t.data().write(values);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.make(values.length), data -> data.write(values));
   }
 
   /**
@@ -91,9 +87,7 @@ public interface TInt64 extends LongNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TInt64> copyOf(NdArray<Long> src) {
-    Tensor<TInt64> t = Tensor.allocate(DTYPE, src.shape());
-    src.copyTo(t.data());
-    return t;
+    return Tensor.allocate(DTYPE, src.shape(), src::copyTo);
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
@@ -59,7 +59,7 @@ public interface TString extends NdArray<String>, TType {
    * @return the new tensor
    */
   static Tensor<TString> scalarOf(String value) {
-    return copyOf(NdArrays.ofObjects(String.class, Shape.scalar()).setObject(value));
+    return copyOf(NdArrays.scalarOfObject(value));
   }
 
   /**
@@ -71,7 +71,7 @@ public interface TString extends NdArray<String>, TType {
    * @return the new tensor
    */
   static Tensor<TString> vectorOf(String... values) {
-    return copyOf(NdArrays.ofObjects(String.class, Shape.make(values.length)).write(values));
+    return copyOf(NdArrays.vectorOfObjects(values));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
@@ -43,9 +43,7 @@ public interface TUint8 extends ByteNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TUint8> scalarOf(byte value) {
-    Tensor<TUint8> t = ofShape();
-    t.data().setByte(value);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.scalar(), data -> data.setByte(value));
   }
 
   /**
@@ -55,9 +53,7 @@ public interface TUint8 extends ByteNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TUint8> vectorOf(byte... values) {
-    Tensor<TUint8> t = ofShape(values.length);
-    t.data().write(values);
-    return t;
+    return Tensor.allocate(DTYPE, Shape.make(values.length), data -> data.write(values));
   }
 
   /**
@@ -91,9 +87,7 @@ public interface TUint8 extends ByteNdArray, TNumber {
    * @return the new tensor
    */
   static Tensor<TUint8> copyOf(NdArray<Byte> src) {
-    Tensor<TUint8> t = Tensor.allocate(DTYPE, src.shape());
-    src.copyTo(t.data());
-    return t;
+    return Tensor.allocate(DTYPE, src.shape(), src::copyTo);
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TStringTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TStringTest.java
@@ -73,18 +73,18 @@ public class TStringTest {
 
   @Test
   public void defaultCharsetIsUtf8() {
-    Tensor<TString> tensor = TString.copyOf(NdArrays.scalarOfObject("🐥"));  // a baby chick
+    Tensor<TString> tensor = TString.copyOf(NdArrays.scalarOfObject(BABY_CHICK));
     byte[] bytes = tensor.data().asBytes().getObject();
     assertArrayEquals(new byte[] { (byte)0xF0, (byte)0x9F, (byte)0x90, (byte)0xA5 }, bytes);
-    assertEquals("🐥", tensor.data().getObject());
+    assertEquals(BABY_CHICK, tensor.data().getObject());
   }
 
   @Test
   public void usingDifferentCharset() {
-    Tensor<TString> tensor = TString.copyOf(StandardCharsets.UTF_16LE, NdArrays.scalarOfObject("🐥"));  // a baby chick
+    Tensor<TString> tensor = TString.copyOf(StandardCharsets.UTF_16LE, NdArrays.scalarOfObject(BABY_CHICK));
     byte[] bytes = tensor.data().asBytes().getObject();
     assertArrayEquals(new byte[] { (byte)0x3D, (byte)0xD8, (byte)0x25, (byte)0xDC }, bytes);
-    assertEquals("🐥", tensor.data().use(StandardCharsets.UTF_16LE).getObject());
+    assertEquals(BABY_CHICK, tensor.data().use(StandardCharsets.UTF_16LE).getObject());
   }
 
   @Test
@@ -103,4 +103,6 @@ public class TStringTest {
       assertArrayEquals(bytes.getObject(i), tensorBytes.getObject(i));
     }
   }
+
+  private static final String BABY_CHICK = "\uD83D\uDC25";	  
 }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TStringTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TStringTest.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  =======================================================================
+ */
+
+package org.tensorflow.types;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.tensorflow.Tensor;
+import org.tensorflow.tools.Shape;
+import org.tensorflow.tools.ndarray.NdArray;
+import org.tensorflow.tools.ndarray.NdArrays;
+
+public class TStringTest {
+
+  @Test
+  public void createScalar() {
+    Tensor<TString> tensor = TString.scalarOf("Pretty vacant");
+    assertNotNull(tensor);
+
+    TString data = tensor.data();
+    assertNotNull(data);
+    assertEquals(Shape.scalar(), data.shape());
+    assertEquals("Pretty vacant", data.getObject());
+  }
+
+  @Test
+  public void createVector() {
+    Tensor<TString> tensor = TString.vectorOf("Pretty", "vacant");
+    assertNotNull(tensor);
+
+    TString data = tensor.data();
+    assertNotNull(data);
+    assertEquals(Shape.make(2), data.shape());
+    assertEquals("Pretty", data.getObject(0));
+    assertEquals("vacant", data.getObject(1));
+  }
+
+  @Test
+  public void createCopy() {
+    NdArray<String> strings = NdArrays.ofObjects(String.class, Shape.make(2, 2))
+        .setObject("Pretty", 0, 0)
+        .setObject("vacant", 0, 1)
+        .setObject("New", 1, 0)
+        .setObject("York", 1, 1);
+
+    Tensor<TString> tensor = TString.copyOf(strings);
+    assertNotNull(tensor);
+
+    TString data = tensor.data();
+    assertNotNull(data);
+    strings.scalars().forEachIndexed((idx, s) ->
+        assertEquals(s.getObject(), data.getObject(idx))
+    );
+  }
+
+  @Test
+  public void defaultCharsetIsUtf8() {
+    Tensor<TString> tensor = TString.copyOf(NdArrays.scalarOfObject("🐥"));  // a baby chick
+    byte[] bytes = tensor.data().asBytes().getObject();
+    assertArrayEquals(new byte[] { (byte)0xF0, (byte)0x9F, (byte)0x90, (byte)0xA5 }, bytes);
+    assertEquals("🐥", tensor.data().getObject());
+  }
+
+  @Test
+  public void usingDifferentCharset() {
+    Tensor<TString> tensor = TString.copyOf(StandardCharsets.UTF_16LE, NdArrays.scalarOfObject("🐥"));  // a baby chick
+    byte[] bytes = tensor.data().asBytes().getObject();
+    assertArrayEquals(new byte[] { (byte)0x3D, (byte)0xD8, (byte)0x25, (byte)0xDC }, bytes);
+    assertEquals("🐥", tensor.data().use(StandardCharsets.UTF_16LE).getObject());
+  }
+
+  @Test
+  public void initializingTensorWithRawBytes() {
+    String[] strings = new String[] { "TensorFlow", "For", "Java", "Rocks", "!" };
+    NdArray<byte[]> bytes = NdArrays.ofObjects(byte[].class, Shape.make(strings.length));
+    for (int i = 0; i < strings.length; ++i) {
+      bytes.setObject(strings[i].getBytes(), i);
+    }
+    Tensor<TString> tensor = TString.copyOfBytes(bytes);
+    assertNotNull(tensor);
+    assertEquals(bytes.shape(), tensor.shape());
+
+    NdArray<byte[]> tensorBytes = tensor.data().asBytes();
+    for (int i = 0; i < strings.length; ++i) {
+      assertArrayEquals(bytes.getObject(i), tensorBytes.getObject(i));
+    }
+  }
+}

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/layout/StringLayout.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/layout/StringLayout.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  =======================================================================
+ */
+
+package org.tensorflow.tools.buffer.impl.layout;
+
+import java.nio.charset.Charset;
+import org.tensorflow.tools.buffer.DataBuffer;
+import org.tensorflow.tools.buffer.ShortDataBuffer;
+import org.tensorflow.tools.buffer.layout.DataLayout;
+import org.tensorflow.tools.buffer.layout.FloatDataLayout;
+
+/**
+ * Data layout that converts a String to/from a sequence of bytes applying a given charset.
+ */
+public final class StringLayout implements DataLayout<DataBuffer<byte[]>, String> {
+
+  public static StringLayout of(Charset charset) {
+    return new StringLayout(charset);
+  }
+
+  @Override
+  public void writeObject(DataBuffer<byte[]> buffer, String value, long index) {
+    buffer.setObject(value.getBytes(charset), index);
+  }
+
+  @Override
+  public String readObject(DataBuffer<byte[]> buffer, long index) {
+    return new String(buffer.getObject(index), charset);
+  }
+
+  private StringLayout(Charset charset) {
+    this.charset = charset;
+  }
+
+  private final Charset charset;
+}

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/layout/DataLayouts.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/layout/DataLayouts.java
@@ -17,11 +17,14 @@
 
 package org.tensorflow.tools.buffer.layout;
 
+import java.nio.charset.Charset;
 import org.tensorflow.tools.buffer.ByteDataBuffer;
+import org.tensorflow.tools.buffer.DataBuffer;
 import org.tensorflow.tools.buffer.ShortDataBuffer;
 import org.tensorflow.tools.buffer.impl.layout.Bfloat16Layout;
 import org.tensorflow.tools.buffer.impl.layout.BoolLayout;
 import org.tensorflow.tools.buffer.impl.layout.Float16Layout;
+import org.tensorflow.tools.buffer.impl.layout.StringLayout;
 
 /**
  * Exposes {@link DataLayout} instances of data formats frequently used in linear algebra computation.
@@ -76,4 +79,17 @@ public final class DataLayouts {
    * explicit type casting.
    */
   public static final BooleanDataLayout<ByteDataBuffer> BOOL = new BoolLayout();
+
+  /**
+   * Creates a data layout for converting strings to/from byte sequences.
+   *
+   * <p>This layout requires a {@code charset} in parameter to specify how the strings must be
+   * encoded/decoded as byte sequences. So a new layout instance is always returned.
+   *
+   * @param charset charset to use
+   * @return a new string layout
+   */
+  public static DataLayout<DataBuffer<byte[]>, String> ofStrings(Charset charset) {
+    return StringLayout.of(charset);
+  }
 }


### PR DESCRIPTION
In previous implementation, UTF-8 character encoding was forced for all string tensors. Furthermore, it was not possible to work directly with sequences of raw bytes.

This PR adds the ability for a user to select which charset to use when encoding/decoding values from a tensor. It is also possible now to read directly the raw bytes of a string tensor and/or to create a tensor from an array of raw bytes. For example:
```java
NdArray<String> strings = NdArrays.vectorOfObjects("Pretty", "vacant");

Tensor<TString> utf8Tensor = TString.copyOf(strings);  // encodes using default UTF-8 charset
assertEquals("Pretty", utf8Tensor.data().getObject(0));  // decodes using default UTF-8 charset

Charset charset = StandardCharsets.UTF_16;
Tensor<TString> utf16Tensor = TString.copyOf(charset, strings); // encodes using UTF-16 charset
assertEquals("Pretty", utf16Tensor.data().use(charset).getObject(0));  // decodes using UTF-16 charset

NdArray<byte[]> utf16Bytes = utf16Tensor.data().asBytes();  // returns raw bytes of the UTF-16 tensor
assertEquals("Pretty", new String(utf16Bytes.getObject(0), charset));

Tensor<TString> utf16TensorCopy = TString.copyOfBytes(utf16Bytes);  // create a tensor from raw bytes
```
Also added to this PR is a safety catch of any exception that might occur when implicitly initializing the data of a tensor, which releases the tensor memory in case of failure.