### PR TITLE
Enable Maven deploy on push for CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI jobs
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   linux-x86_64:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ jobs:
         run: |
           yum -y update
           yum -y install centos-release-scl-rh epel-release
-          yum -y install java-1.8.0-openjdk-devel devtoolset-7 rh-git218 rh-maven35 patch python36-devel python36-pip python36-six
+          yum -y install java-1.8.0-openjdk-devel devtoolset-7 rh-git218 patch python36-devel python36-pip python36-six
+          echo Downloading Maven
+          curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -o $HOME/apache-maven-3.6.3-bin.tar.gz
+          tar xzf $HOME/apache-maven-3.6.3-bin.tar.gz -C /opt/
+          ln -sf /opt/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
           echo Downloading Bazel
           curl -L https://github.com/bazelbuild/bazel/releases/download/0.29.1/bazel-0.29.1-installer-linux-x86_64.sh -o bazel.sh --retry 10
           bash bazel.sh
@@ -21,14 +25,19 @@ jobs:
         uses: actions/checkout@v1
       - name: Build project
         run: |
-          source scl_source enable devtoolset-7 rh-git218 rh-maven35 || true
+          source scl_source enable devtoolset-7 rh-git218 || true
           git --version
           gcc --version
           mvn -version
           bazel version
           df -h
-          echo Executing Maven without Wagon HTTP pool that fails under Docker
-          mvn clean install -B -U -e -Dmaven.wagon.http.pool=false -Djavacpp.platform=linux-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
+          echo "Fixing HOME to /root (was '$HOME')"
+          export HOME=/root
+          mkdir -p $HOME/.m2
+          [[ "${{ github.event_name }}" == "push" ]] && MAVEN_PHASE=deploy || MAVEN_PHASE=install
+          echo "<settings><servers><server><id>ossrh</id><username>${{ secrets.CI_DEPLOY_USERNAME }}</username><password>${{ secrets.CI_DEPLOY_PASSWORD }}</password></server></servers></settings>" > $HOME/.m2/settings.xml
+          echo Executing Maven $MAVEN_PHASE
+          mvn clean $MAVEN_PHASE -Possrh -B -U -e -Djavacpp.platform=linux-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
           df -h
   macosx-x86_64:
     runs-on: macos-latest
@@ -50,9 +59,12 @@ jobs:
           clang --version
           mvn -version
           bazel version
+          mkdir -p $HOME/.m2
+          [[ "${{ github.event_name }}" == "push" ]] && MAVEN_PHASE=deploy || MAVEN_PHASE=install
+          echo "<settings><servers><server><id>ossrh</id><username>${{ secrets.CI_DEPLOY_USERNAME }}</username><password>${{ secrets.CI_DEPLOY_PASSWORD }}</password></server></servers></settings>" > $HOME/.m2/settings.xml
           df -h
-          echo Executing Maven
-          mvn clean install -B -U -e -Djavacpp.platform=macosx-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
+          echo Executing Maven $MAVEN_PHASE
+          mvn clean $MAVEN_PHASE -Possrh -B -U -e -Djavacpp.platform=macosx-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
           df -h
   windows-x86_64:
     runs-on: windows-latest
@@ -97,9 +109,12 @@ jobs:
           cl
           call mvn -version
           bazel version
+          mkdir %USERPROFILE%\.m2
+          if "${{ github.event_name }}"=="push" (set MAVEN_PHASE=deploy) else (set MAVEN_PHASE=install)
+          echo ^<settings^>^<servers^>^<server^>^<id^>ossrh^</id^>^<username^>${{ secrets.CI_DEPLOY_USERNAME }}^</username^>^<password^>${{ secrets.CI_DEPLOY_PASSWORD }}^</password^>^</server^>^</servers^>^</settings^> > %USERPROFILE%\.m2\settings.xml
           df -h
           wmic pagefile list /format:list
-          echo Executing Maven
-          call mvn clean install -B -U -e -Djavacpp.platform=windows-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
+          echo Executing Maven %MAVEN_PHASE%
+          call mvn clean %MAVEN_PHASE% -Possrh -B -U -e -Djavacpp.platform=windows-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
           df -h
           wmic pagefile list /format:list

--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -8,7 +8,7 @@ export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
 export BAZEL_VC="${VCINSTALLDIR:-}"
 if [[ -d $BAZEL_VC ]]; then
     # Work around compiler issues on Windows documented mainly in configure.py but also elsewhere
-    export BUILD_FLAGS="--copt=//arch:AVX `#--copt=//arch:AVX2` --copt=-DWIN32_LEAN_AND_MEAN --host_copt=-DWIN32_LEAN_AND_MEAN --copt=-DNOGDI --host_copt=-DNOGDI --define=override_eigen_strong_inline=true"
+    export BUILD_FLAGS="--copt=//arch:AVX `#--copt=//arch:AVX2` --copt=-DWIN32_LEAN_AND_MEAN --host_copt=-DWIN32_LEAN_AND_MEAN --copt=-DNOGDI --host_copt=-DNOGDI --copt=-D_USE_MATH_DEFINES --host_copt=-D_USE_MATH_DEFINES --define=override_eigen_strong_inline=true"
     # https://software.intel.com/en-us/articles/intel-optimization-for-tensorflow-installation-guide#wind_B_S
     export PATH=$PATH:$(pwd)/bazel-tensorflow-core-api/external/mkl_windows/lib/
     export PYTHON_BIN_PATH=$(which python.exe)


### PR DESCRIPTION
Also fix build on Windows for TensorFlow 2.1.0
(However, it still fails on GitHub Actions as explained in pull https://github.com/tensorflow/java/pull/8.)

With these changes, builds triggered by a `git push` are executed with `mvn clean deploy -Possrh ...`
It looks like this: https://github.com/saudet/tensorflow-java/actions/runs/32841274
(Builds triggered by pull requests remain with `mvn clean install ...`)

To make that work in any given repository, the CI_DEPLOY_USERNAME and CI_DEPLOY_PASSWORD secrets need to be set to valid credentials from https://oss.sonatype.org/ and the `org.tensorflow` domain: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets @sjamesr Does this sound reasonable?

But that's it! We're now getting snapshots deployed that end users can start testing immediately:
https://oss.sonatype.org/content/repositories/snapshots/org/tensorflow/

/cc @vb216