### PR TITLE
Deterministic ops generation

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/AudioOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/AudioOps.java
@@ -22,6 +22,21 @@ public final class AudioOps {
   }
 
   /**
+   * Builds an {@link AudioSpectrogram} operation
+   *
+   * @param input Float representation of audio data.
+   * @param windowSize How wide the input window is in samples. For the highest efficiency
+   * @param stride How widely apart the center of adjacent sample windows should be.
+   * @param options carries optional attributes values
+   * @return a new instance of AudioSpectrogram
+   * @see org.tensorflow.op.audio.AudioSpectrogram
+   */
+  public AudioSpectrogram audioSpectrogram(Operand<TFloat32> input, Long windowSize, Long stride,
+      AudioSpectrogram.Options... options) {
+    return AudioSpectrogram.create(scope, input, windowSize, stride, options);
+  }
+
+  /**
    * Builds an {@link DecodeWav} operation
    *
    * @param contents The WAV-encoded audio, usually from a file.
@@ -57,20 +72,5 @@ public final class AudioOps {
   public Mfcc mfcc(Operand<TFloat32> spectrogram, Operand<TInt32> sampleRate,
       Mfcc.Options... options) {
     return Mfcc.create(scope, spectrogram, sampleRate, options);
-  }
-
-  /**
-   * Builds an {@link AudioSpectrogram} operation
-   *
-   * @param input Float representation of audio data.
-   * @param windowSize How wide the input window is in samples. For the highest efficiency
-   * @param stride How widely apart the center of adjacent sample windows should be.
-   * @param options carries optional attributes values
-   * @return a new instance of AudioSpectrogram
-   * @see org.tensorflow.op.audio.AudioSpectrogram
-   */
-  public AudioSpectrogram audioSpectrogram(Operand<TFloat32> input, Long windowSize, Long stride,
-      AudioSpectrogram.Options... options) {
-    return AudioSpectrogram.create(scope, input, windowSize, stride, options);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/BitwiseOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/BitwiseOps.java
@@ -22,6 +22,18 @@ public final class BitwiseOps {
   }
 
   /**
+   * Builds an {@link BitwiseAnd} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of BitwiseAnd
+   * @see org.tensorflow.op.bitwise.BitwiseAnd
+   */
+  public <T extends TNumber> BitwiseAnd<T> bitwiseAnd(Operand<T> x, Operand<T> y) {
+    return BitwiseAnd.create(scope, x, y);
+  }
+
+  /**
    * Builds an {@link BitwiseOr} operation
    *
    * @param x 
@@ -46,18 +58,6 @@ public final class BitwiseOps {
   }
 
   /**
-   * Builds an {@link BitwiseAnd} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of BitwiseAnd
-   * @see org.tensorflow.op.bitwise.BitwiseAnd
-   */
-  public <T extends TNumber> BitwiseAnd<T> bitwiseAnd(Operand<T> x, Operand<T> y) {
-    return BitwiseAnd.create(scope, x, y);
-  }
-
-  /**
    * Builds an {@link Invert} operation
    *
    * @param x 
@@ -66,18 +66,6 @@ public final class BitwiseOps {
    */
   public <T extends TNumber> Invert<T> invert(Operand<T> x) {
     return Invert.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link RightShift} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of RightShift
-   * @see org.tensorflow.op.bitwise.RightShift
-   */
-  public <T extends TNumber> RightShift<T> rightShift(Operand<T> x, Operand<T> y) {
-    return RightShift.create(scope, x, y);
   }
 
   /**
@@ -90,5 +78,17 @@ public final class BitwiseOps {
    */
   public <T extends TNumber> LeftShift<T> leftShift(Operand<T> x, Operand<T> y) {
     return LeftShift.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link RightShift} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of RightShift
+   * @see org.tensorflow.op.bitwise.RightShift
+   */
+  public <T extends TNumber> RightShift<T> rightShift(Operand<T> x, Operand<T> y) {
+    return RightShift.create(scope, x, y);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DataOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DataOps.java
@@ -29,86 +29,6 @@ public final class DataOps {
   }
 
   /**
-   * Builds an {@link OptionalNone} operation
-   *
-   * @return a new instance of OptionalNone
-   * @see org.tensorflow.op.data.OptionalNone
-   */
-  public OptionalNone optionalNone() {
-    return OptionalNone.create(scope);
-  }
-
-  /**
-   * Builds an {@link OptionalFromValue} operation
-   *
-   * @param components 
-   * @return a new instance of OptionalFromValue
-   * @see org.tensorflow.op.data.OptionalFromValue
-   */
-  public OptionalFromValue optionalFromValue(Iterable<Operand<?>> components) {
-    return OptionalFromValue.create(scope, components);
-  }
-
-  /**
-   * Builds an {@link IteratorGetNextAsOptional} operation
-   *
-   * @param iterator 
-   * @param outputTypes 
-   * @param outputShapes 
-   * @return a new instance of IteratorGetNextAsOptional
-   * @see org.tensorflow.op.data.IteratorGetNextAsOptional
-   */
-  public IteratorGetNextAsOptional iteratorGetNextAsOptional(Operand<?> iterator,
-      List<DataType<?>> outputTypes, List<Shape> outputShapes) {
-    return IteratorGetNextAsOptional.create(scope, iterator, outputTypes, outputShapes);
-  }
-
-  /**
-   * Builds an {@link IteratorToStringHandle} operation
-   *
-   * @param resourceHandle A handle to an iterator resource.
-   * @return a new instance of IteratorToStringHandle
-   * @see org.tensorflow.op.data.IteratorToStringHandle
-   */
-  public IteratorToStringHandle iteratorToStringHandle(Operand<?> resourceHandle) {
-    return IteratorToStringHandle.create(scope, resourceHandle);
-  }
-
-  /**
-   * Builds an {@link OptionalHasValue} operation
-   *
-   * @param optional 
-   * @return a new instance of OptionalHasValue
-   * @see org.tensorflow.op.data.OptionalHasValue
-   */
-  public OptionalHasValue optionalHasValue(Operand<?> optional) {
-    return OptionalHasValue.create(scope, optional);
-  }
-
-  /**
-   * Builds an {@link SerializeIterator} operation
-   *
-   * @param resourceHandle A handle to an iterator resource.
-   * @return a new instance of SerializeIterator
-   * @see org.tensorflow.op.data.SerializeIterator
-   */
-  public SerializeIterator serializeIterator(Operand<?> resourceHandle) {
-    return SerializeIterator.create(scope, resourceHandle);
-  }
-
-  /**
-   * Builds an {@link MakeIterator} operation
-   *
-   * @param dataset 
-   * @param iterator 
-   * @return a new instance of MakeIterator
-   * @see org.tensorflow.op.data.MakeIterator
-   */
-  public MakeIterator makeIterator(Operand<?> dataset, Operand<?> iterator) {
-    return MakeIterator.create(scope, dataset, iterator);
-  }
-
-  /**
    * Builds an {@link DeserializeIterator} operation
    *
    * @param resourceHandle A handle to an iterator resource.
@@ -118,20 +38,6 @@ public final class DataOps {
    */
   public DeserializeIterator deserializeIterator(Operand<?> resourceHandle, Operand<?> serialized) {
     return DeserializeIterator.create(scope, resourceHandle, serialized);
-  }
-
-  /**
-   * Builds an {@link OptionalGetValue} operation
-   *
-   * @param optional 
-   * @param outputTypes 
-   * @param outputShapes 
-   * @return a new instance of OptionalGetValue
-   * @see org.tensorflow.op.data.OptionalGetValue
-   */
-  public OptionalGetValue optionalGetValue(Operand<?> optional, List<DataType<?>> outputTypes,
-      List<Shape> outputShapes) {
-    return OptionalGetValue.create(scope, optional, outputTypes, outputShapes);
   }
 
   /**
@@ -149,6 +55,20 @@ public final class DataOps {
   }
 
   /**
+   * Builds an {@link IteratorGetNextAsOptional} operation
+   *
+   * @param iterator 
+   * @param outputTypes 
+   * @param outputShapes 
+   * @return a new instance of IteratorGetNextAsOptional
+   * @see org.tensorflow.op.data.IteratorGetNextAsOptional
+   */
+  public IteratorGetNextAsOptional iteratorGetNextAsOptional(Operand<?> iterator,
+      List<DataType<?>> outputTypes, List<Shape> outputShapes) {
+    return IteratorGetNextAsOptional.create(scope, iterator, outputTypes, outputShapes);
+  }
+
+  /**
    * Builds an {@link IteratorGetNextSync} operation
    *
    * @param iterator 
@@ -160,5 +80,85 @@ public final class DataOps {
   public IteratorGetNextSync iteratorGetNextSync(Operand<?> iterator, List<DataType<?>> outputTypes,
       List<Shape> outputShapes) {
     return IteratorGetNextSync.create(scope, iterator, outputTypes, outputShapes);
+  }
+
+  /**
+   * Builds an {@link IteratorToStringHandle} operation
+   *
+   * @param resourceHandle A handle to an iterator resource.
+   * @return a new instance of IteratorToStringHandle
+   * @see org.tensorflow.op.data.IteratorToStringHandle
+   */
+  public IteratorToStringHandle iteratorToStringHandle(Operand<?> resourceHandle) {
+    return IteratorToStringHandle.create(scope, resourceHandle);
+  }
+
+  /**
+   * Builds an {@link MakeIterator} operation
+   *
+   * @param dataset 
+   * @param iterator 
+   * @return a new instance of MakeIterator
+   * @see org.tensorflow.op.data.MakeIterator
+   */
+  public MakeIterator makeIterator(Operand<?> dataset, Operand<?> iterator) {
+    return MakeIterator.create(scope, dataset, iterator);
+  }
+
+  /**
+   * Builds an {@link OptionalFromValue} operation
+   *
+   * @param components 
+   * @return a new instance of OptionalFromValue
+   * @see org.tensorflow.op.data.OptionalFromValue
+   */
+  public OptionalFromValue optionalFromValue(Iterable<Operand<?>> components) {
+    return OptionalFromValue.create(scope, components);
+  }
+
+  /**
+   * Builds an {@link OptionalGetValue} operation
+   *
+   * @param optional 
+   * @param outputTypes 
+   * @param outputShapes 
+   * @return a new instance of OptionalGetValue
+   * @see org.tensorflow.op.data.OptionalGetValue
+   */
+  public OptionalGetValue optionalGetValue(Operand<?> optional, List<DataType<?>> outputTypes,
+      List<Shape> outputShapes) {
+    return OptionalGetValue.create(scope, optional, outputTypes, outputShapes);
+  }
+
+  /**
+   * Builds an {@link OptionalHasValue} operation
+   *
+   * @param optional 
+   * @return a new instance of OptionalHasValue
+   * @see org.tensorflow.op.data.OptionalHasValue
+   */
+  public OptionalHasValue optionalHasValue(Operand<?> optional) {
+    return OptionalHasValue.create(scope, optional);
+  }
+
+  /**
+   * Builds an {@link OptionalNone} operation
+   *
+   * @return a new instance of OptionalNone
+   * @see org.tensorflow.op.data.OptionalNone
+   */
+  public OptionalNone optionalNone() {
+    return OptionalNone.create(scope);
+  }
+
+  /**
+   * Builds an {@link SerializeIterator} operation
+   *
+   * @param resourceHandle A handle to an iterator resource.
+   * @return a new instance of SerializeIterator
+   * @see org.tensorflow.op.data.SerializeIterator
+   */
+  public SerializeIterator serializeIterator(Operand<?> resourceHandle) {
+    return SerializeIterator.create(scope, resourceHandle);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DtypesOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DtypesOps.java
@@ -21,6 +21,18 @@ public final class DtypesOps {
   }
 
   /**
+   * Builds an {@link AsString} operation
+   *
+   * @param input 
+   * @param options carries optional attributes values
+   * @return a new instance of AsString
+   * @see org.tensorflow.op.dtypes.AsString
+   */
+  public <T extends TType> AsString asString(Operand<T> input, AsString.Options... options) {
+    return AsString.create(scope, input, options);
+  }
+
+  /**
    * Builds an {@link Cast} operation
    *
    * @param x 
@@ -32,18 +44,6 @@ public final class DtypesOps {
   public <U extends TType, T extends TType> Cast<U> cast(Operand<T> x, DataType<U> DstT,
       Cast.Options... options) {
     return Cast.create(scope, x, DstT, options);
-  }
-
-  /**
-   * Builds an {@link AsString} operation
-   *
-   * @param input 
-   * @param options carries optional attributes values
-   * @return a new instance of AsString
-   * @see org.tensorflow.op.dtypes.AsString
-   */
-  public <T extends TType> AsString asString(Operand<T> input, AsString.Options... options) {
-    return AsString.create(scope, input, options);
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/ImageOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/ImageOps.java
@@ -55,6 +55,19 @@ public final class ImageOps {
   }
 
   /**
+   * Builds an {@link AdjustContrast} operation
+   *
+   * @param images Images to adjust.  At least 3-D.
+   * @param contrastFactor A float multiplier for adjusting contrast.
+   * @return a new instance of AdjustContrast
+   * @see org.tensorflow.op.image.AdjustContrast
+   */
+  public <T extends TNumber> AdjustContrast<T> adjustContrast(Operand<T> images,
+      Operand<TFloat32> contrastFactor) {
+    return AdjustContrast.create(scope, images, contrastFactor);
+  }
+
+  /**
    * Builds an {@link AdjustHue} operation
    *
    * @param images Images to adjust.  At least 3-D.
@@ -64,202 +77,6 @@ public final class ImageOps {
    */
   public <T extends TNumber> AdjustHue<T> adjustHue(Operand<T> images, Operand<TFloat32> delta) {
     return AdjustHue.create(scope, images, delta);
-  }
-
-  /**
-   * Builds an {@link QuantizedResizeBilinear} operation
-   *
-   * @param images 4-D with shape `[batch, height, width, channels]`.
-   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
-   * @param min 
-   * @param max 
-   * @param options carries optional attributes values
-   * @return a new instance of QuantizedResizeBilinear
-   * @see org.tensorflow.op.image.QuantizedResizeBilinear
-   */
-  public <T extends TType> QuantizedResizeBilinear<T> quantizedResizeBilinear(Operand<T> images,
-      Operand<TInt32> size, Operand<TFloat32> min, Operand<TFloat32> max,
-      QuantizedResizeBilinear.Options... options) {
-    return QuantizedResizeBilinear.create(scope, images, size, min, max, options);
-  }
-
-  /**
-   * Builds an {@link ResizeBilinear} operation
-   *
-   * @param images 4-D with shape `[batch, height, width, channels]`.
-   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
-   * @param options carries optional attributes values
-   * @return a new instance of ResizeBilinear
-   * @see org.tensorflow.op.image.ResizeBilinear
-   */
-  public <T extends TNumber> ResizeBilinear resizeBilinear(Operand<T> images, Operand<TInt32> size,
-      ResizeBilinear.Options... options) {
-    return ResizeBilinear.create(scope, images, size, options);
-  }
-
-  /**
-   * Builds an {@link DecodeGif} operation
-   *
-   * @param contents 0-D.  The GIF-encoded image.
-   * @return a new instance of DecodeGif
-   * @see org.tensorflow.op.image.DecodeGif
-   */
-  public DecodeGif decodeGif(Operand<TString> contents) {
-    return DecodeGif.create(scope, contents);
-  }
-
-  /**
-   * Builds an {@link RgbToHsv} operation
-   *
-   * @param images 1-D or higher rank. RGB data to convert. Last dimension must be size 3.
-   * @return a new instance of RgbToHsv
-   * @see org.tensorflow.op.image.RgbToHsv
-   */
-  public <T extends TNumber> RgbToHsv<T> rgbToHsv(Operand<T> images) {
-    return RgbToHsv.create(scope, images);
-  }
-
-  /**
-   * Builds an {@link HsvToRgb} operation
-   *
-   * @param images 1-D or higher rank. HSV data to convert. Last dimension must be size 3.
-   * @return a new instance of HsvToRgb
-   * @see org.tensorflow.op.image.HsvToRgb
-   */
-  public <T extends TNumber> HsvToRgb<T> hsvToRgb(Operand<T> images) {
-    return HsvToRgb.create(scope, images);
-  }
-
-  /**
-   * Builds an {@link DecodeBmp} operation
-   *
-   * @param contents 0-D.  The BMP-encoded image.
-   * @param options carries optional attributes values
-   * @return a new instance of DecodeBmp
-   * @see org.tensorflow.op.image.DecodeBmp
-   */
-  public DecodeBmp decodeBmp(Operand<TString> contents, DecodeBmp.Options... options) {
-    return DecodeBmp.create(scope, contents, options);
-  }
-
-  /**
-   * Builds an {@link ResizeBicubic} operation
-   *
-   * @param images 4-D with shape `[batch, height, width, channels]`.
-   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
-   * @param options carries optional attributes values
-   * @return a new instance of ResizeBicubic
-   * @see org.tensorflow.op.image.ResizeBicubic
-   */
-  public <T extends TNumber> ResizeBicubic resizeBicubic(Operand<T> images, Operand<TInt32> size,
-      ResizeBicubic.Options... options) {
-    return ResizeBicubic.create(scope, images, size, options);
-  }
-
-  /**
-   * Builds an {@link DecodePng} operation
-   *
-   * @param contents 0-D.  The PNG-encoded image.
-   * @param dtype 
-   * @param options carries optional attributes values
-   * @return a new instance of DecodePng
-   * @see org.tensorflow.op.image.DecodePng
-   */
-  public <T extends TNumber> DecodePng<T> decodePng(Operand<TString> contents, DataType<T> dtype,
-      DecodePng.Options... options) {
-    return DecodePng.create(scope, contents, dtype, options);
-  }
-
-  /**
-   * Builds an {@link RandomCrop} operation
-   *
-   * @param image 3-D of shape `[height, width, channels]`.
-   * @param size 1-D of length 2 containing: `crop_height`, `crop_width`..
-   * @param options carries optional attributes values
-   * @return a new instance of RandomCrop
-   * @see org.tensorflow.op.image.RandomCrop
-   */
-  public <T extends TNumber> RandomCrop<T> randomCrop(Operand<T> image, Operand<TInt64> size,
-      RandomCrop.Options... options) {
-    return RandomCrop.create(scope, image, size, options);
-  }
-
-  /**
-   * Builds an {@link DecodePng} operation
-   *
-   * @param contents 0-D.  The PNG-encoded image.
-   * @param options carries optional attributes values
-   * @return a new instance of DecodePng
-   * @see org.tensorflow.op.image.DecodePng
-   */
-  public DecodePng<TUint8> decodePng(Operand<TString> contents, DecodePng.Options... options) {
-    return DecodePng.create(scope, contents, options);
-  }
-
-  /**
-   * Builds an {@link DecodeAndCropJpeg} operation
-   *
-   * @param contents 0-D.  The JPEG-encoded image.
-   * @param cropWindow 1-D.  The crop window: [crop_y, crop_x, crop_height, crop_width].
-   * @param options carries optional attributes values
-   * @return a new instance of DecodeAndCropJpeg
-   * @see org.tensorflow.op.image.DecodeAndCropJpeg
-   */
-  public DecodeAndCropJpeg decodeAndCropJpeg(Operand<TString> contents, Operand<TInt32> cropWindow,
-      DecodeAndCropJpeg.Options... options) {
-    return DecodeAndCropJpeg.create(scope, contents, cropWindow, options);
-  }
-
-  /**
-   * Builds an {@link NonMaxSuppressionWithOverlaps} operation
-   *
-   * @param overlaps A 2-D float tensor of shape `[num_boxes, num_boxes]` representing
-   * @param scores A 1-D float tensor of shape `[num_boxes]` representing a single
-   * @param maxOutputSize A scalar integer tensor representing the maximum number of
-   * @param overlapThreshold A 0-D float tensor representing the threshold for deciding whether
-   * @param scoreThreshold A 0-D float tensor representing the threshold for deciding when to remove
-   * @return a new instance of NonMaxSuppressionWithOverlaps
-   * @see org.tensorflow.op.image.NonMaxSuppressionWithOverlaps
-   */
-  public NonMaxSuppressionWithOverlaps nonMaxSuppressionWithOverlaps(Operand<TFloat32> overlaps,
-      Operand<TFloat32> scores, Operand<TInt32> maxOutputSize, Operand<TFloat32> overlapThreshold,
-      Operand<TFloat32> scoreThreshold) {
-    return NonMaxSuppressionWithOverlaps.create(scope, overlaps, scores, maxOutputSize, overlapThreshold, scoreThreshold);
-  }
-
-  /**
-   * Builds an {@link SampleDistortedBoundingBox} operation
-   *
-   * @param imageSize 1-D, containing `[height, width, channels]`.
-   * @param boundingBoxes 3-D with shape `[batch, N, 4]` describing the N bounding boxes
-   * @param minObjectCovered The cropped area of the image must contain at least this
-   * @param options carries optional attributes values
-   * @return a new instance of SampleDistortedBoundingBox
-   * @see org.tensorflow.op.image.SampleDistortedBoundingBox
-   */
-  public <T extends TNumber> SampleDistortedBoundingBox<T> sampleDistortedBoundingBox(
-      Operand<T> imageSize, Operand<TFloat32> boundingBoxes, Operand<TFloat32> minObjectCovered,
-      SampleDistortedBoundingBox.Options... options) {
-    return SampleDistortedBoundingBox.create(scope, imageSize, boundingBoxes, minObjectCovered, options);
-  }
-
-  /**
-   * Builds an {@link NonMaxSuppression} operation
-   *
-   * @param boxes A 2-D float tensor of shape `[num_boxes, 4]`.
-   * @param scores A 1-D float tensor of shape `[num_boxes]` representing a single
-   * @param maxOutputSize A scalar integer tensor representing the maximum number of
-   * @param iouThreshold A 0-D float tensor representing the threshold for deciding whether
-   * @param scoreThreshold A 0-D float tensor representing the threshold for deciding when to remove
-   * @param softNmsSigma A 0-D float tensor representing the sigma parameter for Soft NMS; see Bodla et
-   * @param options carries optional attributes values
-   * @return a new instance of NonMaxSuppression
-   * @see org.tensorflow.op.image.NonMaxSuppression
-   */
-  public <T extends TNumber> NonMaxSuppression<T> nonMaxSuppression(Operand<T> boxes,
-      Operand<T> scores, Operand<TInt32> maxOutputSize, Operand<T> iouThreshold,
-      Operand<T> scoreThreshold, Operand<T> softNmsSigma, NonMaxSuppression.Options... options) {
-    return NonMaxSuppression.create(scope, boxes, scores, maxOutputSize, iouThreshold, scoreThreshold, softNmsSigma, options);
   }
 
   /**
@@ -273,19 +90,6 @@ public final class ImageOps {
   public <T extends TNumber> AdjustSaturation<T> adjustSaturation(Operand<T> images,
       Operand<TFloat32> scale) {
     return AdjustSaturation.create(scope, images, scale);
-  }
-
-  /**
-   * Builds an {@link ExtractJpegShape} operation
-   *
-   * @param contents 0-D. The JPEG-encoded image.
-   * @param outputType (Optional) The output type of the operation (int32 or int64).
-   * @return a new instance of ExtractJpegShape
-   * @see org.tensorflow.op.image.ExtractJpegShape
-   */
-  public <T extends TNumber> ExtractJpegShape<T> extractJpegShape(Operand<TString> contents,
-      DataType<T> outputType) {
-    return ExtractJpegShape.create(scope, contents, outputType);
   }
 
   /**
@@ -309,6 +113,22 @@ public final class ImageOps {
   }
 
   /**
+   * Builds an {@link CropAndResize} operation
+   *
+   * @param image A 4-D tensor of shape `[batch, image_height, image_width, depth]`.
+   * @param boxes A 2-D tensor of shape `[num_boxes, 4]`. The `i`-th row of the tensor
+   * @param boxInd A 1-D tensor of shape `[num_boxes]` with int32 values in `[0, batch)`.
+   * @param cropSize A 1-D tensor of 2 elements, `size = [crop_height, crop_width]`. All
+   * @param options carries optional attributes values
+   * @return a new instance of CropAndResize
+   * @see org.tensorflow.op.image.CropAndResize
+   */
+  public <T extends TNumber> CropAndResize cropAndResize(Operand<T> image, Operand<TFloat32> boxes,
+      Operand<TInt32> boxInd, Operand<TInt32> cropSize, CropAndResize.Options... options) {
+    return CropAndResize.create(scope, image, boxes, boxInd, cropSize, options);
+  }
+
+  /**
    * Builds an {@link CropAndResizeGradBoxes} operation
    *
    * @param grads A 4-D tensor of shape `[num_boxes, crop_height, crop_width, depth]`.
@@ -326,59 +146,96 @@ public final class ImageOps {
   }
 
   /**
-   * Builds an {@link ResizeArea} operation
+   * Builds an {@link CropAndResizeGradImage} operation
    *
-   * @param images 4-D with shape `[batch, height, width, channels]`.
-   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
+   * @param grads A 4-D tensor of shape `[num_boxes, crop_height, crop_width, depth]`.
+   * @param boxes A 2-D tensor of shape `[num_boxes, 4]`. The `i`-th row of the tensor
+   * @param boxInd A 1-D tensor of shape `[num_boxes]` with int32 values in `[0, batch)`.
+   * @param imageSize A 1-D tensor with value `[batch, image_height, image_width, depth]`
+   * @param T 
    * @param options carries optional attributes values
-   * @return a new instance of ResizeArea
-   * @see org.tensorflow.op.image.ResizeArea
+   * @return a new instance of CropAndResizeGradImage
+   * @see org.tensorflow.op.image.CropAndResizeGradImage
    */
-  public <T extends TNumber> ResizeArea resizeArea(Operand<T> images, Operand<TInt32> size,
-      ResizeArea.Options... options) {
-    return ResizeArea.create(scope, images, size, options);
+  public <T extends TNumber> CropAndResizeGradImage<T> cropAndResizeGradImage(
+      Operand<TFloat32> grads, Operand<TFloat32> boxes, Operand<TInt32> boxInd,
+      Operand<TInt32> imageSize, DataType<T> T, CropAndResizeGradImage.Options... options) {
+    return CropAndResizeGradImage.create(scope, grads, boxes, boxInd, imageSize, T, options);
   }
 
   /**
-   * Builds an {@link EncodePng} operation
+   * Builds an {@link DecodeAndCropJpeg} operation
    *
-   * @param image 3-D with shape `[height, width, channels]`.
+   * @param contents 0-D.  The JPEG-encoded image.
+   * @param cropWindow 1-D.  The crop window: [crop_y, crop_x, crop_height, crop_width].
    * @param options carries optional attributes values
-   * @return a new instance of EncodePng
-   * @see org.tensorflow.op.image.EncodePng
+   * @return a new instance of DecodeAndCropJpeg
+   * @see org.tensorflow.op.image.DecodeAndCropJpeg
    */
-  public <T extends TNumber> EncodePng encodePng(Operand<T> image, EncodePng.Options... options) {
-    return EncodePng.create(scope, image, options);
+  public DecodeAndCropJpeg decodeAndCropJpeg(Operand<TString> contents, Operand<TInt32> cropWindow,
+      DecodeAndCropJpeg.Options... options) {
+    return DecodeAndCropJpeg.create(scope, contents, cropWindow, options);
   }
 
   /**
-   * Builds an {@link EncodeJpegVariableQuality} operation
+   * Builds an {@link DecodeBmp} operation
    *
-   * @param images Images to adjust.  At least 3-D.
-   * @param quality An int quality to encode to.
-   * @return a new instance of EncodeJpegVariableQuality
-   * @see org.tensorflow.op.image.EncodeJpegVariableQuality
+   * @param contents 0-D.  The BMP-encoded image.
+   * @param options carries optional attributes values
+   * @return a new instance of DecodeBmp
+   * @see org.tensorflow.op.image.DecodeBmp
    */
-  public EncodeJpegVariableQuality encodeJpegVariableQuality(Operand<TUint8> images,
-      Operand<TInt32> quality) {
-    return EncodeJpegVariableQuality.create(scope, images, quality);
+  public DecodeBmp decodeBmp(Operand<TString> contents, DecodeBmp.Options... options) {
+    return DecodeBmp.create(scope, contents, options);
   }
 
   /**
-   * Builds an {@link ScaleAndTranslate} operation
+   * Builds an {@link DecodeGif} operation
    *
-   * @param images 
-   * @param size 
-   * @param scale 
-   * @param translation 
-   * @param options carries optional attributes values
-   * @return a new instance of ScaleAndTranslate
-   * @see org.tensorflow.op.image.ScaleAndTranslate
+   * @param contents 0-D.  The GIF-encoded image.
+   * @return a new instance of DecodeGif
+   * @see org.tensorflow.op.image.DecodeGif
    */
-  public <T extends TNumber> ScaleAndTranslate scaleAndTranslate(Operand<T> images,
-      Operand<TInt32> size, Operand<TFloat32> scale, Operand<TFloat32> translation,
-      ScaleAndTranslate.Options... options) {
-    return ScaleAndTranslate.create(scope, images, size, scale, translation, options);
+  public DecodeGif decodeGif(Operand<TString> contents) {
+    return DecodeGif.create(scope, contents);
+  }
+
+  /**
+   * Builds an {@link DecodeJpeg} operation
+   *
+   * @param contents 0-D.  The JPEG-encoded image.
+   * @param options carries optional attributes values
+   * @return a new instance of DecodeJpeg
+   * @see org.tensorflow.op.image.DecodeJpeg
+   */
+  public DecodeJpeg decodeJpeg(Operand<TString> contents, DecodeJpeg.Options... options) {
+    return DecodeJpeg.create(scope, contents, options);
+  }
+
+  /**
+   * Builds an {@link DecodePng} operation
+   *
+   * @param contents 0-D.  The PNG-encoded image.
+   * @param options carries optional attributes values
+   * @return a new instance of DecodePng
+   * @see org.tensorflow.op.image.DecodePng
+   */
+  public DecodePng<TUint8> decodePng(Operand<TString> contents, DecodePng.Options... options) {
+    return DecodePng.create(scope, contents, options);
+  }
+
+  /**
+   * Builds an {@link DecodePng} operation
+   *
+   * @param contents 0-D.  The PNG-encoded image.
+   * @param dtype 
+   * @param options carries optional attributes values
+   * @return a new instance of DecodePng
+   * @see org.tensorflow.op.image.DecodePng
+   */
+  public <T extends TNumber> DecodePng<T> decodePng(Operand<TString> contents, DataType<T> dtype,
+      DecodePng.Options... options) {
+    return DecodePng.create(scope, contents, dtype, options);
   }
 
   /**
@@ -396,30 +253,55 @@ public final class ImageOps {
   }
 
   /**
-   * Builds an {@link ResizeNearestNeighbor} operation
+   * Builds an {@link EncodeJpeg} operation
    *
-   * @param images 4-D with shape `[batch, height, width, channels]`.
-   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
+   * @param image 3-D with shape `[height, width, channels]`.
    * @param options carries optional attributes values
-   * @return a new instance of ResizeNearestNeighbor
-   * @see org.tensorflow.op.image.ResizeNearestNeighbor
+   * @return a new instance of EncodeJpeg
+   * @see org.tensorflow.op.image.EncodeJpeg
    */
-  public <T extends TNumber> ResizeNearestNeighbor<T> resizeNearestNeighbor(Operand<T> images,
-      Operand<TInt32> size, ResizeNearestNeighbor.Options... options) {
-    return ResizeNearestNeighbor.create(scope, images, size, options);
+  public EncodeJpeg encodeJpeg(Operand<TUint8> image, EncodeJpeg.Options... options) {
+    return EncodeJpeg.create(scope, image, options);
   }
 
   /**
-   * Builds an {@link AdjustContrast} operation
+   * Builds an {@link EncodeJpegVariableQuality} operation
    *
    * @param images Images to adjust.  At least 3-D.
-   * @param contrastFactor A float multiplier for adjusting contrast.
-   * @return a new instance of AdjustContrast
-   * @see org.tensorflow.op.image.AdjustContrast
+   * @param quality An int quality to encode to.
+   * @return a new instance of EncodeJpegVariableQuality
+   * @see org.tensorflow.op.image.EncodeJpegVariableQuality
    */
-  public <T extends TNumber> AdjustContrast<T> adjustContrast(Operand<T> images,
-      Operand<TFloat32> contrastFactor) {
-    return AdjustContrast.create(scope, images, contrastFactor);
+  public EncodeJpegVariableQuality encodeJpegVariableQuality(Operand<TUint8> images,
+      Operand<TInt32> quality) {
+    return EncodeJpegVariableQuality.create(scope, images, quality);
+  }
+
+  /**
+   * Builds an {@link EncodePng} operation
+   *
+   * @param image 3-D with shape `[height, width, channels]`.
+   * @param options carries optional attributes values
+   * @return a new instance of EncodePng
+   * @see org.tensorflow.op.image.EncodePng
+   */
+  public <T extends TNumber> EncodePng encodePng(Operand<T> image, EncodePng.Options... options) {
+    return EncodePng.create(scope, image, options);
+  }
+
+  /**
+   * Builds an {@link ExtractGlimpse} operation
+   *
+   * @param input A 4-D float tensor of shape `[batch_size, height, width, channels]`.
+   * @param size A 1-D tensor of 2 elements containing the size of the glimpses
+   * @param offsets A 2-D integer tensor of shape `[batch_size, 2]` containing
+   * @param options carries optional attributes values
+   * @return a new instance of ExtractGlimpse
+   * @see org.tensorflow.op.image.ExtractGlimpse
+   */
+  public ExtractGlimpse extractGlimpse(Operand<TFloat32> input, Operand<TInt32> size,
+      Operand<TFloat32> offsets, ExtractGlimpse.Options... options) {
+    return ExtractGlimpse.create(scope, input, size, offsets, options);
   }
 
   /**
@@ -450,75 +332,193 @@ public final class ImageOps {
   }
 
   /**
-   * Builds an {@link CropAndResizeGradImage} operation
+   * Builds an {@link ExtractJpegShape} operation
    *
-   * @param grads A 4-D tensor of shape `[num_boxes, crop_height, crop_width, depth]`.
-   * @param boxes A 2-D tensor of shape `[num_boxes, 4]`. The `i`-th row of the tensor
-   * @param boxInd A 1-D tensor of shape `[num_boxes]` with int32 values in `[0, batch)`.
-   * @param imageSize A 1-D tensor with value `[batch, image_height, image_width, depth]`
-   * @param T 
-   * @param options carries optional attributes values
-   * @return a new instance of CropAndResizeGradImage
-   * @see org.tensorflow.op.image.CropAndResizeGradImage
+   * @param contents 0-D. The JPEG-encoded image.
+   * @param outputType (Optional) The output type of the operation (int32 or int64).
+   * @return a new instance of ExtractJpegShape
+   * @see org.tensorflow.op.image.ExtractJpegShape
    */
-  public <T extends TNumber> CropAndResizeGradImage<T> cropAndResizeGradImage(
-      Operand<TFloat32> grads, Operand<TFloat32> boxes, Operand<TInt32> boxInd,
-      Operand<TInt32> imageSize, DataType<T> T, CropAndResizeGradImage.Options... options) {
-    return CropAndResizeGradImage.create(scope, grads, boxes, boxInd, imageSize, T, options);
+  public <T extends TNumber> ExtractJpegShape<T> extractJpegShape(Operand<TString> contents,
+      DataType<T> outputType) {
+    return ExtractJpegShape.create(scope, contents, outputType);
   }
 
   /**
-   * Builds an {@link DecodeJpeg} operation
+   * Builds an {@link HsvToRgb} operation
    *
-   * @param contents 0-D.  The JPEG-encoded image.
-   * @param options carries optional attributes values
-   * @return a new instance of DecodeJpeg
-   * @see org.tensorflow.op.image.DecodeJpeg
+   * @param images 1-D or higher rank. HSV data to convert. Last dimension must be size 3.
+   * @return a new instance of HsvToRgb
+   * @see org.tensorflow.op.image.HsvToRgb
    */
-  public DecodeJpeg decodeJpeg(Operand<TString> contents, DecodeJpeg.Options... options) {
-    return DecodeJpeg.create(scope, contents, options);
+  public <T extends TNumber> HsvToRgb<T> hsvToRgb(Operand<T> images) {
+    return HsvToRgb.create(scope, images);
   }
 
   /**
-   * Builds an {@link EncodeJpeg} operation
+   * Builds an {@link NonMaxSuppression} operation
    *
-   * @param image 3-D with shape `[height, width, channels]`.
+   * @param boxes A 2-D float tensor of shape `[num_boxes, 4]`.
+   * @param scores A 1-D float tensor of shape `[num_boxes]` representing a single
+   * @param maxOutputSize A scalar integer tensor representing the maximum number of
+   * @param iouThreshold A 0-D float tensor representing the threshold for deciding whether
+   * @param scoreThreshold A 0-D float tensor representing the threshold for deciding when to remove
+   * @param softNmsSigma A 0-D float tensor representing the sigma parameter for Soft NMS; see Bodla et
    * @param options carries optional attributes values
-   * @return a new instance of EncodeJpeg
-   * @see org.tensorflow.op.image.EncodeJpeg
+   * @return a new instance of NonMaxSuppression
+   * @see org.tensorflow.op.image.NonMaxSuppression
    */
-  public EncodeJpeg encodeJpeg(Operand<TUint8> image, EncodeJpeg.Options... options) {
-    return EncodeJpeg.create(scope, image, options);
+  public <T extends TNumber> NonMaxSuppression<T> nonMaxSuppression(Operand<T> boxes,
+      Operand<T> scores, Operand<TInt32> maxOutputSize, Operand<T> iouThreshold,
+      Operand<T> scoreThreshold, Operand<T> softNmsSigma, NonMaxSuppression.Options... options) {
+    return NonMaxSuppression.create(scope, boxes, scores, maxOutputSize, iouThreshold, scoreThreshold, softNmsSigma, options);
   }
 
   /**
-   * Builds an {@link ExtractGlimpse} operation
+   * Builds an {@link NonMaxSuppressionWithOverlaps} operation
    *
-   * @param input A 4-D float tensor of shape `[batch_size, height, width, channels]`.
-   * @param size A 1-D tensor of 2 elements containing the size of the glimpses
-   * @param offsets A 2-D integer tensor of shape `[batch_size, 2]` containing
-   * @param options carries optional attributes values
-   * @return a new instance of ExtractGlimpse
-   * @see org.tensorflow.op.image.ExtractGlimpse
+   * @param overlaps A 2-D float tensor of shape `[num_boxes, num_boxes]` representing
+   * @param scores A 1-D float tensor of shape `[num_boxes]` representing a single
+   * @param maxOutputSize A scalar integer tensor representing the maximum number of
+   * @param overlapThreshold A 0-D float tensor representing the threshold for deciding whether
+   * @param scoreThreshold A 0-D float tensor representing the threshold for deciding when to remove
+   * @return a new instance of NonMaxSuppressionWithOverlaps
+   * @see org.tensorflow.op.image.NonMaxSuppressionWithOverlaps
    */
-  public ExtractGlimpse extractGlimpse(Operand<TFloat32> input, Operand<TInt32> size,
-      Operand<TFloat32> offsets, ExtractGlimpse.Options... options) {
-    return ExtractGlimpse.create(scope, input, size, offsets, options);
+  public NonMaxSuppressionWithOverlaps nonMaxSuppressionWithOverlaps(Operand<TFloat32> overlaps,
+      Operand<TFloat32> scores, Operand<TInt32> maxOutputSize, Operand<TFloat32> overlapThreshold,
+      Operand<TFloat32> scoreThreshold) {
+    return NonMaxSuppressionWithOverlaps.create(scope, overlaps, scores, maxOutputSize, overlapThreshold, scoreThreshold);
   }
 
   /**
-   * Builds an {@link CropAndResize} operation
+   * Builds an {@link QuantizedResizeBilinear} operation
    *
-   * @param image A 4-D tensor of shape `[batch, image_height, image_width, depth]`.
-   * @param boxes A 2-D tensor of shape `[num_boxes, 4]`. The `i`-th row of the tensor
-   * @param boxInd A 1-D tensor of shape `[num_boxes]` with int32 values in `[0, batch)`.
-   * @param cropSize A 1-D tensor of 2 elements, `size = [crop_height, crop_width]`. All
+   * @param images 4-D with shape `[batch, height, width, channels]`.
+   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
+   * @param min 
+   * @param max 
    * @param options carries optional attributes values
-   * @return a new instance of CropAndResize
-   * @see org.tensorflow.op.image.CropAndResize
+   * @return a new instance of QuantizedResizeBilinear
+   * @see org.tensorflow.op.image.QuantizedResizeBilinear
    */
-  public <T extends TNumber> CropAndResize cropAndResize(Operand<T> image, Operand<TFloat32> boxes,
-      Operand<TInt32> boxInd, Operand<TInt32> cropSize, CropAndResize.Options... options) {
-    return CropAndResize.create(scope, image, boxes, boxInd, cropSize, options);
+  public <T extends TType> QuantizedResizeBilinear<T> quantizedResizeBilinear(Operand<T> images,
+      Operand<TInt32> size, Operand<TFloat32> min, Operand<TFloat32> max,
+      QuantizedResizeBilinear.Options... options) {
+    return QuantizedResizeBilinear.create(scope, images, size, min, max, options);
+  }
+
+  /**
+   * Builds an {@link RandomCrop} operation
+   *
+   * @param image 3-D of shape `[height, width, channels]`.
+   * @param size 1-D of length 2 containing: `crop_height`, `crop_width`..
+   * @param options carries optional attributes values
+   * @return a new instance of RandomCrop
+   * @see org.tensorflow.op.image.RandomCrop
+   */
+  public <T extends TNumber> RandomCrop<T> randomCrop(Operand<T> image, Operand<TInt64> size,
+      RandomCrop.Options... options) {
+    return RandomCrop.create(scope, image, size, options);
+  }
+
+  /**
+   * Builds an {@link ResizeArea} operation
+   *
+   * @param images 4-D with shape `[batch, height, width, channels]`.
+   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
+   * @param options carries optional attributes values
+   * @return a new instance of ResizeArea
+   * @see org.tensorflow.op.image.ResizeArea
+   */
+  public <T extends TNumber> ResizeArea resizeArea(Operand<T> images, Operand<TInt32> size,
+      ResizeArea.Options... options) {
+    return ResizeArea.create(scope, images, size, options);
+  }
+
+  /**
+   * Builds an {@link ResizeBicubic} operation
+   *
+   * @param images 4-D with shape `[batch, height, width, channels]`.
+   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
+   * @param options carries optional attributes values
+   * @return a new instance of ResizeBicubic
+   * @see org.tensorflow.op.image.ResizeBicubic
+   */
+  public <T extends TNumber> ResizeBicubic resizeBicubic(Operand<T> images, Operand<TInt32> size,
+      ResizeBicubic.Options... options) {
+    return ResizeBicubic.create(scope, images, size, options);
+  }
+
+  /**
+   * Builds an {@link ResizeBilinear} operation
+   *
+   * @param images 4-D with shape `[batch, height, width, channels]`.
+   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
+   * @param options carries optional attributes values
+   * @return a new instance of ResizeBilinear
+   * @see org.tensorflow.op.image.ResizeBilinear
+   */
+  public <T extends TNumber> ResizeBilinear resizeBilinear(Operand<T> images, Operand<TInt32> size,
+      ResizeBilinear.Options... options) {
+    return ResizeBilinear.create(scope, images, size, options);
+  }
+
+  /**
+   * Builds an {@link ResizeNearestNeighbor} operation
+   *
+   * @param images 4-D with shape `[batch, height, width, channels]`.
+   * @param size = A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
+   * @param options carries optional attributes values
+   * @return a new instance of ResizeNearestNeighbor
+   * @see org.tensorflow.op.image.ResizeNearestNeighbor
+   */
+  public <T extends TNumber> ResizeNearestNeighbor<T> resizeNearestNeighbor(Operand<T> images,
+      Operand<TInt32> size, ResizeNearestNeighbor.Options... options) {
+    return ResizeNearestNeighbor.create(scope, images, size, options);
+  }
+
+  /**
+   * Builds an {@link RgbToHsv} operation
+   *
+   * @param images 1-D or higher rank. RGB data to convert. Last dimension must be size 3.
+   * @return a new instance of RgbToHsv
+   * @see org.tensorflow.op.image.RgbToHsv
+   */
+  public <T extends TNumber> RgbToHsv<T> rgbToHsv(Operand<T> images) {
+    return RgbToHsv.create(scope, images);
+  }
+
+  /**
+   * Builds an {@link SampleDistortedBoundingBox} operation
+   *
+   * @param imageSize 1-D, containing `[height, width, channels]`.
+   * @param boundingBoxes 3-D with shape `[batch, N, 4]` describing the N bounding boxes
+   * @param minObjectCovered The cropped area of the image must contain at least this
+   * @param options carries optional attributes values
+   * @return a new instance of SampleDistortedBoundingBox
+   * @see org.tensorflow.op.image.SampleDistortedBoundingBox
+   */
+  public <T extends TNumber> SampleDistortedBoundingBox<T> sampleDistortedBoundingBox(
+      Operand<T> imageSize, Operand<TFloat32> boundingBoxes, Operand<TFloat32> minObjectCovered,
+      SampleDistortedBoundingBox.Options... options) {
+    return SampleDistortedBoundingBox.create(scope, imageSize, boundingBoxes, minObjectCovered, options);
+  }
+
+  /**
+   * Builds an {@link ScaleAndTranslate} operation
+   *
+   * @param images 
+   * @param size 
+   * @param scale 
+   * @param translation 
+   * @param options carries optional attributes values
+   * @return a new instance of ScaleAndTranslate
+   * @see org.tensorflow.op.image.ScaleAndTranslate
+   */
+  public <T extends TNumber> ScaleAndTranslate scaleAndTranslate(Operand<T> images,
+      Operand<TInt32> size, Operand<TFloat32> scale, Operand<TFloat32> translation,
+      ScaleAndTranslate.Options... options) {
+    return ScaleAndTranslate.create(scope, images, size, scale, translation, options);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/IoOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/IoOps.java
@@ -70,150 +70,6 @@ public final class IoOps {
   }
 
   /**
-   * Builds an {@link QueueEnqueueMany} operation
-   *
-   * @param handle The handle to a queue.
-   * @param components One or more tensors from which the enqueued tensors should
-   * @param options carries optional attributes values
-   * @return a new instance of QueueEnqueueMany
-   * @see org.tensorflow.op.io.QueueEnqueueMany
-   */
-  public QueueEnqueueMany queueEnqueueMany(Operand<?> handle, Iterable<Operand<?>> components,
-      QueueEnqueueMany.Options... options) {
-    return QueueEnqueueMany.create(scope, handle, components, options);
-  }
-
-  /**
-   * Builds an {@link SerializeManySparse} operation
-   *
-   * @param sparseIndices 2-D.  The `indices` of the minibatch `SparseTensor`.
-   * @param sparseValues 1-D.  The `values` of the minibatch `SparseTensor`.
-   * @param sparseShape 1-D.  The `shape` of the minibatch `SparseTensor`.
-   * @return a new instance of SerializeManySparse
-   * @see org.tensorflow.op.io.SerializeManySparse
-   */
-  public <T extends TType> SerializeManySparse<TString> serializeManySparse(
-      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape) {
-    return SerializeManySparse.create(scope, sparseIndices, sparseValues, sparseShape);
-  }
-
-  /**
-   * Builds an {@link ShardedFilename} operation
-   *
-   * @param basename 
-   * @param shard 
-   * @param numShards 
-   * @return a new instance of ShardedFilename
-   * @see org.tensorflow.op.io.ShardedFilename
-   */
-  public ShardedFilename shardedFilename(Operand<TString> basename, Operand<TInt32> shard,
-      Operand<TInt32> numShards) {
-    return ShardedFilename.create(scope, basename, shard, numShards);
-  }
-
-  /**
-   * Builds an {@link FifoQueue} operation
-   *
-   * @param componentTypes The type of each component in a value.
-   * @param options carries optional attributes values
-   * @return a new instance of FifoQueue
-   * @see org.tensorflow.op.io.FifoQueue
-   */
-  public FifoQueue fifoQueue(List<DataType<?>> componentTypes, FifoQueue.Options... options) {
-    return FifoQueue.create(scope, componentTypes, options);
-  }
-
-  /**
-   * Builds an {@link ReaderReset} operation
-   *
-   * @param readerHandle Handle to a Reader.
-   * @return a new instance of ReaderReset
-   * @see org.tensorflow.op.io.ReaderReset
-   */
-  public ReaderReset readerReset(Operand<?> readerHandle) {
-    return ReaderReset.create(scope, readerHandle);
-  }
-
-  /**
-   * Builds an {@link ParseTensor} operation
-   *
-   * @param serialized A scalar string containing a serialized TensorProto proto.
-   * @param outType The type of the serialized tensor.  The provided type must match the
-   * @return a new instance of ParseTensor
-   * @see org.tensorflow.op.io.ParseTensor
-   */
-  public <T extends TType> ParseTensor<T> parseTensor(Operand<TString> serialized,
-      DataType<T> outType) {
-    return ParseTensor.create(scope, serialized, outType);
-  }
-
-  /**
-   * Builds an {@link SerializeSparse} operation
-   *
-   * @param sparseIndices 2-D.  The `indices` of the `SparseTensor`.
-   * @param sparseValues 1-D.  The `values` of the `SparseTensor`.
-   * @param sparseShape 1-D.  The `shape` of the `SparseTensor`.
-   * @param outType The `dtype` to use for serialization; the supported types are `string`
-   * @return a new instance of SerializeSparse
-   * @see org.tensorflow.op.io.SerializeSparse
-   */
-  public <U extends TType, T extends TType> SerializeSparse<U> serializeSparse(
-      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape,
-      DataType<U> outType) {
-    return SerializeSparse.create(scope, sparseIndices, sparseValues, sparseShape, outType);
-  }
-
-  /**
-   * Builds an {@link ReaderReadUpTo} operation
-   *
-   * @param readerHandle Handle to a `Reader`.
-   * @param queueHandle Handle to a `Queue`, with string work items.
-   * @param numRecords number of records to read from `Reader`.
-   * @return a new instance of ReaderReadUpTo
-   * @see org.tensorflow.op.io.ReaderReadUpTo
-   */
-  public ReaderReadUpTo readerReadUpTo(Operand<?> readerHandle, Operand<?> queueHandle,
-      Operand<TInt64> numRecords) {
-    return ReaderReadUpTo.create(scope, readerHandle, queueHandle, numRecords);
-  }
-
-  /**
-   * Builds an {@link IdentityReader} operation
-   *
-   * @param options carries optional attributes values
-   * @return a new instance of IdentityReader
-   * @see org.tensorflow.op.io.IdentityReader
-   */
-  public IdentityReader identityReader(IdentityReader.Options... options) {
-    return IdentityReader.create(scope, options);
-  }
-
-  /**
-   * Builds an {@link SerializeTensor} operation
-   *
-   * @param tensor A Tensor of type `T`.
-   * @return a new instance of SerializeTensor
-   * @see org.tensorflow.op.io.SerializeTensor
-   */
-  public <T extends TType> SerializeTensor serializeTensor(Operand<T> tensor) {
-    return SerializeTensor.create(scope, tensor);
-  }
-
-  /**
-   * Builds an {@link SerializeSparse} operation
-   *
-   * @param sparseIndices 2-D.  The `indices` of the `SparseTensor`.
-   * @param sparseValues 1-D.  The `values` of the `SparseTensor`.
-   * @param sparseShape 1-D.  The `shape` of the `SparseTensor`.
-   * @return a new instance of SerializeSparse
-   * @see org.tensorflow.op.io.SerializeSparse
-   */
-  public <T extends TType> SerializeSparse<TString> serializeSparse(Operand<TInt64> sparseIndices,
-      Operand<T> sparseValues, Operand<TInt64> sparseShape) {
-    return SerializeSparse.create(scope, sparseIndices, sparseValues, sparseShape);
-  }
-
-  /**
    * Builds an {@link DecodeBase64} operation
    *
    * @param input Base64 strings to decode.
@@ -225,14 +81,56 @@ public final class IoOps {
   }
 
   /**
-   * Builds an {@link MatchingFiles} operation
+   * Builds an {@link DecodeCompressed} operation
    *
-   * @param pattern Shell wildcard pattern(s). Scalar or vector of type string.
-   * @return a new instance of MatchingFiles
-   * @see org.tensorflow.op.io.MatchingFiles
+   * @param bytes A Tensor of string which is compressed.
+   * @param options carries optional attributes values
+   * @return a new instance of DecodeCompressed
+   * @see org.tensorflow.op.io.DecodeCompressed
    */
-  public MatchingFiles matchingFiles(Operand<TString> pattern) {
-    return MatchingFiles.create(scope, pattern);
+  public DecodeCompressed decodeCompressed(Operand<TString> bytes,
+      DecodeCompressed.Options... options) {
+    return DecodeCompressed.create(scope, bytes, options);
+  }
+
+  /**
+   * Builds an {@link DecodeCsv} operation
+   *
+   * @param records Each string is a record/row in the csv and all records should have
+   * @param recordDefaults One tensor per column of the input record, with either a
+   * @param options carries optional attributes values
+   * @return a new instance of DecodeCsv
+   * @see org.tensorflow.op.io.DecodeCsv
+   */
+  public DecodeCsv decodeCsv(Operand<TString> records, Iterable<Operand<?>> recordDefaults,
+      DecodeCsv.Options... options) {
+    return DecodeCsv.create(scope, records, recordDefaults, options);
+  }
+
+  /**
+   * Builds an {@link DecodeJsonExample} operation
+   *
+   * @param jsonExamples Each string is a JSON object serialized according to the JSON
+   * @return a new instance of DecodeJsonExample
+   * @see org.tensorflow.op.io.DecodeJsonExample
+   */
+  public DecodeJsonExample decodeJsonExample(Operand<TString> jsonExamples) {
+    return DecodeJsonExample.create(scope, jsonExamples);
+  }
+
+  /**
+   * Builds an {@link DecodePaddedRaw} operation
+   *
+   * @param inputBytes Tensor of string to be decoded.
+   * @param fixedLength Length in bytes for each element of the decoded output. Must be a multiple
+   * @param outType 
+   * @param options carries optional attributes values
+   * @return a new instance of DecodePaddedRaw
+   * @see org.tensorflow.op.io.DecodePaddedRaw
+   */
+  public <T extends TNumber> DecodePaddedRaw<T> decodePaddedRaw(Operand<TString> inputBytes,
+      Operand<TInt32> fixedLength, DataType<T> outType, DecodePaddedRaw.Options... options) {
+    return DecodePaddedRaw.create(scope, inputBytes, fixedLength, outType, options);
   }
 
   /**
@@ -250,99 +148,99 @@ public final class IoOps {
   }
 
   /**
-   * Builds an {@link WholeFileReader} operation
+   * Builds an {@link DeserializeManySparse} operation
    *
+   * @param serializedSparse 2-D, The `N` serialized `SparseTensor` objects.
+   * @param dtype The `dtype` of the serialized `SparseTensor` objects.
+   * @return a new instance of DeserializeManySparse
+   * @see org.tensorflow.op.io.DeserializeManySparse
+   */
+  public <T extends TType> DeserializeManySparse<T> deserializeManySparse(
+      Operand<TString> serializedSparse, DataType<T> dtype) {
+    return DeserializeManySparse.create(scope, serializedSparse, dtype);
+  }
+
+  /**
+   * Builds an {@link EncodeBase64} operation
+   *
+   * @param input Strings to be encoded.
    * @param options carries optional attributes values
-   * @return a new instance of WholeFileReader
-   * @see org.tensorflow.op.io.WholeFileReader
+   * @return a new instance of EncodeBase64
+   * @see org.tensorflow.op.io.EncodeBase64
    */
-  public WholeFileReader wholeFileReader(WholeFileReader.Options... options) {
-    return WholeFileReader.create(scope, options);
+  public EncodeBase64 encodeBase64(Operand<TString> input, EncodeBase64.Options... options) {
+    return EncodeBase64.create(scope, input, options);
   }
 
   /**
-   * Builds an {@link WriteFile} operation
-   *
-   * @param filename scalar. The name of the file to which we write the contents.
-   * @param contents scalar. The content to be written to the output file.
-   * @return a new instance of WriteFile
-   * @see org.tensorflow.op.io.WriteFile
-   */
-  public WriteFile writeFile(Operand<TString> filename, Operand<TString> contents) {
-    return WriteFile.create(scope, filename, contents);
-  }
-
-  /**
-   * Builds an {@link ReaderNumRecordsProduced} operation
-   *
-   * @param readerHandle Handle to a Reader.
-   * @return a new instance of ReaderNumRecordsProduced
-   * @see org.tensorflow.op.io.ReaderNumRecordsProduced
-   */
-  public ReaderNumRecordsProduced readerNumRecordsProduced(Operand<?> readerHandle) {
-    return ReaderNumRecordsProduced.create(scope, readerHandle);
-  }
-
-  /**
-   * Builds an {@link QueueEnqueue} operation
-   *
-   * @param handle The handle to a queue.
-   * @param components One or more tensors from which the enqueued tensors should be taken.
-   * @param options carries optional attributes values
-   * @return a new instance of QueueEnqueue
-   * @see org.tensorflow.op.io.QueueEnqueue
-   */
-  public QueueEnqueue queueEnqueue(Operand<?> handle, Iterable<Operand<?>> components,
-      QueueEnqueue.Options... options) {
-    return QueueEnqueue.create(scope, handle, components, options);
-  }
-
-  /**
-   * Builds an {@link ReaderSerializeState} operation
-   *
-   * @param readerHandle Handle to a Reader.
-   * @return a new instance of ReaderSerializeState
-   * @see org.tensorflow.op.io.ReaderSerializeState
-   */
-  public ReaderSerializeState readerSerializeState(Operand<?> readerHandle) {
-    return ReaderSerializeState.create(scope, readerHandle);
-  }
-
-  /**
-   * Builds an {@link PriorityQueue} operation
+   * Builds an {@link FifoQueue} operation
    *
    * @param componentTypes The type of each component in a value.
-   * @param shapes The shape of each component in a value. The length of this attr must
    * @param options carries optional attributes values
-   * @return a new instance of PriorityQueue
-   * @see org.tensorflow.op.io.PriorityQueue
+   * @return a new instance of FifoQueue
+   * @see org.tensorflow.op.io.FifoQueue
    */
-  public PriorityQueue priorityQueue(List<DataType<?>> componentTypes, List<Shape> shapes,
-      PriorityQueue.Options... options) {
-    return PriorityQueue.create(scope, componentTypes, shapes, options);
+  public FifoQueue fifoQueue(List<DataType<?>> componentTypes, FifoQueue.Options... options) {
+    return FifoQueue.create(scope, componentTypes, options);
   }
 
   /**
-   * Builds an {@link QueueClose} operation
+   * Builds an {@link FixedLengthRecordReader} operation
    *
-   * @param handle The handle to a queue.
+   * @param recordBytes Number of bytes in the record.
    * @param options carries optional attributes values
-   * @return a new instance of QueueClose
-   * @see org.tensorflow.op.io.QueueClose
+   * @return a new instance of FixedLengthRecordReader
+   * @see org.tensorflow.op.io.FixedLengthRecordReader
    */
-  public QueueClose queueClose(Operand<?> handle, QueueClose.Options... options) {
-    return QueueClose.create(scope, handle, options);
+  public FixedLengthRecordReader fixedLengthRecordReader(Long recordBytes,
+      FixedLengthRecordReader.Options... options) {
+    return FixedLengthRecordReader.create(scope, recordBytes, options);
   }
 
   /**
-   * Builds an {@link ReadFile} operation
+   * Builds an {@link IdentityReader} operation
    *
-   * @param filename 
-   * @return a new instance of ReadFile
-   * @see org.tensorflow.op.io.ReadFile
+   * @param options carries optional attributes values
+   * @return a new instance of IdentityReader
+   * @see org.tensorflow.op.io.IdentityReader
    */
-  public ReadFile readFile(Operand<TString> filename) {
-    return ReadFile.create(scope, filename);
+  public IdentityReader identityReader(IdentityReader.Options... options) {
+    return IdentityReader.create(scope, options);
+  }
+
+  /**
+   * Builds an {@link LmdbReader} operation
+   *
+   * @param options carries optional attributes values
+   * @return a new instance of LmdbReader
+   * @see org.tensorflow.op.io.LmdbReader
+   */
+  public LmdbReader lmdbReader(LmdbReader.Options... options) {
+    return LmdbReader.create(scope, options);
+  }
+
+  /**
+   * Builds an {@link MatchingFiles} operation
+   *
+   * @param pattern Shell wildcard pattern(s). Scalar or vector of type string.
+   * @return a new instance of MatchingFiles
+   * @see org.tensorflow.op.io.MatchingFiles
+   */
+  public MatchingFiles matchingFiles(Operand<TString> pattern) {
+    return MatchingFiles.create(scope, pattern);
+  }
+
+  /**
+   * Builds an {@link PaddingFifoQueue} operation
+   *
+   * @param componentTypes The type of each component in a value.
+   * @param options carries optional attributes values
+   * @return a new instance of PaddingFifoQueue
+   * @see org.tensorflow.op.io.PaddingFifoQueue
+   */
+  public PaddingFifoQueue paddingFifoQueue(List<DataType<?>> componentTypes,
+      PaddingFifoQueue.Options... options) {
+    return PaddingFifoQueue.create(scope, componentTypes, options);
   }
 
   /**
@@ -368,73 +266,6 @@ public final class IoOps {
       List<DataType<?>> raggedValueTypes, List<DataType<?>> raggedSplitTypes,
       List<Shape> denseShapes) {
     return ParseExample.create(scope, serialized, names, sparseKeys, denseKeys, raggedKeys, denseDefaults, numSparse, sparseTypes, raggedValueTypes, raggedSplitTypes, denseShapes);
-  }
-
-  /**
-   * Builds an {@link QueueDequeueUpTo} operation
-   *
-   * @param handle The handle to a queue.
-   * @param n The number of tuples to dequeue.
-   * @param componentTypes The type of each component in a tuple.
-   * @param options carries optional attributes values
-   * @return a new instance of QueueDequeueUpTo
-   * @see org.tensorflow.op.io.QueueDequeueUpTo
-   */
-  public QueueDequeueUpTo queueDequeueUpTo(Operand<?> handle, Operand<TInt32> n,
-      List<DataType<?>> componentTypes, QueueDequeueUpTo.Options... options) {
-    return QueueDequeueUpTo.create(scope, handle, n, componentTypes, options);
-  }
-
-  /**
-   * Builds an {@link ParseSingleSequenceExample} operation
-   *
-   * @param serialized A scalar containing a binary serialized SequenceExample proto.
-   * @param featureListDenseMissingAssumedEmpty A vector listing the
-   * @param contextSparseKeys A list of Ncontext_sparse string Tensors (scalars).
-   * @param contextDenseKeys A list of Ncontext_dense string Tensors (scalars).
-   * @param featureListSparseKeys A list of Nfeature_list_sparse string Tensors
-   * @param featureListDenseKeys A list of Nfeature_list_dense string Tensors (scalars).
-   * @param contextDenseDefaults A list of Ncontext_dense Tensors (some may be empty).
-   * @param debugName A scalar containing the name of the serialized proto.
-   * @param contextSparseTypes A list of Ncontext_sparse types; the data types of data in
-   * @param featureListDenseTypes 
-   * @param featureListSparseTypes A list of Nfeature_list_sparse types; the data types
-   * @param options carries optional attributes values
-   * @return a new instance of ParseSingleSequenceExample
-   * @see org.tensorflow.op.io.ParseSingleSequenceExample
-   */
-  public ParseSingleSequenceExample parseSingleSequenceExample(Operand<TString> serialized,
-      Operand<TString> featureListDenseMissingAssumedEmpty,
-      Iterable<Operand<TString>> contextSparseKeys, Iterable<Operand<TString>> contextDenseKeys,
-      Iterable<Operand<TString>> featureListSparseKeys,
-      Iterable<Operand<TString>> featureListDenseKeys, Iterable<Operand<?>> contextDenseDefaults,
-      Operand<TString> debugName, List<DataType<?>> contextSparseTypes,
-      List<DataType<?>> featureListDenseTypes, List<DataType<?>> featureListSparseTypes,
-      ParseSingleSequenceExample.Options... options) {
-    return ParseSingleSequenceExample.create(scope, serialized, featureListDenseMissingAssumedEmpty, contextSparseKeys, contextDenseKeys, featureListSparseKeys, featureListDenseKeys, contextDenseDefaults, debugName, contextSparseTypes, featureListDenseTypes, featureListSparseTypes, options);
-  }
-
-  /**
-   * Builds an {@link ShardedFilespec} operation
-   *
-   * @param basename 
-   * @param numShards 
-   * @return a new instance of ShardedFilespec
-   * @see org.tensorflow.op.io.ShardedFilespec
-   */
-  public ShardedFilespec shardedFilespec(Operand<TString> basename, Operand<TInt32> numShards) {
-    return ShardedFilespec.create(scope, basename, numShards);
-  }
-
-  /**
-   * Builds an {@link TfRecordReader} operation
-   *
-   * @param options carries optional attributes values
-   * @return a new instance of TfRecordReader
-   * @see org.tensorflow.op.io.TfRecordReader
-   */
-  public TfRecordReader tfRecordReader(TfRecordReader.Options... options) {
-    return TfRecordReader.create(scope, options);
   }
 
   /**
@@ -475,33 +306,6 @@ public final class IoOps {
   }
 
   /**
-   * Builds an {@link SerializeManySparse} operation
-   *
-   * @param sparseIndices 2-D.  The `indices` of the minibatch `SparseTensor`.
-   * @param sparseValues 1-D.  The `values` of the minibatch `SparseTensor`.
-   * @param sparseShape 1-D.  The `shape` of the minibatch `SparseTensor`.
-   * @param outType The `dtype` to use for serialization; the supported types are `string`
-   * @return a new instance of SerializeManySparse
-   * @see org.tensorflow.op.io.SerializeManySparse
-   */
-  public <U extends TType, T extends TType> SerializeManySparse<U> serializeManySparse(
-      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape,
-      DataType<U> outType) {
-    return SerializeManySparse.create(scope, sparseIndices, sparseValues, sparseShape, outType);
-  }
-
-  /**
-   * Builds an {@link DecodeJsonExample} operation
-   *
-   * @param jsonExamples Each string is a JSON object serialized according to the JSON
-   * @return a new instance of DecodeJsonExample
-   * @see org.tensorflow.op.io.DecodeJsonExample
-   */
-  public DecodeJsonExample decodeJsonExample(Operand<TString> jsonExamples) {
-    return DecodeJsonExample.create(scope, jsonExamples);
-  }
-
-  /**
    * Builds an {@link ParseSingleExample} operation
    *
    * @param serialized A vector containing a batch of binary serialized Example protos.
@@ -521,29 +325,85 @@ public final class IoOps {
   }
 
   /**
-   * Builds an {@link EncodeBase64} operation
+   * Builds an {@link ParseSingleSequenceExample} operation
    *
-   * @param input Strings to be encoded.
+   * @param serialized A scalar containing a binary serialized SequenceExample proto.
+   * @param featureListDenseMissingAssumedEmpty A vector listing the
+   * @param contextSparseKeys A list of Ncontext_sparse string Tensors (scalars).
+   * @param contextDenseKeys A list of Ncontext_dense string Tensors (scalars).
+   * @param featureListSparseKeys A list of Nfeature_list_sparse string Tensors
+   * @param featureListDenseKeys A list of Nfeature_list_dense string Tensors (scalars).
+   * @param contextDenseDefaults A list of Ncontext_dense Tensors (some may be empty).
+   * @param debugName A scalar containing the name of the serialized proto.
+   * @param contextSparseTypes A list of Ncontext_sparse types; the data types of data in
+   * @param featureListDenseTypes 
+   * @param featureListSparseTypes A list of Nfeature_list_sparse types; the data types
    * @param options carries optional attributes values
-   * @return a new instance of EncodeBase64
-   * @see org.tensorflow.op.io.EncodeBase64
+   * @return a new instance of ParseSingleSequenceExample
+   * @see org.tensorflow.op.io.ParseSingleSequenceExample
    */
-  public EncodeBase64 encodeBase64(Operand<TString> input, EncodeBase64.Options... options) {
-    return EncodeBase64.create(scope, input, options);
+  public ParseSingleSequenceExample parseSingleSequenceExample(Operand<TString> serialized,
+      Operand<TString> featureListDenseMissingAssumedEmpty,
+      Iterable<Operand<TString>> contextSparseKeys, Iterable<Operand<TString>> contextDenseKeys,
+      Iterable<Operand<TString>> featureListSparseKeys,
+      Iterable<Operand<TString>> featureListDenseKeys, Iterable<Operand<?>> contextDenseDefaults,
+      Operand<TString> debugName, List<DataType<?>> contextSparseTypes,
+      List<DataType<?>> featureListDenseTypes, List<DataType<?>> featureListSparseTypes,
+      ParseSingleSequenceExample.Options... options) {
+    return ParseSingleSequenceExample.create(scope, serialized, featureListDenseMissingAssumedEmpty, contextSparseKeys, contextDenseKeys, featureListSparseKeys, featureListDenseKeys, contextDenseDefaults, debugName, contextSparseTypes, featureListDenseTypes, featureListSparseTypes, options);
   }
 
   /**
-   * Builds an {@link DecodeCsv} operation
+   * Builds an {@link ParseTensor} operation
    *
-   * @param records Each string is a record/row in the csv and all records should have
-   * @param recordDefaults One tensor per column of the input record, with either a
-   * @param options carries optional attributes values
-   * @return a new instance of DecodeCsv
-   * @see org.tensorflow.op.io.DecodeCsv
+   * @param serialized A scalar string containing a serialized TensorProto proto.
+   * @param outType The type of the serialized tensor.  The provided type must match the
+   * @return a new instance of ParseTensor
+   * @see org.tensorflow.op.io.ParseTensor
    */
-  public DecodeCsv decodeCsv(Operand<TString> records, Iterable<Operand<?>> recordDefaults,
-      DecodeCsv.Options... options) {
-    return DecodeCsv.create(scope, records, recordDefaults, options);
+  public <T extends TType> ParseTensor<T> parseTensor(Operand<TString> serialized,
+      DataType<T> outType) {
+    return ParseTensor.create(scope, serialized, outType);
+  }
+
+  /**
+   * Builds an {@link PriorityQueue} operation
+   *
+   * @param componentTypes The type of each component in a value.
+   * @param shapes The shape of each component in a value. The length of this attr must
+   * @param options carries optional attributes values
+   * @return a new instance of PriorityQueue
+   * @see org.tensorflow.op.io.PriorityQueue
+   */
+  public PriorityQueue priorityQueue(List<DataType<?>> componentTypes, List<Shape> shapes,
+      PriorityQueue.Options... options) {
+    return PriorityQueue.create(scope, componentTypes, shapes, options);
+  }
+
+  /**
+   * Builds an {@link QueueClose} operation
+   *
+   * @param handle The handle to a queue.
+   * @param options carries optional attributes values
+   * @return a new instance of QueueClose
+   * @see org.tensorflow.op.io.QueueClose
+   */
+  public QueueClose queueClose(Operand<?> handle, QueueClose.Options... options) {
+    return QueueClose.create(scope, handle, options);
+  }
+
+  /**
+   * Builds an {@link QueueDequeue} operation
+   *
+   * @param handle The handle to a queue.
+   * @param componentTypes The type of each component in a tuple.
+   * @param options carries optional attributes values
+   * @return a new instance of QueueDequeue
+   * @see org.tensorflow.op.io.QueueDequeue
+   */
+  public QueueDequeue queueDequeue(Operand<?> handle, List<DataType<?>> componentTypes,
+      QueueDequeue.Options... options) {
+    return QueueDequeue.create(scope, handle, componentTypes, options);
   }
 
   /**
@@ -562,50 +422,46 @@ public final class IoOps {
   }
 
   /**
-   * Builds an {@link DeserializeManySparse} operation
+   * Builds an {@link QueueDequeueUpTo} operation
    *
-   * @param serializedSparse 2-D, The `N` serialized `SparseTensor` objects.
-   * @param dtype The `dtype` of the serialized `SparseTensor` objects.
-   * @return a new instance of DeserializeManySparse
-   * @see org.tensorflow.op.io.DeserializeManySparse
-   */
-  public <T extends TType> DeserializeManySparse<T> deserializeManySparse(
-      Operand<TString> serializedSparse, DataType<T> dtype) {
-    return DeserializeManySparse.create(scope, serializedSparse, dtype);
-  }
-
-  /**
-   * Builds an {@link LmdbReader} operation
-   *
+   * @param handle The handle to a queue.
+   * @param n The number of tuples to dequeue.
+   * @param componentTypes The type of each component in a tuple.
    * @param options carries optional attributes values
-   * @return a new instance of LmdbReader
-   * @see org.tensorflow.op.io.LmdbReader
+   * @return a new instance of QueueDequeueUpTo
+   * @see org.tensorflow.op.io.QueueDequeueUpTo
    */
-  public LmdbReader lmdbReader(LmdbReader.Options... options) {
-    return LmdbReader.create(scope, options);
+  public QueueDequeueUpTo queueDequeueUpTo(Operand<?> handle, Operand<TInt32> n,
+      List<DataType<?>> componentTypes, QueueDequeueUpTo.Options... options) {
+    return QueueDequeueUpTo.create(scope, handle, n, componentTypes, options);
   }
 
   /**
-   * Builds an {@link ReaderNumWorkUnitsCompleted} operation
+   * Builds an {@link QueueEnqueue} operation
    *
-   * @param readerHandle Handle to a Reader.
-   * @return a new instance of ReaderNumWorkUnitsCompleted
-   * @see org.tensorflow.op.io.ReaderNumWorkUnitsCompleted
+   * @param handle The handle to a queue.
+   * @param components One or more tensors from which the enqueued tensors should be taken.
+   * @param options carries optional attributes values
+   * @return a new instance of QueueEnqueue
+   * @see org.tensorflow.op.io.QueueEnqueue
    */
-  public ReaderNumWorkUnitsCompleted readerNumWorkUnitsCompleted(Operand<?> readerHandle) {
-    return ReaderNumWorkUnitsCompleted.create(scope, readerHandle);
+  public QueueEnqueue queueEnqueue(Operand<?> handle, Iterable<Operand<?>> components,
+      QueueEnqueue.Options... options) {
+    return QueueEnqueue.create(scope, handle, components, options);
   }
 
   /**
-   * Builds an {@link ReaderRead} operation
+   * Builds an {@link QueueEnqueueMany} operation
    *
-   * @param readerHandle Handle to a Reader.
-   * @param queueHandle Handle to a Queue, with string work items.
-   * @return a new instance of ReaderRead
-   * @see org.tensorflow.op.io.ReaderRead
+   * @param handle The handle to a queue.
+   * @param components One or more tensors from which the enqueued tensors should
+   * @param options carries optional attributes values
+   * @return a new instance of QueueEnqueueMany
+   * @see org.tensorflow.op.io.QueueEnqueueMany
    */
-  public ReaderRead readerRead(Operand<?> readerHandle, Operand<?> queueHandle) {
-    return ReaderRead.create(scope, readerHandle, queueHandle);
+  public QueueEnqueueMany queueEnqueueMany(Operand<?> handle, Iterable<Operand<?>> components,
+      QueueEnqueueMany.Options... options) {
+    return QueueEnqueueMany.create(scope, handle, components, options);
   }
 
   /**
@@ -617,19 +473,6 @@ public final class IoOps {
    */
   public QueueIsClosed queueIsClosed(Operand<?> handle) {
     return QueueIsClosed.create(scope, handle);
-  }
-
-  /**
-   * Builds an {@link DecodeCompressed} operation
-   *
-   * @param bytes A Tensor of string which is compressed.
-   * @param options carries optional attributes values
-   * @return a new instance of DecodeCompressed
-   * @see org.tensorflow.op.io.DecodeCompressed
-   */
-  public DecodeCompressed decodeCompressed(Operand<TString> bytes,
-      DecodeCompressed.Options... options) {
-    return DecodeCompressed.create(scope, bytes, options);
   }
 
   /**
@@ -657,56 +500,73 @@ public final class IoOps {
   }
 
   /**
-   * Builds an {@link QueueDequeue} operation
+   * Builds an {@link ReadFile} operation
    *
-   * @param handle The handle to a queue.
-   * @param componentTypes The type of each component in a tuple.
-   * @param options carries optional attributes values
-   * @return a new instance of QueueDequeue
-   * @see org.tensorflow.op.io.QueueDequeue
+   * @param filename 
+   * @return a new instance of ReadFile
+   * @see org.tensorflow.op.io.ReadFile
    */
-  public QueueDequeue queueDequeue(Operand<?> handle, List<DataType<?>> componentTypes,
-      QueueDequeue.Options... options) {
-    return QueueDequeue.create(scope, handle, componentTypes, options);
+  public ReadFile readFile(Operand<TString> filename) {
+    return ReadFile.create(scope, filename);
   }
 
   /**
-   * Builds an {@link TextLineReader} operation
+   * Builds an {@link ReaderNumRecordsProduced} operation
    *
-   * @param options carries optional attributes values
-   * @return a new instance of TextLineReader
-   * @see org.tensorflow.op.io.TextLineReader
+   * @param readerHandle Handle to a Reader.
+   * @return a new instance of ReaderNumRecordsProduced
+   * @see org.tensorflow.op.io.ReaderNumRecordsProduced
    */
-  public TextLineReader textLineReader(TextLineReader.Options... options) {
-    return TextLineReader.create(scope, options);
+  public ReaderNumRecordsProduced readerNumRecordsProduced(Operand<?> readerHandle) {
+    return ReaderNumRecordsProduced.create(scope, readerHandle);
   }
 
   /**
-   * Builds an {@link FixedLengthRecordReader} operation
+   * Builds an {@link ReaderNumWorkUnitsCompleted} operation
    *
-   * @param recordBytes Number of bytes in the record.
-   * @param options carries optional attributes values
-   * @return a new instance of FixedLengthRecordReader
-   * @see org.tensorflow.op.io.FixedLengthRecordReader
+   * @param readerHandle Handle to a Reader.
+   * @return a new instance of ReaderNumWorkUnitsCompleted
+   * @see org.tensorflow.op.io.ReaderNumWorkUnitsCompleted
    */
-  public FixedLengthRecordReader fixedLengthRecordReader(Long recordBytes,
-      FixedLengthRecordReader.Options... options) {
-    return FixedLengthRecordReader.create(scope, recordBytes, options);
+  public ReaderNumWorkUnitsCompleted readerNumWorkUnitsCompleted(Operand<?> readerHandle) {
+    return ReaderNumWorkUnitsCompleted.create(scope, readerHandle);
   }
 
   /**
-   * Builds an {@link DecodePaddedRaw} operation
+   * Builds an {@link ReaderRead} operation
    *
-   * @param inputBytes Tensor of string to be decoded.
-   * @param fixedLength Length in bytes for each element of the decoded output. Must be a multiple
-   * @param outType 
-   * @param options carries optional attributes values
-   * @return a new instance of DecodePaddedRaw
-   * @see org.tensorflow.op.io.DecodePaddedRaw
+   * @param readerHandle Handle to a Reader.
+   * @param queueHandle Handle to a Queue, with string work items.
+   * @return a new instance of ReaderRead
+   * @see org.tensorflow.op.io.ReaderRead
    */
-  public <T extends TNumber> DecodePaddedRaw<T> decodePaddedRaw(Operand<TString> inputBytes,
-      Operand<TInt32> fixedLength, DataType<T> outType, DecodePaddedRaw.Options... options) {
-    return DecodePaddedRaw.create(scope, inputBytes, fixedLength, outType, options);
+  public ReaderRead readerRead(Operand<?> readerHandle, Operand<?> queueHandle) {
+    return ReaderRead.create(scope, readerHandle, queueHandle);
+  }
+
+  /**
+   * Builds an {@link ReaderReadUpTo} operation
+   *
+   * @param readerHandle Handle to a `Reader`.
+   * @param queueHandle Handle to a `Queue`, with string work items.
+   * @param numRecords number of records to read from `Reader`.
+   * @return a new instance of ReaderReadUpTo
+   * @see org.tensorflow.op.io.ReaderReadUpTo
+   */
+  public ReaderReadUpTo readerReadUpTo(Operand<?> readerHandle, Operand<?> queueHandle,
+      Operand<TInt64> numRecords) {
+    return ReaderReadUpTo.create(scope, readerHandle, queueHandle, numRecords);
+  }
+
+  /**
+   * Builds an {@link ReaderReset} operation
+   *
+   * @param readerHandle Handle to a Reader.
+   * @return a new instance of ReaderReset
+   * @see org.tensorflow.op.io.ReaderReset
+   */
+  public ReaderReset readerReset(Operand<?> readerHandle) {
+    return ReaderReset.create(scope, readerHandle);
   }
 
   /**
@@ -722,15 +582,155 @@ public final class IoOps {
   }
 
   /**
-   * Builds an {@link PaddingFifoQueue} operation
+   * Builds an {@link ReaderSerializeState} operation
    *
-   * @param componentTypes The type of each component in a value.
-   * @param options carries optional attributes values
-   * @return a new instance of PaddingFifoQueue
-   * @see org.tensorflow.op.io.PaddingFifoQueue
+   * @param readerHandle Handle to a Reader.
+   * @return a new instance of ReaderSerializeState
+   * @see org.tensorflow.op.io.ReaderSerializeState
    */
-  public PaddingFifoQueue paddingFifoQueue(List<DataType<?>> componentTypes,
-      PaddingFifoQueue.Options... options) {
-    return PaddingFifoQueue.create(scope, componentTypes, options);
+  public ReaderSerializeState readerSerializeState(Operand<?> readerHandle) {
+    return ReaderSerializeState.create(scope, readerHandle);
+  }
+
+  /**
+   * Builds an {@link SerializeManySparse} operation
+   *
+   * @param sparseIndices 2-D.  The `indices` of the minibatch `SparseTensor`.
+   * @param sparseValues 1-D.  The `values` of the minibatch `SparseTensor`.
+   * @param sparseShape 1-D.  The `shape` of the minibatch `SparseTensor`.
+   * @return a new instance of SerializeManySparse
+   * @see org.tensorflow.op.io.SerializeManySparse
+   */
+  public <T extends TType> SerializeManySparse<TString> serializeManySparse(
+      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape) {
+    return SerializeManySparse.create(scope, sparseIndices, sparseValues, sparseShape);
+  }
+
+  /**
+   * Builds an {@link SerializeManySparse} operation
+   *
+   * @param sparseIndices 2-D.  The `indices` of the minibatch `SparseTensor`.
+   * @param sparseValues 1-D.  The `values` of the minibatch `SparseTensor`.
+   * @param sparseShape 1-D.  The `shape` of the minibatch `SparseTensor`.
+   * @param outType The `dtype` to use for serialization; the supported types are `string`
+   * @return a new instance of SerializeManySparse
+   * @see org.tensorflow.op.io.SerializeManySparse
+   */
+  public <U extends TType, T extends TType> SerializeManySparse<U> serializeManySparse(
+      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape,
+      DataType<U> outType) {
+    return SerializeManySparse.create(scope, sparseIndices, sparseValues, sparseShape, outType);
+  }
+
+  /**
+   * Builds an {@link SerializeSparse} operation
+   *
+   * @param sparseIndices 2-D.  The `indices` of the `SparseTensor`.
+   * @param sparseValues 1-D.  The `values` of the `SparseTensor`.
+   * @param sparseShape 1-D.  The `shape` of the `SparseTensor`.
+   * @return a new instance of SerializeSparse
+   * @see org.tensorflow.op.io.SerializeSparse
+   */
+  public <T extends TType> SerializeSparse<TString> serializeSparse(Operand<TInt64> sparseIndices,
+      Operand<T> sparseValues, Operand<TInt64> sparseShape) {
+    return SerializeSparse.create(scope, sparseIndices, sparseValues, sparseShape);
+  }
+
+  /**
+   * Builds an {@link SerializeSparse} operation
+   *
+   * @param sparseIndices 2-D.  The `indices` of the `SparseTensor`.
+   * @param sparseValues 1-D.  The `values` of the `SparseTensor`.
+   * @param sparseShape 1-D.  The `shape` of the `SparseTensor`.
+   * @param outType The `dtype` to use for serialization; the supported types are `string`
+   * @return a new instance of SerializeSparse
+   * @see org.tensorflow.op.io.SerializeSparse
+   */
+  public <U extends TType, T extends TType> SerializeSparse<U> serializeSparse(
+      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape,
+      DataType<U> outType) {
+    return SerializeSparse.create(scope, sparseIndices, sparseValues, sparseShape, outType);
+  }
+
+  /**
+   * Builds an {@link SerializeTensor} operation
+   *
+   * @param tensor A Tensor of type `T`.
+   * @return a new instance of SerializeTensor
+   * @see org.tensorflow.op.io.SerializeTensor
+   */
+  public <T extends TType> SerializeTensor serializeTensor(Operand<T> tensor) {
+    return SerializeTensor.create(scope, tensor);
+  }
+
+  /**
+   * Builds an {@link ShardedFilename} operation
+   *
+   * @param basename 
+   * @param shard 
+   * @param numShards 
+   * @return a new instance of ShardedFilename
+   * @see org.tensorflow.op.io.ShardedFilename
+   */
+  public ShardedFilename shardedFilename(Operand<TString> basename, Operand<TInt32> shard,
+      Operand<TInt32> numShards) {
+    return ShardedFilename.create(scope, basename, shard, numShards);
+  }
+
+  /**
+   * Builds an {@link ShardedFilespec} operation
+   *
+   * @param basename 
+   * @param numShards 
+   * @return a new instance of ShardedFilespec
+   * @see org.tensorflow.op.io.ShardedFilespec
+   */
+  public ShardedFilespec shardedFilespec(Operand<TString> basename, Operand<TInt32> numShards) {
+    return ShardedFilespec.create(scope, basename, numShards);
+  }
+
+  /**
+   * Builds an {@link TextLineReader} operation
+   *
+   * @param options carries optional attributes values
+   * @return a new instance of TextLineReader
+   * @see org.tensorflow.op.io.TextLineReader
+   */
+  public TextLineReader textLineReader(TextLineReader.Options... options) {
+    return TextLineReader.create(scope, options);
+  }
+
+  /**
+   * Builds an {@link TfRecordReader} operation
+   *
+   * @param options carries optional attributes values
+   * @return a new instance of TfRecordReader
+   * @see org.tensorflow.op.io.TfRecordReader
+   */
+  public TfRecordReader tfRecordReader(TfRecordReader.Options... options) {
+    return TfRecordReader.create(scope, options);
+  }
+
+  /**
+   * Builds an {@link WholeFileReader} operation
+   *
+   * @param options carries optional attributes values
+   * @return a new instance of WholeFileReader
+   * @see org.tensorflow.op.io.WholeFileReader
+   */
+  public WholeFileReader wholeFileReader(WholeFileReader.Options... options) {
+    return WholeFileReader.create(scope, options);
+  }
+
+  /**
+   * Builds an {@link WriteFile} operation
+   *
+   * @param filename scalar. The name of the file to which we write the contents.
+   * @param contents scalar. The content to be written to the output file.
+   * @return a new instance of WriteFile
+   * @see org.tensorflow.op.io.WriteFile
+   */
+  public WriteFile writeFile(Operand<TString> filename, Operand<TString> contents) {
+    return WriteFile.create(scope, filename, contents);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/LinalgOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/LinalgOps.java
@@ -67,66 +67,87 @@ public final class LinalgOps {
   }
 
   /**
-   * Builds an {@link Transpose} operation
+   * Builds an {@link BandPart} operation
    *
-   * @param x 
-   * @param perm 
-   * @return a new instance of Transpose
-   * @see org.tensorflow.op.linalg.Transpose
+   * @param input Rank `k` tensor.
+   * @param numLower 0-D tensor. Number of subdiagonals to keep. If negative, keep entire
+   * @param numUpper 0-D tensor. Number of superdiagonals to keep. If negative, keep
+   * @return a new instance of BandPart
+   * @see org.tensorflow.op.linalg.BandPart
    */
-  public <T extends TType, U extends TNumber> Transpose<T> transpose(Operand<T> x,
-      Operand<U> perm) {
-    return Transpose.create(scope, x, perm);
+  public <T extends TType, U extends TNumber> BandPart<T> bandPart(Operand<T> input,
+      Operand<U> numLower, Operand<U> numUpper) {
+    return BandPart.create(scope, input, numLower, numUpper);
   }
 
   /**
-   * Builds an {@link LogMatrixDeterminant} operation
+   * Builds an {@link BatchCholesky} operation
    *
-   * @param input Shape is `[N, M, M]`.
-   * @return a new instance of LogMatrixDeterminant
-   * @see org.tensorflow.op.linalg.LogMatrixDeterminant
+   * @param input 
+   * @return a new instance of BatchCholesky
+   * @see org.tensorflow.op.linalg.BatchCholesky
    */
-  public <T extends TType> LogMatrixDeterminant<T> logMatrixDeterminant(Operand<T> input) {
-    return LogMatrixDeterminant.create(scope, input);
+  public <T extends TNumber> BatchCholesky<T> batchCholesky(Operand<T> input) {
+    return BatchCholesky.create(scope, input);
   }
 
   /**
-   * Builds an {@link TriangularSolve} operation
+   * Builds an {@link BatchCholeskyGrad} operation
    *
-   * @param matrix Shape is `[..., M, M]`.
-   * @param rhs Shape is `[..., M, K]`.
-   * @param options carries optional attributes values
-   * @return a new instance of TriangularSolve
-   * @see org.tensorflow.op.linalg.TriangularSolve
+   * @param l 
+   * @param grad 
+   * @return a new instance of BatchCholeskyGrad
+   * @see org.tensorflow.op.linalg.BatchCholeskyGrad
    */
-  public <T extends TType> TriangularSolve<T> triangularSolve(Operand<T> matrix, Operand<T> rhs,
-      TriangularSolve.Options... options) {
-    return TriangularSolve.create(scope, matrix, rhs, options);
+  public <T extends TNumber> BatchCholeskyGrad<T> batchCholeskyGrad(Operand<T> l, Operand<T> grad) {
+    return BatchCholeskyGrad.create(scope, l, grad);
   }
 
   /**
-   * Builds an {@link Svd} operation
+   * Builds an {@link BatchMatrixBandPart} operation
    *
-   * @param input A tensor of shape `[..., M, N]` whose inner-most 2 dimensions
-   * @param options carries optional attributes values
-   * @return a new instance of Svd
-   * @see org.tensorflow.op.linalg.Svd
+   * @param input 
+   * @param numLower 
+   * @param numUpper 
+   * @return a new instance of BatchMatrixBandPart
+   * @see org.tensorflow.op.linalg.BatchMatrixBandPart
    */
-  public <T extends TType> Svd<T> svd(Operand<T> input, Svd.Options... options) {
-    return Svd.create(scope, input, options);
+  public <T extends TType> BatchMatrixBandPart<T> batchMatrixBandPart(Operand<T> input,
+      Operand<TInt64> numLower, Operand<TInt64> numUpper) {
+    return BatchMatrixBandPart.create(scope, input, numLower, numUpper);
   }
 
   /**
-   * Builds an {@link Lu} operation
+   * Builds an {@link BatchMatrixDeterminant} operation
    *
-   * @param input A tensor of shape `[..., M, M]` whose inner-most 2 dimensions form matrices of
-   * @param outputIdxType 
-   * @return a new instance of Lu
-   * @see org.tensorflow.op.linalg.Lu
+   * @param input 
+   * @return a new instance of BatchMatrixDeterminant
+   * @see org.tensorflow.op.linalg.BatchMatrixDeterminant
    */
-  public <T extends TType, U extends TNumber> Lu<T, U> lu(Operand<T> input,
-      DataType<U> outputIdxType) {
-    return Lu.create(scope, input, outputIdxType);
+  public <T extends TType> BatchMatrixDeterminant<T> batchMatrixDeterminant(Operand<T> input) {
+    return BatchMatrixDeterminant.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link BatchMatrixDiag} operation
+   *
+   * @param diagonal 
+   * @return a new instance of BatchMatrixDiag
+   * @see org.tensorflow.op.linalg.BatchMatrixDiag
+   */
+  public <T extends TType> BatchMatrixDiag<T> batchMatrixDiag(Operand<T> diagonal) {
+    return BatchMatrixDiag.create(scope, diagonal);
+  }
+
+  /**
+   * Builds an {@link BatchMatrixDiagPart} operation
+   *
+   * @param input 
+   * @return a new instance of BatchMatrixDiagPart
+   * @see org.tensorflow.op.linalg.BatchMatrixDiagPart
+   */
+  public <T extends TType> BatchMatrixDiagPart<T> batchMatrixDiagPart(Operand<T> input) {
+    return BatchMatrixDiagPart.create(scope, input);
   }
 
   /**
@@ -143,43 +164,6 @@ public final class LinalgOps {
   }
 
   /**
-   * Builds an {@link Solve} operation
-   *
-   * @param matrix Shape is `[..., M, M]`.
-   * @param rhs Shape is `[..., M, K]`.
-   * @param options carries optional attributes values
-   * @return a new instance of Solve
-   * @see org.tensorflow.op.linalg.Solve
-   */
-  public <T extends TType> Solve<T> solve(Operand<T> matrix, Operand<T> rhs,
-      Solve.Options... options) {
-    return Solve.create(scope, matrix, rhs, options);
-  }
-
-  /**
-   * Builds an {@link BatchMatrixDiagPart} operation
-   *
-   * @param input 
-   * @return a new instance of BatchMatrixDiagPart
-   * @see org.tensorflow.op.linalg.BatchMatrixDiagPart
-   */
-  public <T extends TType> BatchMatrixDiagPart<T> batchMatrixDiagPart(Operand<T> input) {
-    return BatchMatrixDiagPart.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Cross} operation
-   *
-   * @param a A tensor containing 3-element vectors.
-   * @param b Another tensor, of same type and shape as `a`.
-   * @return a new instance of Cross
-   * @see org.tensorflow.op.linalg.Cross
-   */
-  public <T extends TNumber> Cross<T> cross(Operand<T> a, Operand<T> b) {
-    return Cross.create(scope, a, b);
-  }
-
-  /**
    * Builds an {@link BatchMatrixSetDiag} operation
    *
    * @param input 
@@ -193,42 +177,46 @@ public final class LinalgOps {
   }
 
   /**
-   * Builds an {@link MatrixSolveLs} operation
+   * Builds an {@link BatchMatrixSolve} operation
    *
-   * @param matrix Shape is `[..., M, N]`.
-   * @param rhs Shape is `[..., M, K]`.
-   * @param l2Regularizer Scalar tensor.
+   * @param matrix 
+   * @param rhs 
    * @param options carries optional attributes values
-   * @return a new instance of MatrixSolveLs
-   * @see org.tensorflow.op.linalg.MatrixSolveLs
+   * @return a new instance of BatchMatrixSolve
+   * @see org.tensorflow.op.linalg.BatchMatrixSolve
    */
-  public <T extends TType> MatrixSolveLs<T> matrixSolveLs(Operand<T> matrix, Operand<T> rhs,
-      Operand<TFloat64> l2Regularizer, MatrixSolveLs.Options... options) {
-    return MatrixSolveLs.create(scope, matrix, rhs, l2Regularizer, options);
+  public <T extends TNumber> BatchMatrixSolve<T> batchMatrixSolve(Operand<T> matrix, Operand<T> rhs,
+      BatchMatrixSolve.Options... options) {
+    return BatchMatrixSolve.create(scope, matrix, rhs, options);
   }
 
   /**
-   * Builds an {@link CholeskyGrad} operation
+   * Builds an {@link BatchMatrixSolveLs} operation
    *
-   * @param l Output of batch Cholesky algorithm l = cholesky(A). Shape is `[..., M, M]`.
-   * @param grad df/dl where f is some scalar function. Shape is `[..., M, M]`.
-   * @return a new instance of CholeskyGrad
-   * @see org.tensorflow.op.linalg.CholeskyGrad
+   * @param matrix 
+   * @param rhs 
+   * @param l2Regularizer 
+   * @param options carries optional attributes values
+   * @return a new instance of BatchMatrixSolveLs
+   * @see org.tensorflow.op.linalg.BatchMatrixSolveLs
    */
-  public <T extends TNumber> CholeskyGrad<T> choleskyGrad(Operand<T> l, Operand<T> grad) {
-    return CholeskyGrad.create(scope, l, grad);
+  public <T extends TNumber> BatchMatrixSolveLs<T> batchMatrixSolveLs(Operand<T> matrix,
+      Operand<T> rhs, Operand<TFloat64> l2Regularizer, BatchMatrixSolveLs.Options... options) {
+    return BatchMatrixSolveLs.create(scope, matrix, rhs, l2Regularizer, options);
   }
 
   /**
-   * Builds an {@link Qr} operation
+   * Builds an {@link BatchMatrixTriangularSolve} operation
    *
-   * @param input A tensor of shape `[..., M, N]` whose inner-most 2 dimensions
+   * @param matrix 
+   * @param rhs 
    * @param options carries optional attributes values
-   * @return a new instance of Qr
-   * @see org.tensorflow.op.linalg.Qr
+   * @return a new instance of BatchMatrixTriangularSolve
+   * @see org.tensorflow.op.linalg.BatchMatrixTriangularSolve
    */
-  public <T extends TType> Qr<T> qr(Operand<T> input, Qr.Options... options) {
-    return Qr.create(scope, input, options);
+  public <T extends TNumber> BatchMatrixTriangularSolve<T> batchMatrixTriangularSolve(
+      Operand<T> matrix, Operand<T> rhs, BatchMatrixTriangularSolve.Options... options) {
+    return BatchMatrixTriangularSolve.create(scope, matrix, rhs, options);
   }
 
   /**
@@ -245,6 +233,18 @@ public final class LinalgOps {
   }
 
   /**
+   * Builds an {@link BatchSvd} operation
+   *
+   * @param input 
+   * @param options carries optional attributes values
+   * @return a new instance of BatchSvd
+   * @see org.tensorflow.op.linalg.BatchSvd
+   */
+  public <T extends TType> BatchSvd<T> batchSvd(Operand<T> input, BatchSvd.Options... options) {
+    return BatchSvd.create(scope, input, options);
+  }
+
+  /**
    * Builds an {@link Cholesky} operation
    *
    * @param input Shape is `[..., M, M]`.
@@ -256,75 +256,103 @@ public final class LinalgOps {
   }
 
   /**
-   * Builds an {@link MatrixSetDiag} operation
+   * Builds an {@link CholeskyGrad} operation
    *
-   * @param input Rank `r+1`, where `r >= 1`.
-   * @param diagonal Rank `r` when `k` is an integer or `k[0] == k[1]`. Otherwise, it has rank `r+1`.
-   * @param k Diagonal offset(s). Positive value means superdiagonal, 0 refers to the main
-   * @return a new instance of MatrixSetDiag
-   * @see org.tensorflow.op.linalg.MatrixSetDiag
+   * @param l Output of batch Cholesky algorithm l = cholesky(A). Shape is `[..., M, M]`.
+   * @param grad df/dl where f is some scalar function. Shape is `[..., M, M]`.
+   * @return a new instance of CholeskyGrad
+   * @see org.tensorflow.op.linalg.CholeskyGrad
    */
-  public <T extends TType> MatrixSetDiag<T> matrixSetDiag(Operand<T> input, Operand<T> diagonal,
-      Operand<TInt32> k) {
-    return MatrixSetDiag.create(scope, input, diagonal, k);
+  public <T extends TNumber> CholeskyGrad<T> choleskyGrad(Operand<T> l, Operand<T> grad) {
+    return CholeskyGrad.create(scope, l, grad);
   }
 
   /**
-   * Builds an {@link BatchMatrixDiag} operation
+   * Builds an {@link ConjugateTranspose} operation
    *
-   * @param diagonal 
-   * @return a new instance of BatchMatrixDiag
-   * @see org.tensorflow.op.linalg.BatchMatrixDiag
+   * @param x 
+   * @param perm 
+   * @return a new instance of ConjugateTranspose
+   * @see org.tensorflow.op.linalg.ConjugateTranspose
    */
-  public <T extends TType> BatchMatrixDiag<T> batchMatrixDiag(Operand<T> diagonal) {
-    return BatchMatrixDiag.create(scope, diagonal);
+  public <T extends TType, U extends TNumber> ConjugateTranspose<T> conjugateTranspose(Operand<T> x,
+      Operand<U> perm) {
+    return ConjugateTranspose.create(scope, x, perm);
   }
 
   /**
-   * Builds an {@link Sqrtm} operation
+   * Builds an {@link Cross} operation
+   *
+   * @param a A tensor containing 3-element vectors.
+   * @param b Another tensor, of same type and shape as `a`.
+   * @return a new instance of Cross
+   * @see org.tensorflow.op.linalg.Cross
+   */
+  public <T extends TNumber> Cross<T> cross(Operand<T> a, Operand<T> b) {
+    return Cross.create(scope, a, b);
+  }
+
+  /**
+   * Builds an {@link Det} operation
    *
    * @param input Shape is `[..., M, M]`.
-   * @return a new instance of Sqrtm
-   * @see org.tensorflow.op.linalg.Sqrtm
+   * @return a new instance of Det
+   * @see org.tensorflow.op.linalg.Det
    */
-  public <T extends TType> Sqrtm<T> sqrtm(Operand<T> input) {
-    return Sqrtm.create(scope, input);
+  public <T extends TType> Det<T> det(Operand<T> input) {
+    return Det.create(scope, input);
   }
 
   /**
-   * Builds an {@link MatrixDiagPart} operation
+   * Builds an {@link Eig} operation
    *
-   * @param input Rank `r` tensor where `r >= 2`.
-   * @param k Diagonal offset(s). Positive value means superdiagonal, 0 refers to the main
-   * @param paddingValue The value to fill the area outside the specified diagonal band with.
-   * @return a new instance of MatrixDiagPart
-   * @see org.tensorflow.op.linalg.MatrixDiagPart
+   * @param input `Tensor` input of shape `[N, N]`.
+   * @param Tout 
+   * @param options carries optional attributes values
+   * @return a new instance of Eig
+   * @see org.tensorflow.op.linalg.Eig
    */
-  public <T extends TType> MatrixDiagPart<T> matrixDiagPart(Operand<T> input, Operand<TInt32> k,
-      Operand<T> paddingValue) {
-    return MatrixDiagPart.create(scope, input, k, paddingValue);
+  public <U extends TType, T extends TType> Eig<U> eig(Operand<T> input, DataType<U> Tout,
+      Eig.Options... options) {
+    return Eig.create(scope, input, Tout, options);
   }
 
   /**
-   * Builds an {@link TensorDiag} operation
+   * Builds an {@link Einsum} operation
    *
-   * @param diagonal Rank k tensor where k is at most 1.
-   * @return a new instance of TensorDiag
-   * @see org.tensorflow.op.linalg.TensorDiag
+   * @param inputs List of 1 or 2 Tensors.
+   * @param equation String describing the Einstein Summation operation; in the format of np.einsum.
+   * @return a new instance of Einsum
+   * @see org.tensorflow.op.linalg.Einsum
    */
-  public <T extends TType> TensorDiag<T> tensorDiag(Operand<T> diagonal) {
-    return TensorDiag.create(scope, diagonal);
+  public <T extends TType> Einsum<T> einsum(Iterable<Operand<T>> inputs, String equation) {
+    return Einsum.create(scope, inputs, equation);
   }
 
   /**
-   * Builds an {@link BatchCholesky} operation
+   * Builds an {@link EuclideanNorm} operation
    *
-   * @param input 
-   * @return a new instance of BatchCholesky
-   * @see org.tensorflow.op.linalg.BatchCholesky
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of EuclideanNorm
+   * @see org.tensorflow.op.linalg.EuclideanNorm
    */
-  public <T extends TNumber> BatchCholesky<T> batchCholesky(Operand<T> input) {
-    return BatchCholesky.create(scope, input);
+  public <T extends TType, U extends TNumber> EuclideanNorm<T> euclideanNorm(Operand<T> input,
+      Operand<U> axis, EuclideanNorm.Options... options) {
+    return EuclideanNorm.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link Inv} operation
+   *
+   * @param input Shape is `[..., M, M]`.
+   * @param options carries optional attributes values
+   * @return a new instance of Inv
+   * @see org.tensorflow.op.linalg.Inv
+   */
+  public <T extends TType> Inv<T> inv(Operand<T> input, Inv.Options... options) {
+    return Inv.create(scope, input, options);
   }
 
   /**
@@ -349,28 +377,14 @@ public final class LinalgOps {
   }
 
   /**
-   * Builds an {@link BatchMatrixSolve} operation
+   * Builds an {@link LogMatrixDeterminant} operation
    *
-   * @param matrix 
-   * @param rhs 
-   * @param options carries optional attributes values
-   * @return a new instance of BatchMatrixSolve
-   * @see org.tensorflow.op.linalg.BatchMatrixSolve
+   * @param input Shape is `[N, M, M]`.
+   * @return a new instance of LogMatrixDeterminant
+   * @see org.tensorflow.op.linalg.LogMatrixDeterminant
    */
-  public <T extends TNumber> BatchMatrixSolve<T> batchMatrixSolve(Operand<T> matrix, Operand<T> rhs,
-      BatchMatrixSolve.Options... options) {
-    return BatchMatrixSolve.create(scope, matrix, rhs, options);
-  }
-
-  /**
-   * Builds an {@link BatchMatrixDeterminant} operation
-   *
-   * @param input 
-   * @return a new instance of BatchMatrixDeterminant
-   * @see org.tensorflow.op.linalg.BatchMatrixDeterminant
-   */
-  public <T extends TType> BatchMatrixDeterminant<T> batchMatrixDeterminant(Operand<T> input) {
-    return BatchMatrixDeterminant.create(scope, input);
+  public <T extends TType> LogMatrixDeterminant<T> logMatrixDeterminant(Operand<T> input) {
+    return LogMatrixDeterminant.create(scope, input);
   }
 
   /**
@@ -385,121 +399,29 @@ public final class LinalgOps {
   }
 
   /**
-   * Builds an {@link EuclideanNorm} operation
+   * Builds an {@link Lu} operation
    *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
+   * @param input A tensor of shape `[..., M, M]` whose inner-most 2 dimensions form matrices of
+   * @param outputIdxType 
+   * @return a new instance of Lu
+   * @see org.tensorflow.op.linalg.Lu
+   */
+  public <T extends TType, U extends TNumber> Lu<T, U> lu(Operand<T> input,
+      DataType<U> outputIdxType) {
+    return Lu.create(scope, input, outputIdxType);
+  }
+
+  /**
+   * Builds an {@link MatMul} operation
+   *
+   * @param a 
+   * @param b 
    * @param options carries optional attributes values
-   * @return a new instance of EuclideanNorm
-   * @see org.tensorflow.op.linalg.EuclideanNorm
+   * @return a new instance of MatMul
+   * @see org.tensorflow.op.linalg.MatMul
    */
-  public <T extends TType, U extends TNumber> EuclideanNorm<T> euclideanNorm(Operand<T> input,
-      Operand<U> axis, EuclideanNorm.Options... options) {
-    return EuclideanNorm.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link SelfAdjointEig} operation
-   *
-   * @param input `Tensor` input of shape `[N, N]`.
-   * @param options carries optional attributes values
-   * @return a new instance of SelfAdjointEig
-   * @see org.tensorflow.op.linalg.SelfAdjointEig
-   */
-  public <T extends TType> SelfAdjointEig<T> selfAdjointEig(Operand<T> input,
-      SelfAdjointEig.Options... options) {
-    return SelfAdjointEig.create(scope, input, options);
-  }
-
-  /**
-   * Builds an {@link BandPart} operation
-   *
-   * @param input Rank `k` tensor.
-   * @param numLower 0-D tensor. Number of subdiagonals to keep. If negative, keep entire
-   * @param numUpper 0-D tensor. Number of superdiagonals to keep. If negative, keep
-   * @return a new instance of BandPart
-   * @see org.tensorflow.op.linalg.BandPart
-   */
-  public <T extends TType, U extends TNumber> BandPart<T> bandPart(Operand<T> input,
-      Operand<U> numLower, Operand<U> numUpper) {
-    return BandPart.create(scope, input, numLower, numUpper);
-  }
-
-  /**
-   * Builds an {@link ConjugateTranspose} operation
-   *
-   * @param x 
-   * @param perm 
-   * @return a new instance of ConjugateTranspose
-   * @see org.tensorflow.op.linalg.ConjugateTranspose
-   */
-  public <T extends TType, U extends TNumber> ConjugateTranspose<T> conjugateTranspose(Operand<T> x,
-      Operand<U> perm) {
-    return ConjugateTranspose.create(scope, x, perm);
-  }
-
-  /**
-   * Builds an {@link Inv} operation
-   *
-   * @param input Shape is `[..., M, M]`.
-   * @param options carries optional attributes values
-   * @return a new instance of Inv
-   * @see org.tensorflow.op.linalg.Inv
-   */
-  public <T extends TType> Inv<T> inv(Operand<T> input, Inv.Options... options) {
-    return Inv.create(scope, input, options);
-  }
-
-  /**
-   * Builds an {@link BatchMatrixBandPart} operation
-   *
-   * @param input 
-   * @param numLower 
-   * @param numUpper 
-   * @return a new instance of BatchMatrixBandPart
-   * @see org.tensorflow.op.linalg.BatchMatrixBandPart
-   */
-  public <T extends TType> BatchMatrixBandPart<T> batchMatrixBandPart(Operand<T> input,
-      Operand<TInt64> numLower, Operand<TInt64> numUpper) {
-    return BatchMatrixBandPart.create(scope, input, numLower, numUpper);
-  }
-
-  /**
-   * Builds an {@link TensorDiagPart} operation
-   *
-   * @param input Rank k tensor where k is even and not zero.
-   * @return a new instance of TensorDiagPart
-   * @see org.tensorflow.op.linalg.TensorDiagPart
-   */
-  public <T extends TType> TensorDiagPart<T> tensorDiagPart(Operand<T> input) {
-    return TensorDiagPart.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link BatchCholeskyGrad} operation
-   *
-   * @param l 
-   * @param grad 
-   * @return a new instance of BatchCholeskyGrad
-   * @see org.tensorflow.op.linalg.BatchCholeskyGrad
-   */
-  public <T extends TNumber> BatchCholeskyGrad<T> batchCholeskyGrad(Operand<T> l, Operand<T> grad) {
-    return BatchCholeskyGrad.create(scope, l, grad);
-  }
-
-  /**
-   * Builds an {@link BatchMatrixSolveLs} operation
-   *
-   * @param matrix 
-   * @param rhs 
-   * @param l2Regularizer 
-   * @param options carries optional attributes values
-   * @return a new instance of BatchMatrixSolveLs
-   * @see org.tensorflow.op.linalg.BatchMatrixSolveLs
-   */
-  public <T extends TNumber> BatchMatrixSolveLs<T> batchMatrixSolveLs(Operand<T> matrix,
-      Operand<T> rhs, Operand<TFloat64> l2Regularizer, BatchMatrixSolveLs.Options... options) {
-    return BatchMatrixSolveLs.create(scope, matrix, rhs, l2Regularizer, options);
+  public <T extends TType> MatMul<T> matMul(Operand<T> a, Operand<T> b, MatMul.Options... options) {
+    return MatMul.create(scope, a, b, options);
   }
 
   /**
@@ -519,79 +441,58 @@ public final class LinalgOps {
   }
 
   /**
-   * Builds an {@link BatchSvd} operation
+   * Builds an {@link MatrixDiagPart} operation
    *
-   * @param input 
+   * @param input Rank `r` tensor where `r >= 2`.
+   * @param k Diagonal offset(s). Positive value means superdiagonal, 0 refers to the main
+   * @param paddingValue The value to fill the area outside the specified diagonal band with.
+   * @return a new instance of MatrixDiagPart
+   * @see org.tensorflow.op.linalg.MatrixDiagPart
+   */
+  public <T extends TType> MatrixDiagPart<T> matrixDiagPart(Operand<T> input, Operand<TInt32> k,
+      Operand<T> paddingValue) {
+    return MatrixDiagPart.create(scope, input, k, paddingValue);
+  }
+
+  /**
+   * Builds an {@link MatrixSetDiag} operation
+   *
+   * @param input Rank `r+1`, where `r >= 1`.
+   * @param diagonal Rank `r` when `k` is an integer or `k[0] == k[1]`. Otherwise, it has rank `r+1`.
+   * @param k Diagonal offset(s). Positive value means superdiagonal, 0 refers to the main
+   * @return a new instance of MatrixSetDiag
+   * @see org.tensorflow.op.linalg.MatrixSetDiag
+   */
+  public <T extends TType> MatrixSetDiag<T> matrixSetDiag(Operand<T> input, Operand<T> diagonal,
+      Operand<TInt32> k) {
+    return MatrixSetDiag.create(scope, input, diagonal, k);
+  }
+
+  /**
+   * Builds an {@link MatrixSolveLs} operation
+   *
+   * @param matrix Shape is `[..., M, N]`.
+   * @param rhs Shape is `[..., M, K]`.
+   * @param l2Regularizer Scalar tensor.
    * @param options carries optional attributes values
-   * @return a new instance of BatchSvd
-   * @see org.tensorflow.op.linalg.BatchSvd
+   * @return a new instance of MatrixSolveLs
+   * @see org.tensorflow.op.linalg.MatrixSolveLs
    */
-  public <T extends TType> BatchSvd<T> batchSvd(Operand<T> input, BatchSvd.Options... options) {
-    return BatchSvd.create(scope, input, options);
+  public <T extends TType> MatrixSolveLs<T> matrixSolveLs(Operand<T> matrix, Operand<T> rhs,
+      Operand<TFloat64> l2Regularizer, MatrixSolveLs.Options... options) {
+    return MatrixSolveLs.create(scope, matrix, rhs, l2Regularizer, options);
   }
 
   /**
-   * Builds an {@link MatMul} operation
+   * Builds an {@link Qr} operation
    *
-   * @param a 
-   * @param b 
+   * @param input A tensor of shape `[..., M, N]` whose inner-most 2 dimensions
    * @param options carries optional attributes values
-   * @return a new instance of MatMul
-   * @see org.tensorflow.op.linalg.MatMul
+   * @return a new instance of Qr
+   * @see org.tensorflow.op.linalg.Qr
    */
-  public <T extends TType> MatMul<T> matMul(Operand<T> a, Operand<T> b, MatMul.Options... options) {
-    return MatMul.create(scope, a, b, options);
-  }
-
-  /**
-   * Builds an {@link Det} operation
-   *
-   * @param input Shape is `[..., M, M]`.
-   * @return a new instance of Det
-   * @see org.tensorflow.op.linalg.Det
-   */
-  public <T extends TType> Det<T> det(Operand<T> input) {
-    return Det.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Einsum} operation
-   *
-   * @param inputs List of 1 or 2 Tensors.
-   * @param equation String describing the Einstein Summation operation; in the format of np.einsum.
-   * @return a new instance of Einsum
-   * @see org.tensorflow.op.linalg.Einsum
-   */
-  public <T extends TType> Einsum<T> einsum(Iterable<Operand<T>> inputs, String equation) {
-    return Einsum.create(scope, inputs, equation);
-  }
-
-  /**
-   * Builds an {@link BatchMatrixTriangularSolve} operation
-   *
-   * @param matrix 
-   * @param rhs 
-   * @param options carries optional attributes values
-   * @return a new instance of BatchMatrixTriangularSolve
-   * @see org.tensorflow.op.linalg.BatchMatrixTriangularSolve
-   */
-  public <T extends TNumber> BatchMatrixTriangularSolve<T> batchMatrixTriangularSolve(
-      Operand<T> matrix, Operand<T> rhs, BatchMatrixTriangularSolve.Options... options) {
-    return BatchMatrixTriangularSolve.create(scope, matrix, rhs, options);
-  }
-
-  /**
-   * Builds an {@link Eig} operation
-   *
-   * @param input `Tensor` input of shape `[N, N]`.
-   * @param Tout 
-   * @param options carries optional attributes values
-   * @return a new instance of Eig
-   * @see org.tensorflow.op.linalg.Eig
-   */
-  public <U extends TType, T extends TType> Eig<U> eig(Operand<T> input, DataType<U> Tout,
-      Eig.Options... options) {
-    return Eig.create(scope, input, Tout, options);
+  public <T extends TType> Qr<T> qr(Operand<T> input, Qr.Options... options) {
+    return Qr.create(scope, input, options);
   }
 
   /**
@@ -614,5 +515,104 @@ public final class LinalgOps {
       Operand<TFloat32> minB, Operand<TFloat32> maxB, DataType<V> Toutput, DataType<W> Tactivation,
       QuantizedMatMul.Options... options) {
     return QuantizedMatMul.create(scope, a, b, minA, maxA, minB, maxB, Toutput, Tactivation, options);
+  }
+
+  /**
+   * Builds an {@link SelfAdjointEig} operation
+   *
+   * @param input `Tensor` input of shape `[N, N]`.
+   * @param options carries optional attributes values
+   * @return a new instance of SelfAdjointEig
+   * @see org.tensorflow.op.linalg.SelfAdjointEig
+   */
+  public <T extends TType> SelfAdjointEig<T> selfAdjointEig(Operand<T> input,
+      SelfAdjointEig.Options... options) {
+    return SelfAdjointEig.create(scope, input, options);
+  }
+
+  /**
+   * Builds an {@link Solve} operation
+   *
+   * @param matrix Shape is `[..., M, M]`.
+   * @param rhs Shape is `[..., M, K]`.
+   * @param options carries optional attributes values
+   * @return a new instance of Solve
+   * @see org.tensorflow.op.linalg.Solve
+   */
+  public <T extends TType> Solve<T> solve(Operand<T> matrix, Operand<T> rhs,
+      Solve.Options... options) {
+    return Solve.create(scope, matrix, rhs, options);
+  }
+
+  /**
+   * Builds an {@link Sqrtm} operation
+   *
+   * @param input Shape is `[..., M, M]`.
+   * @return a new instance of Sqrtm
+   * @see org.tensorflow.op.linalg.Sqrtm
+   */
+  public <T extends TType> Sqrtm<T> sqrtm(Operand<T> input) {
+    return Sqrtm.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Svd} operation
+   *
+   * @param input A tensor of shape `[..., M, N]` whose inner-most 2 dimensions
+   * @param options carries optional attributes values
+   * @return a new instance of Svd
+   * @see org.tensorflow.op.linalg.Svd
+   */
+  public <T extends TType> Svd<T> svd(Operand<T> input, Svd.Options... options) {
+    return Svd.create(scope, input, options);
+  }
+
+  /**
+   * Builds an {@link TensorDiag} operation
+   *
+   * @param diagonal Rank k tensor where k is at most 1.
+   * @return a new instance of TensorDiag
+   * @see org.tensorflow.op.linalg.TensorDiag
+   */
+  public <T extends TType> TensorDiag<T> tensorDiag(Operand<T> diagonal) {
+    return TensorDiag.create(scope, diagonal);
+  }
+
+  /**
+   * Builds an {@link TensorDiagPart} operation
+   *
+   * @param input Rank k tensor where k is even and not zero.
+   * @return a new instance of TensorDiagPart
+   * @see org.tensorflow.op.linalg.TensorDiagPart
+   */
+  public <T extends TType> TensorDiagPart<T> tensorDiagPart(Operand<T> input) {
+    return TensorDiagPart.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Transpose} operation
+   *
+   * @param x 
+   * @param perm 
+   * @return a new instance of Transpose
+   * @see org.tensorflow.op.linalg.Transpose
+   */
+  public <T extends TType, U extends TNumber> Transpose<T> transpose(Operand<T> x,
+      Operand<U> perm) {
+    return Transpose.create(scope, x, perm);
+  }
+
+  /**
+   * Builds an {@link TriangularSolve} operation
+   *
+   * @param matrix Shape is `[..., M, M]`.
+   * @param rhs Shape is `[..., M, K]`.
+   * @param options carries optional attributes values
+   * @return a new instance of TriangularSolve
+   * @see org.tensorflow.op.linalg.TriangularSolve
+   */
+  public <T extends TType> TriangularSolve<T> triangularSolve(Operand<T> matrix, Operand<T> rhs,
+      TriangularSolve.Options... options) {
+    return TriangularSolve.create(scope, matrix, rhs, options);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/LinalgSparseOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/LinalgSparseOps.java
@@ -34,42 +34,44 @@ public final class LinalgSparseOps {
   }
 
   /**
-   * Builds an {@link SparseMatrixMul} operation
+   * Builds an {@link CSRSparseMatrixToSparseTensor} operation
+   *
+   * @param sparseMatrix A (possibly batched) CSRSparseMatrix.
+   * @param type 
+   * @return a new instance of CSRSparseMatrixToSparseTensor
+   * @see org.tensorflow.op.linalg.sparse.CSRSparseMatrixToSparseTensor
+   */
+  public <T extends TType> CSRSparseMatrixToSparseTensor<T> cSRSparseMatrixToSparseTensor(
+      Operand<?> sparseMatrix, DataType<T> type) {
+    return CSRSparseMatrixToSparseTensor.create(scope, sparseMatrix, type);
+  }
+
+  /**
+   * Builds an {@link DenseToCSRSparseMatrix} operation
+   *
+   * @param denseInput A Dense tensor.
+   * @param indices Indices of nonzero elements.
+   * @return a new instance of DenseToCSRSparseMatrix
+   * @see org.tensorflow.op.linalg.sparse.DenseToCSRSparseMatrix
+   */
+  public <T extends TType> DenseToCSRSparseMatrix denseToCSRSparseMatrix(Operand<T> denseInput,
+      Operand<TInt64> indices) {
+    return DenseToCSRSparseMatrix.create(scope, denseInput, indices);
+  }
+
+  /**
+   * Builds an {@link SparseMatrixAdd} operation
    *
    * @param a A CSRSparseMatrix.
-   * @param b A dense tensor.
-   * @return a new instance of SparseMatrixMul
-   * @see org.tensorflow.op.linalg.sparse.SparseMatrixMul
+   * @param b A CSRSparseMatrix.
+   * @param alpha A constant scalar.
+   * @param beta A constant scalar.
+   * @return a new instance of SparseMatrixAdd
+   * @see org.tensorflow.op.linalg.sparse.SparseMatrixAdd
    */
-  public <T extends TType> SparseMatrixMul sparseMatrixMul(Operand<?> a, Operand<T> b) {
-    return SparseMatrixMul.create(scope, a, b);
-  }
-
-  /**
-   * Builds an {@link SparseMatrixSoftmaxGrad} operation
-   *
-   * @param softmax A CSRSparseMatrix.
-   * @param gradSoftmax The gradient of `softmax`.
-   * @param type 
-   * @return a new instance of SparseMatrixSoftmaxGrad
-   * @see org.tensorflow.op.linalg.sparse.SparseMatrixSoftmaxGrad
-   */
-  public <T extends TNumber> SparseMatrixSoftmaxGrad sparseMatrixSoftmaxGrad(Operand<?> softmax,
-      Operand<?> gradSoftmax, DataType<T> type) {
-    return SparseMatrixSoftmaxGrad.create(scope, softmax, gradSoftmax, type);
-  }
-
-  /**
-   * Builds an {@link SparseMatrixZeros} operation
-   *
-   * @param denseShape The desired matrix shape.
-   * @param type 
-   * @return a new instance of SparseMatrixZeros
-   * @see org.tensorflow.op.linalg.sparse.SparseMatrixZeros
-   */
-  public <T extends TType> SparseMatrixZeros sparseMatrixZeros(Operand<TInt64> denseShape,
-      DataType<T> type) {
-    return SparseMatrixZeros.create(scope, denseShape, type);
+  public <T extends TType> SparseMatrixAdd sparseMatrixAdd(Operand<?> a, Operand<?> b,
+      Operand<T> alpha, Operand<T> beta) {
+    return SparseMatrixAdd.create(scope, a, b, alpha, beta);
   }
 
   /**
@@ -87,6 +89,18 @@ public final class LinalgSparseOps {
   }
 
   /**
+   * Builds an {@link SparseMatrixMul} operation
+   *
+   * @param a A CSRSparseMatrix.
+   * @param b A dense tensor.
+   * @return a new instance of SparseMatrixMul
+   * @see org.tensorflow.op.linalg.sparse.SparseMatrixMul
+   */
+  public <T extends TType> SparseMatrixMul sparseMatrixMul(Operand<?> a, Operand<T> b) {
+    return SparseMatrixMul.create(scope, a, b);
+  }
+
+  /**
    * Builds an {@link SparseMatrixNNZ} operation
    *
    * @param sparseMatrix A CSRSparseMatrix.
@@ -95,47 +109,6 @@ public final class LinalgSparseOps {
    */
   public SparseMatrixNNZ sparseMatrixNNZ(Operand<?> sparseMatrix) {
     return SparseMatrixNNZ.create(scope, sparseMatrix);
-  }
-
-  /**
-   * Builds an {@link DenseToCSRSparseMatrix} operation
-   *
-   * @param denseInput A Dense tensor.
-   * @param indices Indices of nonzero elements.
-   * @return a new instance of DenseToCSRSparseMatrix
-   * @see org.tensorflow.op.linalg.sparse.DenseToCSRSparseMatrix
-   */
-  public <T extends TType> DenseToCSRSparseMatrix denseToCSRSparseMatrix(Operand<T> denseInput,
-      Operand<TInt64> indices) {
-    return DenseToCSRSparseMatrix.create(scope, denseInput, indices);
-  }
-
-  /**
-   * Builds an {@link SparseMatrixSparseCholesky} operation
-   *
-   * @param input A `CSRSparseMatrix`.
-   * @param permutation A fill-in reducing permutation matrix.
-   * @param type 
-   * @return a new instance of SparseMatrixSparseCholesky
-   * @see org.tensorflow.op.linalg.sparse.SparseMatrixSparseCholesky
-   */
-  public <T extends TType> SparseMatrixSparseCholesky sparseMatrixSparseCholesky(Operand<?> input,
-      Operand<TInt32> permutation, DataType<T> type) {
-    return SparseMatrixSparseCholesky.create(scope, input, permutation, type);
-  }
-
-  /**
-   * Builds an {@link SparseTensorToCSRSparseMatrix} operation
-   *
-   * @param indices SparseTensor indices.
-   * @param values SparseTensor values.
-   * @param denseShape SparseTensor dense shape.
-   * @return a new instance of SparseTensorToCSRSparseMatrix
-   * @see org.tensorflow.op.linalg.sparse.SparseTensorToCSRSparseMatrix
-   */
-  public <T extends TType> SparseTensorToCSRSparseMatrix sparseTensorToCSRSparseMatrix(
-      Operand<TInt64> indices, Operand<T> values, Operand<TInt64> denseShape) {
-    return SparseTensorToCSRSparseMatrix.create(scope, indices, values, denseShape);
   }
 
   /**
@@ -163,6 +136,34 @@ public final class LinalgSparseOps {
   }
 
   /**
+   * Builds an {@link SparseMatrixSoftmaxGrad} operation
+   *
+   * @param softmax A CSRSparseMatrix.
+   * @param gradSoftmax The gradient of `softmax`.
+   * @param type 
+   * @return a new instance of SparseMatrixSoftmaxGrad
+   * @see org.tensorflow.op.linalg.sparse.SparseMatrixSoftmaxGrad
+   */
+  public <T extends TNumber> SparseMatrixSoftmaxGrad sparseMatrixSoftmaxGrad(Operand<?> softmax,
+      Operand<?> gradSoftmax, DataType<T> type) {
+    return SparseMatrixSoftmaxGrad.create(scope, softmax, gradSoftmax, type);
+  }
+
+  /**
+   * Builds an {@link SparseMatrixSparseCholesky} operation
+   *
+   * @param input A `CSRSparseMatrix`.
+   * @param permutation A fill-in reducing permutation matrix.
+   * @param type 
+   * @return a new instance of SparseMatrixSparseCholesky
+   * @see org.tensorflow.op.linalg.sparse.SparseMatrixSparseCholesky
+   */
+  public <T extends TType> SparseMatrixSparseCholesky sparseMatrixSparseCholesky(Operand<?> input,
+      Operand<TInt32> permutation, DataType<T> type) {
+    return SparseMatrixSparseCholesky.create(scope, input, permutation, type);
+  }
+
+  /**
    * Builds an {@link SparseMatrixSparseMatMul} operation
    *
    * @param a A CSRSparseMatrix.
@@ -175,21 +176,6 @@ public final class LinalgSparseOps {
   public <T extends TType> SparseMatrixSparseMatMul sparseMatrixSparseMatMul(Operand<?> a,
       Operand<?> b, DataType<T> type, SparseMatrixSparseMatMul.Options... options) {
     return SparseMatrixSparseMatMul.create(scope, a, b, type, options);
-  }
-
-  /**
-   * Builds an {@link SparseMatrixAdd} operation
-   *
-   * @param a A CSRSparseMatrix.
-   * @param b A CSRSparseMatrix.
-   * @param alpha A constant scalar.
-   * @param beta A constant scalar.
-   * @return a new instance of SparseMatrixAdd
-   * @see org.tensorflow.op.linalg.sparse.SparseMatrixAdd
-   */
-  public <T extends TType> SparseMatrixAdd sparseMatrixAdd(Operand<?> a, Operand<?> b,
-      Operand<T> alpha, Operand<T> beta) {
-    return SparseMatrixAdd.create(scope, a, b, alpha, beta);
   }
 
   /**
@@ -207,15 +193,29 @@ public final class LinalgSparseOps {
   }
 
   /**
-   * Builds an {@link CSRSparseMatrixToSparseTensor} operation
+   * Builds an {@link SparseMatrixZeros} operation
    *
-   * @param sparseMatrix A (possibly batched) CSRSparseMatrix.
+   * @param denseShape The desired matrix shape.
    * @param type 
-   * @return a new instance of CSRSparseMatrixToSparseTensor
-   * @see org.tensorflow.op.linalg.sparse.CSRSparseMatrixToSparseTensor
+   * @return a new instance of SparseMatrixZeros
+   * @see org.tensorflow.op.linalg.sparse.SparseMatrixZeros
    */
-  public <T extends TType> CSRSparseMatrixToSparseTensor<T> cSRSparseMatrixToSparseTensor(
-      Operand<?> sparseMatrix, DataType<T> type) {
-    return CSRSparseMatrixToSparseTensor.create(scope, sparseMatrix, type);
+  public <T extends TType> SparseMatrixZeros sparseMatrixZeros(Operand<TInt64> denseShape,
+      DataType<T> type) {
+    return SparseMatrixZeros.create(scope, denseShape, type);
+  }
+
+  /**
+   * Builds an {@link SparseTensorToCSRSparseMatrix} operation
+   *
+   * @param indices SparseTensor indices.
+   * @param values SparseTensor values.
+   * @param denseShape SparseTensor dense shape.
+   * @return a new instance of SparseTensorToCSRSparseMatrix
+   * @see org.tensorflow.op.linalg.sparse.SparseTensorToCSRSparseMatrix
+   */
+  public <T extends TType> SparseTensorToCSRSparseMatrix sparseTensorToCSRSparseMatrix(
+      Operand<TInt64> indices, Operand<T> values, Operand<TInt64> denseShape) {
+    return SparseTensorToCSRSparseMatrix.create(scope, indices, values, denseShape);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/MathOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/MathOps.java
@@ -127,258 +127,48 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link MulNoNan} operation
+   * Builds an {@link Abs} operation
    *
    * @param x 
-   * @param y 
-   * @return a new instance of MulNoNan
-   * @see org.tensorflow.op.math.MulNoNan
+   * @return a new instance of Abs
+   * @see org.tensorflow.op.math.Abs
    */
-  public <T extends TType> MulNoNan<T> mulNoNan(Operand<T> x, Operand<T> y) {
-    return MulNoNan.create(scope, x, y);
+  public <T extends TNumber> Abs<T> abs(Operand<T> x) {
+    return Abs.create(scope, x);
   }
 
   /**
-   * Builds an {@link Bincount} operation
+   * Builds an {@link AccumulateN} operation
    *
-   * @param arr int32 `Tensor`.
-   * @param size non-negative int32 scalar `Tensor`.
-   * @param weights is an int32, int64, float32, or float64 `Tensor` with the same
-   * @return a new instance of Bincount
-   * @see org.tensorflow.op.math.Bincount
+   * @param inputs A list of `Tensor` objects, each with same shape and type.
+   * @param shape Shape of elements of `inputs`.
+   * @return a new instance of AccumulateN
+   * @see org.tensorflow.op.math.AccumulateN
    */
-  public <T extends TNumber> Bincount<T> bincount(Operand<TInt32> arr, Operand<TInt32> size,
-      Operand<T> weights) {
-    return Bincount.create(scope, arr, size, weights);
+  public <T extends TType> AccumulateN<T> accumulateN(Iterable<Operand<T>> inputs, Shape shape) {
+    return AccumulateN.create(scope, inputs, shape);
   }
 
   /**
-   * Builds an {@link Polygamma} operation
-   *
-   * @param a 
-   * @param x 
-   * @return a new instance of Polygamma
-   * @see org.tensorflow.op.math.Polygamma
-   */
-  public <T extends TNumber> Polygamma<T> polygamma(Operand<T> a, Operand<T> x) {
-    return Polygamma.create(scope, a, x);
-  }
-
-  /**
-   * Builds an {@link BesselI0e} operation
+   * Builds an {@link Acos} operation
    *
    * @param x 
-   * @return a new instance of BesselI0e
-   * @see org.tensorflow.op.math.BesselI0e
+   * @return a new instance of Acos
+   * @see org.tensorflow.op.math.Acos
    */
-  public <T extends TNumber> BesselI0e<T> besselI0e(Operand<T> x) {
-    return BesselI0e.create(scope, x);
+  public <T extends TType> Acos<T> acos(Operand<T> x) {
+    return Acos.create(scope, x);
   }
 
   /**
-   * Builds an {@link Reciprocal} operation
+   * Builds an {@link Acosh} operation
    *
    * @param x 
-   * @return a new instance of Reciprocal
-   * @see org.tensorflow.op.math.Reciprocal
+   * @return a new instance of Acosh
+   * @see org.tensorflow.op.math.Acosh
    */
-  public <T extends TType> Reciprocal<T> reciprocal(Operand<T> x) {
-    return Reciprocal.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Rint} operation
-   *
-   * @param x 
-   * @return a new instance of Rint
-   * @see org.tensorflow.op.math.Rint
-   */
-  public <T extends TNumber> Rint<T> rint(Operand<T> x) {
-    return Rint.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Igamma} operation
-   *
-   * @param a 
-   * @param x 
-   * @return a new instance of Igamma
-   * @see org.tensorflow.op.math.Igamma
-   */
-  public <T extends TNumber> Igamma<T> igamma(Operand<T> a, Operand<T> x) {
-    return Igamma.create(scope, a, x);
-  }
-
-  /**
-   * Builds an {@link Pow} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Pow
-   * @see org.tensorflow.op.math.Pow
-   */
-  public <T extends TType> Pow<T> pow(Operand<T> x, Operand<T> y) {
-    return Pow.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Cosh} operation
-   *
-   * @param x 
-   * @return a new instance of Cosh
-   * @see org.tensorflow.op.math.Cosh
-   */
-  public <T extends TType> Cosh<T> cosh(Operand<T> x) {
-    return Cosh.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Round} operation
-   *
-   * @param x 
-   * @return a new instance of Round
-   * @see org.tensorflow.op.math.Round
-   */
-  public <T extends TType> Round<T> round(Operand<T> x) {
-    return Round.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link IsInf} operation
-   *
-   * @param x 
-   * @return a new instance of IsInf
-   * @see org.tensorflow.op.math.IsInf
-   */
-  public <T extends TNumber> IsInf isInf(Operand<T> x) {
-    return IsInf.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link LessEqual} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of LessEqual
-   * @see org.tensorflow.op.math.LessEqual
-   */
-  public <T extends TNumber> LessEqual lessEqual(Operand<T> x, Operand<T> y) {
-    return LessEqual.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Real} operation
-   *
-   * @param input 
-   * @return a new instance of Real
-   * @see org.tensorflow.op.math.Real
-   */
-  public <T extends TType> Real<TFloat32> real(Operand<T> input) {
-    return Real.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link BesselI1e} operation
-   *
-   * @param x 
-   * @return a new instance of BesselI1e
-   * @see org.tensorflow.op.math.BesselI1e
-   */
-  public <T extends TNumber> BesselI1e<T> besselI1e(Operand<T> x) {
-    return BesselI1e.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Atanh} operation
-   *
-   * @param x 
-   * @return a new instance of Atanh
-   * @see org.tensorflow.op.math.Atanh
-   */
-  public <T extends TType> Atanh<T> atanh(Operand<T> x) {
-    return Atanh.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Ceil} operation
-   *
-   * @param x 
-   * @return a new instance of Ceil
-   * @see org.tensorflow.op.math.Ceil
-   */
-  public <T extends TNumber> Ceil<T> ceil(Operand<T> x) {
-    return Ceil.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link erfinv} operation
-   *
-   * @param x 
-   * @return a new instance of erfinv
-   * @see org.tensorflow.op.math.erfinv
-   */
-  public <T extends TNumber> erfinv<T> erfinv(Operand<T> x) {
-    return erfinv.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Atan2} operation
-   *
-   * @param y 
-   * @param x 
-   * @return a new instance of Atan2
-   * @see org.tensorflow.op.math.Atan2
-   */
-  public <T extends TNumber> Atan2<T> atan2(Operand<T> y, Operand<T> x) {
-    return Atan2.create(scope, y, x);
-  }
-
-  /**
-   * Builds an {@link ArgMin} operation
-   *
-   * @param input 
-   * @param dimension int32 or int64, must be in the range `[-rank(input), rank(input))`.
-   * @param outputType 
-   * @return a new instance of ArgMin
-   * @see org.tensorflow.op.math.ArgMin
-   */
-  public <V extends TNumber, T extends TType, U extends TNumber> ArgMin<V> argMin(Operand<T> input,
-      Operand<U> dimension, DataType<V> outputType) {
-    return ArgMin.create(scope, input, dimension, outputType);
-  }
-
-  /**
-   * Builds an {@link Sign} operation
-   *
-   * @param x 
-   * @return a new instance of Sign
-   * @see org.tensorflow.op.math.Sign
-   */
-  public <T extends TType> Sign<T> sign(Operand<T> x) {
-    return Sign.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Exp} operation
-   *
-   * @param x 
-   * @return a new instance of Exp
-   * @see org.tensorflow.op.math.Exp
-   */
-  public <T extends TType> Exp<T> exp(Operand<T> x) {
-    return Exp.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Angle} operation
-   *
-   * @param input 
-   * @param Tout 
-   * @return a new instance of Angle
-   * @see org.tensorflow.op.math.Angle
-   */
-  public <U extends TNumber, T extends TType> Angle<U> angle(Operand<T> input, DataType<U> Tout) {
-    return Angle.create(scope, input, Tout);
+  public <T extends TType> Acosh<T> acosh(Operand<T> x) {
+    return Acosh.create(scope, x);
   }
 
   /**
@@ -394,554 +184,37 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link Log} operation
+   * Builds an {@link AddN} operation
    *
-   * @param x 
-   * @return a new instance of Log
-   * @see org.tensorflow.op.math.Log
+   * @param inputs 
+   * @return a new instance of AddN
+   * @see org.tensorflow.op.math.AddN
    */
-  public <T extends TType> Log<T> log(Operand<T> x) {
-    return Log.create(scope, x);
+  public <T extends TType> AddN<T> addN(Iterable<Operand<T>> inputs) {
+    return AddN.create(scope, inputs);
   }
 
   /**
-   * Builds an {@link UnsortedSegmentMin} operation
-   *
-   * @param data 
-   * @param segmentIds A tensor whose shape is a prefix of `data.shape`.
-   * @param numSegments 
-   * @return a new instance of UnsortedSegmentMin
-   * @see org.tensorflow.op.math.UnsortedSegmentMin
-   */
-  public <T extends TNumber, U extends TNumber, V extends TNumber> UnsortedSegmentMin<T> unsortedSegmentMin(
-      Operand<T> data, Operand<U> segmentIds, Operand<V> numSegments) {
-    return UnsortedSegmentMin.create(scope, data, segmentIds, numSegments);
-  }
-
-  /**
-   * Builds an {@link SquaredDifference} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of SquaredDifference
-   * @see org.tensorflow.op.math.SquaredDifference
-   */
-  public <T extends TType> SquaredDifference<T> squaredDifference(Operand<T> x, Operand<T> y) {
-    return SquaredDifference.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link NotEqual} operation
-   *
-   * @param x 
-   * @param y 
-   * @param options carries optional attributes values
-   * @return a new instance of NotEqual
-   * @see org.tensorflow.op.math.NotEqual
-   */
-  public <T extends TType> NotEqual notEqual(Operand<T> x, Operand<T> y,
-      NotEqual.Options... options) {
-    return NotEqual.create(scope, x, y, options);
-  }
-
-  /**
-   * Builds an {@link Cumprod} operation
-   *
-   * @param x A `Tensor`. Must be one of the following types: `float32`, `float64`,
-   * @param axis A `Tensor` of type `int32` (default: 0). Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of Cumprod
-   * @see org.tensorflow.op.math.Cumprod
-   */
-  public <T extends TType, U extends TNumber> Cumprod<T> cumprod(Operand<T> x, Operand<U> axis,
-      Cumprod.Options... options) {
-    return Cumprod.create(scope, x, axis, options);
-  }
-
-  /**
-   * Builds an {@link DivNoNan} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of DivNoNan
-   * @see org.tensorflow.op.math.DivNoNan
-   */
-  public <T extends TType> DivNoNan<T> divNoNan(Operand<T> x, Operand<T> y) {
-    return DivNoNan.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Atan} operation
-   *
-   * @param x 
-   * @return a new instance of Atan
-   * @see org.tensorflow.op.math.Atan
-   */
-  public <T extends TType> Atan<T> atan(Operand<T> x) {
-    return Atan.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link ArgMax} operation
+   * Builds an {@link Angle} operation
    *
    * @param input 
-   * @param dimension int32 or int64, must be in the range `[-rank(input), rank(input))`.
-   * @return a new instance of ArgMax
-   * @see org.tensorflow.op.math.ArgMax
+   * @return a new instance of Angle
+   * @see org.tensorflow.op.math.Angle
    */
-  public <T extends TType, U extends TNumber> ArgMax<TInt64> argMax(Operand<T> input,
-      Operand<U> dimension) {
-    return ArgMax.create(scope, input, dimension);
+  public <T extends TType> Angle<TFloat32> angle(Operand<T> input) {
+    return Angle.create(scope, input);
   }
 
   /**
-   * Builds an {@link Maximum} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Maximum
-   * @see org.tensorflow.op.math.Maximum
-   */
-  public <T extends TNumber> Maximum<T> maximum(Operand<T> x, Operand<T> y) {
-    return Maximum.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link ArgMax} operation
-   *
-   * @param input 
-   * @param dimension int32 or int64, must be in the range `[-rank(input), rank(input))`.
-   * @param outputType 
-   * @return a new instance of ArgMax
-   * @see org.tensorflow.op.math.ArgMax
-   */
-  public <V extends TNumber, T extends TType, U extends TNumber> ArgMax<V> argMax(Operand<T> input,
-      Operand<U> dimension, DataType<V> outputType) {
-    return ArgMax.create(scope, input, dimension, outputType);
-  }
-
-  /**
-   * Builds an {@link UnsortedSegmentProd} operation
-   *
-   * @param data 
-   * @param segmentIds A tensor whose shape is a prefix of `data.shape`.
-   * @param numSegments 
-   * @return a new instance of UnsortedSegmentProd
-   * @see org.tensorflow.op.math.UnsortedSegmentProd
-   */
-  public <T extends TType, U extends TNumber, V extends TNumber> UnsortedSegmentProd<T> unsortedSegmentProd(
-      Operand<T> data, Operand<U> segmentIds, Operand<V> numSegments) {
-    return UnsortedSegmentProd.create(scope, data, segmentIds, numSegments);
-  }
-
-  /**
-   * Builds an {@link LogicalNot} operation
-   *
-   * @param x 
-   * @return a new instance of LogicalNot
-   * @see org.tensorflow.op.math.LogicalNot
-   */
-  public LogicalNot logicalNot(Operand<TBool> x) {
-    return LogicalNot.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Cos} operation
-   *
-   * @param x 
-   * @return a new instance of Cos
-   * @see org.tensorflow.op.math.Cos
-   */
-  public <T extends TType> Cos<T> cos(Operand<T> x) {
-    return Cos.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Ndtri} operation
-   *
-   * @param x 
-   * @return a new instance of Ndtri
-   * @see org.tensorflow.op.math.Ndtri
-   */
-  public <T extends TNumber> Ndtri<T> ndtri(Operand<T> x) {
-    return Ndtri.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Imag} operation
-   *
-   * @param input 
-   * @return a new instance of Imag
-   * @see org.tensorflow.op.math.Imag
-   */
-  public <T extends TType> Imag<TFloat32> imag(Operand<T> input) {
-    return Imag.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Greater} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Greater
-   * @see org.tensorflow.op.math.Greater
-   */
-  public <T extends TNumber> Greater greater(Operand<T> x, Operand<T> y) {
-    return Greater.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link TruncateDiv} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of TruncateDiv
-   * @see org.tensorflow.op.math.TruncateDiv
-   */
-  public <T extends TType> TruncateDiv<T> truncateDiv(Operand<T> x, Operand<T> y) {
-    return TruncateDiv.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link CheckNumerics} operation
-   *
-   * @param tensor 
-   * @param message Prefix of the error message.
-   * @return a new instance of CheckNumerics
-   * @see org.tensorflow.op.math.CheckNumerics
-   */
-  public <T extends TNumber> CheckNumerics<T> checkNumerics(Operand<T> tensor, String message) {
-    return CheckNumerics.create(scope, tensor, message);
-  }
-
-  /**
-   * Builds an {@link Minimum} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Minimum
-   * @see org.tensorflow.op.math.Minimum
-   */
-  public <T extends TNumber> Minimum<T> minimum(Operand<T> x, Operand<T> y) {
-    return Minimum.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Div} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Div
-   * @see org.tensorflow.op.math.Div
-   */
-  public <T extends TType> Div<T> div(Operand<T> x, Operand<T> y) {
-    return Div.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link QuantizedAdd} operation
-   *
-   * @param x 
-   * @param y 
-   * @param minX The float value that the lowest quantized `x` value represents.
-   * @param maxX The float value that the highest quantized `x` value represents.
-   * @param minY The float value that the lowest quantized `y` value represents.
-   * @param maxY The float value that the highest quantized `y` value represents.
-   * @param Toutput 
-   * @return a new instance of QuantizedAdd
-   * @see org.tensorflow.op.math.QuantizedAdd
-   */
-  public <V extends TType, T extends TType, U extends TType> QuantizedAdd<V> quantizedAdd(
-      Operand<T> x, Operand<U> y, Operand<TFloat32> minX, Operand<TFloat32> maxX,
-      Operand<TFloat32> minY, Operand<TFloat32> maxY, DataType<V> Toutput) {
-    return QuantizedAdd.create(scope, x, y, minX, maxX, minY, maxY, Toutput);
-  }
-
-  /**
-   * Builds an {@link Digamma} operation
-   *
-   * @param x 
-   * @return a new instance of Digamma
-   * @see org.tensorflow.op.math.Digamma
-   */
-  public <T extends TNumber> Digamma<T> digamma(Operand<T> x) {
-    return Digamma.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Mean} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of Mean
-   * @see org.tensorflow.op.math.Mean
-   */
-  public <T extends TType, U extends TNumber> Mean<T> mean(Operand<T> input, Operand<U> axis,
-      Mean.Options... options) {
-    return Mean.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link Betainc} operation
-   *
-   * @param a 
-   * @param b 
-   * @param x 
-   * @return a new instance of Betainc
-   * @see org.tensorflow.op.math.Betainc
-   */
-  public <T extends TNumber> Betainc<T> betainc(Operand<T> a, Operand<T> b, Operand<T> x) {
-    return Betainc.create(scope, a, b, x);
-  }
-
-  /**
-   * Builds an {@link Real} operation
+   * Builds an {@link Angle} operation
    *
    * @param input 
    * @param Tout 
-   * @return a new instance of Real
-   * @see org.tensorflow.op.math.Real
+   * @return a new instance of Angle
+   * @see org.tensorflow.op.math.Angle
    */
-  public <U extends TNumber, T extends TType> Real<U> real(Operand<T> input, DataType<U> Tout) {
-    return Real.create(scope, input, Tout);
-  }
-
-  /**
-   * Builds an {@link Asin} operation
-   *
-   * @param x 
-   * @return a new instance of Asin
-   * @see org.tensorflow.op.math.Asin
-   */
-  public <T extends TType> Asin<T> asin(Operand<T> x) {
-    return Asin.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Log1p} operation
-   *
-   * @param x 
-   * @return a new instance of Log1p
-   * @see org.tensorflow.op.math.Log1p
-   */
-  public <T extends TType> Log1p<T> log1p(Operand<T> x) {
-    return Log1p.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Conj} operation
-   *
-   * @param input 
-   * @return a new instance of Conj
-   * @see org.tensorflow.op.math.Conj
-   */
-  public <T extends TType> Conj<T> conj(Operand<T> input) {
-    return Conj.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Mul} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Mul
-   * @see org.tensorflow.op.math.Mul
-   */
-  public <T extends TType> Mul<T> mul(Operand<T> x, Operand<T> y) {
-    return Mul.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Rsqrt} operation
-   *
-   * @param x 
-   * @return a new instance of Rsqrt
-   * @see org.tensorflow.op.math.Rsqrt
-   */
-  public <T extends TType> Rsqrt<T> rsqrt(Operand<T> x) {
-    return Rsqrt.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Tanh} operation
-   *
-   * @param x 
-   * @return a new instance of Tanh
-   * @see org.tensorflow.op.math.Tanh
-   */
-  public <T extends TType> Tanh<T> tanh(Operand<T> x) {
-    return Tanh.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Cumsum} operation
-   *
-   * @param x A `Tensor`. Must be one of the following types: `float32`, `float64`,
-   * @param axis A `Tensor` of type `int32` (default: 0). Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of Cumsum
-   * @see org.tensorflow.op.math.Cumsum
-   */
-  public <T extends TType, U extends TNumber> Cumsum<T> cumsum(Operand<T> x, Operand<U> axis,
-      Cumsum.Options... options) {
-    return Cumsum.create(scope, x, axis, options);
-  }
-
-  /**
-   * Builds an {@link Xlogy} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Xlogy
-   * @see org.tensorflow.op.math.Xlogy
-   */
-  public <T extends TType> Xlogy<T> xlogy(Operand<T> x, Operand<T> y) {
-    return Xlogy.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Mod} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Mod
-   * @see org.tensorflow.op.math.Mod
-   */
-  public <T extends TNumber> Mod<T> mod(Operand<T> x, Operand<T> y) {
-    return Mod.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Expm1} operation
-   *
-   * @param x 
-   * @return a new instance of Expm1
-   * @see org.tensorflow.op.math.Expm1
-   */
-  public <T extends TType> Expm1<T> expm1(Operand<T> x) {
-    return Expm1.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link UnsortedSegmentSum} operation
-   *
-   * @param data 
-   * @param segmentIds A tensor whose shape is a prefix of `data.shape`.
-   * @param numSegments 
-   * @return a new instance of UnsortedSegmentSum
-   * @see org.tensorflow.op.math.UnsortedSegmentSum
-   */
-  public <T extends TType, U extends TNumber, V extends TNumber> UnsortedSegmentSum<T> unsortedSegmentSum(
-      Operand<T> data, Operand<U> segmentIds, Operand<V> numSegments) {
-    return UnsortedSegmentSum.create(scope, data, segmentIds, numSegments);
-  }
-
-  /**
-   * Builds an {@link SegmentMax} operation
-   *
-   * @param data 
-   * @param segmentIds A 1-D tensor whose size is equal to the size of `data`'s
-   * @return a new instance of SegmentMax
-   * @see org.tensorflow.op.math.SegmentMax
-   */
-  public <T extends TNumber, U extends TNumber> SegmentMax<T> segmentMax(Operand<T> data,
-      Operand<U> segmentIds) {
-    return SegmentMax.create(scope, data, segmentIds);
-  }
-
-  /**
-   * Builds an {@link Less} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of Less
-   * @see org.tensorflow.op.math.Less
-   */
-  public <T extends TNumber> Less less(Operand<T> x, Operand<T> y) {
-    return Less.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link FloorDiv} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of FloorDiv
-   * @see org.tensorflow.op.math.FloorDiv
-   */
-  public <T extends TType> FloorDiv<T> floorDiv(Operand<T> x, Operand<T> y) {
-    return FloorDiv.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link LogicalOr} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of LogicalOr
-   * @see org.tensorflow.op.math.LogicalOr
-   */
-  public LogicalOr logicalOr(Operand<TBool> x, Operand<TBool> y) {
-    return LogicalOr.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Neg} operation
-   *
-   * @param x 
-   * @return a new instance of Neg
-   * @see org.tensorflow.op.math.Neg
-   */
-  public <T extends TType> Neg<T> neg(Operand<T> x) {
-    return Neg.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link FloorMod} operation
-   *
-   * @param x 
-   * @param y 
-   * @return a new instance of FloorMod
-   * @see org.tensorflow.op.math.FloorMod
-   */
-  public <T extends TNumber> FloorMod<T> floorMod(Operand<T> x, Operand<T> y) {
-    return FloorMod.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link Acos} operation
-   *
-   * @param x 
-   * @return a new instance of Acos
-   * @see org.tensorflow.op.math.Acos
-   */
-  public <T extends TType> Acos<T> acos(Operand<T> x) {
-    return Acos.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link NextAfter} operation
-   *
-   * @param x1 
-   * @param x2 
-   * @return a new instance of NextAfter
-   * @see org.tensorflow.op.math.NextAfter
-   */
-  public <T extends TNumber> NextAfter<T> nextAfter(Operand<T> x1, Operand<T> x2) {
-    return NextAfter.create(scope, x1, x2);
-  }
-
-  /**
-   * Builds an {@link Igammac} operation
-   *
-   * @param a 
-   * @param x 
-   * @return a new instance of Igammac
-   * @see org.tensorflow.op.math.Igammac
-   */
-  public <T extends TNumber> Igammac<T> igammac(Operand<T> a, Operand<T> x) {
-    return Igammac.create(scope, a, x);
+  public <U extends TNumber, T extends TType> Angle<U> angle(Operand<T> input, DataType<U> Tout) {
+    return Angle.create(scope, input, Tout);
   }
 
   /**
@@ -959,49 +232,318 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link SegmentMean} operation
+   * Builds an {@link ArgMax} operation
    *
-   * @param data 
-   * @param segmentIds A 1-D tensor whose size is equal to the size of `data`'s
-   * @return a new instance of SegmentMean
-   * @see org.tensorflow.op.math.SegmentMean
+   * @param input 
+   * @param dimension int32 or int64, must be in the range `[-rank(input), rank(input))`.
+   * @return a new instance of ArgMax
+   * @see org.tensorflow.op.math.ArgMax
    */
-  public <T extends TType, U extends TNumber> SegmentMean<T> segmentMean(Operand<T> data,
-      Operand<U> segmentIds) {
-    return SegmentMean.create(scope, data, segmentIds);
+  public <T extends TType, U extends TNumber> ArgMax<TInt64> argMax(Operand<T> input,
+      Operand<U> dimension) {
+    return ArgMax.create(scope, input, dimension);
   }
 
   /**
-   * Builds an {@link Lgamma} operation
+   * Builds an {@link ArgMax} operation
    *
-   * @param x 
-   * @return a new instance of Lgamma
-   * @see org.tensorflow.op.math.Lgamma
+   * @param input 
+   * @param dimension int32 or int64, must be in the range `[-rank(input), rank(input))`.
+   * @param outputType 
+   * @return a new instance of ArgMax
+   * @see org.tensorflow.op.math.ArgMax
    */
-  public <T extends TNumber> Lgamma<T> lgamma(Operand<T> x) {
-    return Lgamma.create(scope, x);
+  public <V extends TNumber, T extends TType, U extends TNumber> ArgMax<V> argMax(Operand<T> input,
+      Operand<U> dimension, DataType<V> outputType) {
+    return ArgMax.create(scope, input, dimension, outputType);
   }
 
   /**
-   * Builds an {@link Sqrt} operation
+   * Builds an {@link ArgMin} operation
    *
-   * @param x 
-   * @return a new instance of Sqrt
-   * @see org.tensorflow.op.math.Sqrt
+   * @param input 
+   * @param dimension int32 or int64, must be in the range `[-rank(input), rank(input))`.
+   * @return a new instance of ArgMin
+   * @see org.tensorflow.op.math.ArgMin
    */
-  public <T extends TType> Sqrt<T> sqrt(Operand<T> x) {
-    return Sqrt.create(scope, x);
+  public <T extends TType, U extends TNumber> ArgMin<TInt64> argMin(Operand<T> input,
+      Operand<U> dimension) {
+    return ArgMin.create(scope, input, dimension);
   }
 
   /**
-   * Builds an {@link IsNan} operation
+   * Builds an {@link ArgMin} operation
+   *
+   * @param input 
+   * @param dimension int32 or int64, must be in the range `[-rank(input), rank(input))`.
+   * @param outputType 
+   * @return a new instance of ArgMin
+   * @see org.tensorflow.op.math.ArgMin
+   */
+  public <V extends TNumber, T extends TType, U extends TNumber> ArgMin<V> argMin(Operand<T> input,
+      Operand<U> dimension, DataType<V> outputType) {
+    return ArgMin.create(scope, input, dimension, outputType);
+  }
+
+  /**
+   * Builds an {@link Asin} operation
    *
    * @param x 
-   * @return a new instance of IsNan
-   * @see org.tensorflow.op.math.IsNan
+   * @return a new instance of Asin
+   * @see org.tensorflow.op.math.Asin
    */
-  public <T extends TNumber> IsNan isNan(Operand<T> x) {
-    return IsNan.create(scope, x);
+  public <T extends TType> Asin<T> asin(Operand<T> x) {
+    return Asin.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Asinh} operation
+   *
+   * @param x 
+   * @return a new instance of Asinh
+   * @see org.tensorflow.op.math.Asinh
+   */
+  public <T extends TType> Asinh<T> asinh(Operand<T> x) {
+    return Asinh.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Atan} operation
+   *
+   * @param x 
+   * @return a new instance of Atan
+   * @see org.tensorflow.op.math.Atan
+   */
+  public <T extends TType> Atan<T> atan(Operand<T> x) {
+    return Atan.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Atan2} operation
+   *
+   * @param y 
+   * @param x 
+   * @return a new instance of Atan2
+   * @see org.tensorflow.op.math.Atan2
+   */
+  public <T extends TNumber> Atan2<T> atan2(Operand<T> y, Operand<T> x) {
+    return Atan2.create(scope, y, x);
+  }
+
+  /**
+   * Builds an {@link Atanh} operation
+   *
+   * @param x 
+   * @return a new instance of Atanh
+   * @see org.tensorflow.op.math.Atanh
+   */
+  public <T extends TType> Atanh<T> atanh(Operand<T> x) {
+    return Atanh.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link BesselI0e} operation
+   *
+   * @param x 
+   * @return a new instance of BesselI0e
+   * @see org.tensorflow.op.math.BesselI0e
+   */
+  public <T extends TNumber> BesselI0e<T> besselI0e(Operand<T> x) {
+    return BesselI0e.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link BesselI1e} operation
+   *
+   * @param x 
+   * @return a new instance of BesselI1e
+   * @see org.tensorflow.op.math.BesselI1e
+   */
+  public <T extends TNumber> BesselI1e<T> besselI1e(Operand<T> x) {
+    return BesselI1e.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Betainc} operation
+   *
+   * @param a 
+   * @param b 
+   * @param x 
+   * @return a new instance of Betainc
+   * @see org.tensorflow.op.math.Betainc
+   */
+  public <T extends TNumber> Betainc<T> betainc(Operand<T> a, Operand<T> b, Operand<T> x) {
+    return Betainc.create(scope, a, b, x);
+  }
+
+  /**
+   * Builds an {@link Bincount} operation
+   *
+   * @param arr int32 `Tensor`.
+   * @param size non-negative int32 scalar `Tensor`.
+   * @param weights is an int32, int64, float32, or float64 `Tensor` with the same
+   * @return a new instance of Bincount
+   * @see org.tensorflow.op.math.Bincount
+   */
+  public <T extends TNumber> Bincount<T> bincount(Operand<TInt32> arr, Operand<TInt32> size,
+      Operand<T> weights) {
+    return Bincount.create(scope, arr, size, weights);
+  }
+
+  /**
+   * Builds an {@link Ceil} operation
+   *
+   * @param x 
+   * @return a new instance of Ceil
+   * @see org.tensorflow.op.math.Ceil
+   */
+  public <T extends TNumber> Ceil<T> ceil(Operand<T> x) {
+    return Ceil.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link CheckNumerics} operation
+   *
+   * @param tensor 
+   * @param message Prefix of the error message.
+   * @return a new instance of CheckNumerics
+   * @see org.tensorflow.op.math.CheckNumerics
+   */
+  public <T extends TNumber> CheckNumerics<T> checkNumerics(Operand<T> tensor, String message) {
+    return CheckNumerics.create(scope, tensor, message);
+  }
+
+  /**
+   * Builds an {@link CompareAndBitpack} operation
+   *
+   * @param input Values to compare against `threshold` and bitpack.
+   * @param threshold Threshold to compare against.
+   * @return a new instance of CompareAndBitpack
+   * @see org.tensorflow.op.math.CompareAndBitpack
+   */
+  public <T extends TType> CompareAndBitpack compareAndBitpack(Operand<T> input,
+      Operand<T> threshold) {
+    return CompareAndBitpack.create(scope, input, threshold);
+  }
+
+  /**
+   * Builds an {@link ComplexAbs} operation
+   *
+   * @param x 
+   * @return a new instance of ComplexAbs
+   * @see org.tensorflow.op.math.ComplexAbs
+   */
+  public <T extends TType> ComplexAbs<TFloat32> complexAbs(Operand<T> x) {
+    return ComplexAbs.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link ComplexAbs} operation
+   *
+   * @param x 
+   * @param Tout 
+   * @return a new instance of ComplexAbs
+   * @see org.tensorflow.op.math.ComplexAbs
+   */
+  public <U extends TNumber, T extends TType> ComplexAbs<U> complexAbs(Operand<T> x,
+      DataType<U> Tout) {
+    return ComplexAbs.create(scope, x, Tout);
+  }
+
+  /**
+   * Builds an {@link Conj} operation
+   *
+   * @param input 
+   * @return a new instance of Conj
+   * @see org.tensorflow.op.math.Conj
+   */
+  public <T extends TType> Conj<T> conj(Operand<T> input) {
+    return Conj.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Cos} operation
+   *
+   * @param x 
+   * @return a new instance of Cos
+   * @see org.tensorflow.op.math.Cos
+   */
+  public <T extends TType> Cos<T> cos(Operand<T> x) {
+    return Cos.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Cosh} operation
+   *
+   * @param x 
+   * @return a new instance of Cosh
+   * @see org.tensorflow.op.math.Cosh
+   */
+  public <T extends TType> Cosh<T> cosh(Operand<T> x) {
+    return Cosh.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Cumprod} operation
+   *
+   * @param x A `Tensor`. Must be one of the following types: `float32`, `float64`,
+   * @param axis A `Tensor` of type `int32` (default: 0). Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of Cumprod
+   * @see org.tensorflow.op.math.Cumprod
+   */
+  public <T extends TType, U extends TNumber> Cumprod<T> cumprod(Operand<T> x, Operand<U> axis,
+      Cumprod.Options... options) {
+    return Cumprod.create(scope, x, axis, options);
+  }
+
+  /**
+   * Builds an {@link Cumsum} operation
+   *
+   * @param x A `Tensor`. Must be one of the following types: `float32`, `float64`,
+   * @param axis A `Tensor` of type `int32` (default: 0). Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of Cumsum
+   * @see org.tensorflow.op.math.Cumsum
+   */
+  public <T extends TType, U extends TNumber> Cumsum<T> cumsum(Operand<T> x, Operand<U> axis,
+      Cumsum.Options... options) {
+    return Cumsum.create(scope, x, axis, options);
+  }
+
+  /**
+   * Builds an {@link Digamma} operation
+   *
+   * @param x 
+   * @return a new instance of Digamma
+   * @see org.tensorflow.op.math.Digamma
+   */
+  public <T extends TNumber> Digamma<T> digamma(Operand<T> x) {
+    return Digamma.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Div} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of Div
+   * @see org.tensorflow.op.math.Div
+   */
+  public <T extends TType> Div<T> div(Operand<T> x, Operand<T> y) {
+    return Div.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link DivNoNan} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of DivNoNan
+   * @see org.tensorflow.op.math.DivNoNan
+   */
+  public <T extends TType> DivNoNan<T> divNoNan(Operand<T> x, Operand<T> y) {
+    return DivNoNan.create(scope, x, y);
   }
 
   /**
@@ -1029,64 +571,163 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link LogicalAnd} operation
+   * Builds an {@link Erfc} operation
+   *
+   * @param x 
+   * @return a new instance of Erfc
+   * @see org.tensorflow.op.math.Erfc
+   */
+  public <T extends TNumber> Erfc<T> erfc(Operand<T> x) {
+    return Erfc.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link erfinv} operation
+   *
+   * @param x 
+   * @return a new instance of erfinv
+   * @see org.tensorflow.op.math.erfinv
+   */
+  public <T extends TNumber> erfinv<T> erfinv(Operand<T> x) {
+    return erfinv.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Exp} operation
+   *
+   * @param x 
+   * @return a new instance of Exp
+   * @see org.tensorflow.op.math.Exp
+   */
+  public <T extends TType> Exp<T> exp(Operand<T> x) {
+    return Exp.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Expm1} operation
+   *
+   * @param x 
+   * @return a new instance of Expm1
+   * @see org.tensorflow.op.math.Expm1
+   */
+  public <T extends TType> Expm1<T> expm1(Operand<T> x) {
+    return Expm1.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Fact} operation
+   *
+   * @return a new instance of Fact
+   * @see org.tensorflow.op.math.Fact
+   */
+  public Fact fact() {
+    return Fact.create(scope);
+  }
+
+  /**
+   * Builds an {@link Floor} operation
+   *
+   * @param x 
+   * @return a new instance of Floor
+   * @see org.tensorflow.op.math.Floor
+   */
+  public <T extends TNumber> Floor<T> floor(Operand<T> x) {
+    return Floor.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link FloorDiv} operation
    *
    * @param x 
    * @param y 
-   * @return a new instance of LogicalAnd
-   * @see org.tensorflow.op.math.LogicalAnd
+   * @return a new instance of FloorDiv
+   * @see org.tensorflow.op.math.FloorDiv
    */
-  public LogicalAnd logicalAnd(Operand<TBool> x, Operand<TBool> y) {
-    return LogicalAnd.create(scope, x, y);
+  public <T extends TType> FloorDiv<T> floorDiv(Operand<T> x, Operand<T> y) {
+    return FloorDiv.create(scope, x, y);
   }
 
   /**
-   * Builds an {@link Square} operation
-   *
-   * @param x 
-   * @return a new instance of Square
-   * @see org.tensorflow.op.math.Square
-   */
-  public <T extends TType> Square<T> square(Operand<T> x) {
-    return Square.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Sub} operation
+   * Builds an {@link FloorMod} operation
    *
    * @param x 
    * @param y 
-   * @return a new instance of Sub
-   * @see org.tensorflow.op.math.Sub
+   * @return a new instance of FloorMod
+   * @see org.tensorflow.op.math.FloorMod
    */
-  public <T extends TType> Sub<T> sub(Operand<T> x, Operand<T> y) {
-    return Sub.create(scope, x, y);
+  public <T extends TNumber> FloorMod<T> floorMod(Operand<T> x, Operand<T> y) {
+    return FloorMod.create(scope, x, y);
   }
 
   /**
-   * Builds an {@link AccumulateN} operation
+   * Builds an {@link Greater} operation
    *
-   * @param inputs A list of `Tensor` objects, each with same shape and type.
-   * @param shape Shape of elements of `inputs`.
-   * @return a new instance of AccumulateN
-   * @see org.tensorflow.op.math.AccumulateN
+   * @param x 
+   * @param y 
+   * @return a new instance of Greater
+   * @see org.tensorflow.op.math.Greater
    */
-  public <T extends TType> AccumulateN<T> accumulateN(Iterable<Operand<T>> inputs, Shape shape) {
-    return AccumulateN.create(scope, inputs, shape);
+  public <T extends TNumber> Greater greater(Operand<T> x, Operand<T> y) {
+    return Greater.create(scope, x, y);
   }
 
   /**
-   * Builds an {@link UnsortedSegmentMax} operation
+   * Builds an {@link GreaterEqual} operation
    *
-   * @param data 
-   * @param segmentIds A tensor whose shape is a prefix of `data.shape`.
-   * @param numSegments 
-   * @return a new instance of UnsortedSegmentMax
-   * @see org.tensorflow.op.math.UnsortedSegmentMax
+   * @param x 
+   * @param y 
+   * @return a new instance of GreaterEqual
+   * @see org.tensorflow.op.math.GreaterEqual
    */
-  public <T extends TNumber, U extends TNumber, V extends TNumber> UnsortedSegmentMax<T> unsortedSegmentMax(
-      Operand<T> data, Operand<U> segmentIds, Operand<V> numSegments) {
-    return UnsortedSegmentMax.create(scope, data, segmentIds, numSegments);
+  public <T extends TNumber> GreaterEqual greaterEqual(Operand<T> x, Operand<T> y) {
+    return GreaterEqual.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Igamma} operation
+   *
+   * @param a 
+   * @param x 
+   * @return a new instance of Igamma
+   * @see org.tensorflow.op.math.Igamma
+   */
+  public <T extends TNumber> Igamma<T> igamma(Operand<T> a, Operand<T> x) {
+    return Igamma.create(scope, a, x);
+  }
+
+  /**
+   * Builds an {@link Igammac} operation
+   *
+   * @param a 
+   * @param x 
+   * @return a new instance of Igammac
+   * @see org.tensorflow.op.math.Igammac
+   */
+  public <T extends TNumber> Igammac<T> igammac(Operand<T> a, Operand<T> x) {
+    return Igammac.create(scope, a, x);
+  }
+
+  /**
+   * Builds an {@link Imag} operation
+   *
+   * @param input 
+   * @return a new instance of Imag
+   * @see org.tensorflow.op.math.Imag
+   */
+  public <T extends TType> Imag<TFloat32> imag(Operand<T> input) {
+    return Imag.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Imag} operation
+   *
+   * @param input 
+   * @param Tout 
+   * @return a new instance of Imag
+   * @see org.tensorflow.op.math.Imag
+   */
+  public <U extends TNumber, T extends TType> Imag<U> imag(Operand<T> input, DataType<U> Tout) {
+    return Imag.create(scope, input, Tout);
   }
 
   /**
@@ -1112,130 +753,251 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link Abs} operation
+   * Builds an {@link IsInf} operation
    *
    * @param x 
-   * @return a new instance of Abs
-   * @see org.tensorflow.op.math.Abs
+   * @return a new instance of IsInf
+   * @see org.tensorflow.op.math.IsInf
    */
-  public <T extends TNumber> Abs<T> abs(Operand<T> x) {
-    return Abs.create(scope, x);
+  public <T extends TNumber> IsInf isInf(Operand<T> x) {
+    return IsInf.create(scope, x);
   }
 
   /**
-   * Builds an {@link TruncateMod} operation
+   * Builds an {@link IsNan} operation
    *
    * @param x 
-   * @param y 
-   * @return a new instance of TruncateMod
-   * @see org.tensorflow.op.math.TruncateMod
+   * @return a new instance of IsNan
+   * @see org.tensorflow.op.math.IsNan
    */
-  public <T extends TNumber> TruncateMod<T> truncateMod(Operand<T> x, Operand<T> y) {
-    return TruncateMod.create(scope, x, y);
+  public <T extends TNumber> IsNan isNan(Operand<T> x) {
+    return IsNan.create(scope, x);
   }
 
   /**
-   * Builds an {@link SegmentProd} operation
-   *
-   * @param data 
-   * @param segmentIds A 1-D tensor whose size is equal to the size of `data`'s
-   * @return a new instance of SegmentProd
-   * @see org.tensorflow.op.math.SegmentProd
-   */
-  public <T extends TType, U extends TNumber> SegmentProd<T> segmentProd(Operand<T> data,
-      Operand<U> segmentIds) {
-    return SegmentProd.create(scope, data, segmentIds);
-  }
-
-  /**
-   * Builds an {@link Angle} operation
-   *
-   * @param input 
-   * @return a new instance of Angle
-   * @see org.tensorflow.op.math.Angle
-   */
-  public <T extends TType> Angle<TFloat32> angle(Operand<T> input) {
-    return Angle.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link AddN} operation
-   *
-   * @param inputs 
-   * @return a new instance of AddN
-   * @see org.tensorflow.op.math.AddN
-   */
-  public <T extends TType> AddN<T> addN(Iterable<Operand<T>> inputs) {
-    return AddN.create(scope, inputs);
-  }
-
-  /**
-   * Builds an {@link RealDiv} operation
+   * Builds an {@link Less} operation
    *
    * @param x 
    * @param y 
-   * @return a new instance of RealDiv
-   * @see org.tensorflow.op.math.RealDiv
+   * @return a new instance of Less
+   * @see org.tensorflow.op.math.Less
    */
-  public <T extends TType> RealDiv<T> realDiv(Operand<T> x, Operand<T> y) {
-    return RealDiv.create(scope, x, y);
+  public <T extends TNumber> Less less(Operand<T> x, Operand<T> y) {
+    return Less.create(scope, x, y);
   }
 
   /**
-   * Builds an {@link Sinh} operation
+   * Builds an {@link LessEqual} operation
    *
    * @param x 
-   * @return a new instance of Sinh
-   * @see org.tensorflow.op.math.Sinh
+   * @param y 
+   * @return a new instance of LessEqual
+   * @see org.tensorflow.op.math.LessEqual
    */
-  public <T extends TType> Sinh<T> sinh(Operand<T> x) {
-    return Sinh.create(scope, x);
+  public <T extends TNumber> LessEqual lessEqual(Operand<T> x, Operand<T> y) {
+    return LessEqual.create(scope, x, y);
   }
 
   /**
-   * Builds an {@link ComplexAbs} operation
+   * Builds an {@link Lgamma} operation
    *
    * @param x 
-   * @return a new instance of ComplexAbs
-   * @see org.tensorflow.op.math.ComplexAbs
+   * @return a new instance of Lgamma
+   * @see org.tensorflow.op.math.Lgamma
    */
-  public <T extends TType> ComplexAbs<TFloat32> complexAbs(Operand<T> x) {
-    return ComplexAbs.create(scope, x);
+  public <T extends TNumber> Lgamma<T> lgamma(Operand<T> x) {
+    return Lgamma.create(scope, x);
   }
 
   /**
-   * Builds an {@link Acosh} operation
+   * Builds an {@link Log} operation
    *
    * @param x 
-   * @return a new instance of Acosh
-   * @see org.tensorflow.op.math.Acosh
+   * @return a new instance of Log
+   * @see org.tensorflow.op.math.Log
    */
-  public <T extends TType> Acosh<T> acosh(Operand<T> x) {
-    return Acosh.create(scope, x);
+  public <T extends TType> Log<T> log(Operand<T> x) {
+    return Log.create(scope, x);
   }
 
   /**
-   * Builds an {@link Floor} operation
+   * Builds an {@link Log1p} operation
    *
    * @param x 
-   * @return a new instance of Floor
-   * @see org.tensorflow.op.math.Floor
+   * @return a new instance of Log1p
+   * @see org.tensorflow.op.math.Log1p
    */
-  public <T extends TNumber> Floor<T> floor(Operand<T> x) {
-    return Floor.create(scope, x);
+  public <T extends TType> Log1p<T> log1p(Operand<T> x) {
+    return Log1p.create(scope, x);
   }
 
   /**
-   * Builds an {@link SegmentMin} operation
+   * Builds an {@link LogicalAnd} operation
    *
-   * @param data 
-   * @param segmentIds A 1-D tensor whose size is equal to the size of `data`'s
-   * @return a new instance of SegmentMin
-   * @see org.tensorflow.op.math.SegmentMin
+   * @param x 
+   * @param y 
+   * @return a new instance of LogicalAnd
+   * @see org.tensorflow.op.math.LogicalAnd
    */
-  public <T extends TNumber, U extends TNumber> SegmentMin<T> segmentMin(Operand<T> data,
-      Operand<U> segmentIds) {
-    return SegmentMin.create(scope, data, segmentIds);
+  public LogicalAnd logicalAnd(Operand<TBool> x, Operand<TBool> y) {
+    return LogicalAnd.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link LogicalNot} operation
+   *
+   * @param x 
+   * @return a new instance of LogicalNot
+   * @see org.tensorflow.op.math.LogicalNot
+   */
+  public LogicalNot logicalNot(Operand<TBool> x) {
+    return LogicalNot.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link LogicalOr} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of LogicalOr
+   * @see org.tensorflow.op.math.LogicalOr
+   */
+  public LogicalOr logicalOr(Operand<TBool> x, Operand<TBool> y) {
+    return LogicalOr.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Maximum} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of Maximum
+   * @see org.tensorflow.op.math.Maximum
+   */
+  public <T extends TNumber> Maximum<T> maximum(Operand<T> x, Operand<T> y) {
+    return Maximum.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Mean} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of Mean
+   * @see org.tensorflow.op.math.Mean
+   */
+  public <T extends TType, U extends TNumber> Mean<T> mean(Operand<T> input, Operand<U> axis,
+      Mean.Options... options) {
+    return Mean.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link Minimum} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of Minimum
+   * @see org.tensorflow.op.math.Minimum
+   */
+  public <T extends TNumber> Minimum<T> minimum(Operand<T> x, Operand<T> y) {
+    return Minimum.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Mod} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of Mod
+   * @see org.tensorflow.op.math.Mod
+   */
+  public <T extends TNumber> Mod<T> mod(Operand<T> x, Operand<T> y) {
+    return Mod.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Mul} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of Mul
+   * @see org.tensorflow.op.math.Mul
+   */
+  public <T extends TType> Mul<T> mul(Operand<T> x, Operand<T> y) {
+    return Mul.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link MulNoNan} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of MulNoNan
+   * @see org.tensorflow.op.math.MulNoNan
+   */
+  public <T extends TType> MulNoNan<T> mulNoNan(Operand<T> x, Operand<T> y) {
+    return MulNoNan.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Ndtri} operation
+   *
+   * @param x 
+   * @return a new instance of Ndtri
+   * @see org.tensorflow.op.math.Ndtri
+   */
+  public <T extends TNumber> Ndtri<T> ndtri(Operand<T> x) {
+    return Ndtri.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Neg} operation
+   *
+   * @param x 
+   * @return a new instance of Neg
+   * @see org.tensorflow.op.math.Neg
+   */
+  public <T extends TType> Neg<T> neg(Operand<T> x) {
+    return Neg.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link NextAfter} operation
+   *
+   * @param x1 
+   * @param x2 
+   * @return a new instance of NextAfter
+   * @see org.tensorflow.op.math.NextAfter
+   */
+  public <T extends TNumber> NextAfter<T> nextAfter(Operand<T> x1, Operand<T> x2) {
+    return NextAfter.create(scope, x1, x2);
+  }
+
+  /**
+   * Builds an {@link NotEqual} operation
+   *
+   * @param x 
+   * @param y 
+   * @param options carries optional attributes values
+   * @return a new instance of NotEqual
+   * @see org.tensorflow.op.math.NotEqual
+   */
+  public <T extends TType> NotEqual notEqual(Operand<T> x, Operand<T> y,
+      NotEqual.Options... options) {
+    return NotEqual.create(scope, x, y, options);
+  }
+
+  /**
+   * Builds an {@link Polygamma} operation
+   *
+   * @param a 
+   * @param x 
+   * @return a new instance of Polygamma
+   * @see org.tensorflow.op.math.Polygamma
+   */
+  public <T extends TNumber> Polygamma<T> polygamma(Operand<T> a, Operand<T> x) {
+    return Polygamma.create(scope, a, x);
   }
 
   /**
@@ -1250,36 +1012,34 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link Softplus} operation
+   * Builds an {@link Pow} operation
    *
-   * @param features 
-   * @return a new instance of Softplus
-   * @see org.tensorflow.op.math.Softplus
+   * @param x 
+   * @param y 
+   * @return a new instance of Pow
+   * @see org.tensorflow.op.math.Pow
    */
-  public <T extends TNumber> Softplus<T> softplus(Operand<T> features) {
-    return Softplus.create(scope, features);
+  public <T extends TType> Pow<T> pow(Operand<T> x, Operand<T> y) {
+    return Pow.create(scope, x, y);
   }
 
   /**
-   * Builds an {@link Asinh} operation
+   * Builds an {@link QuantizedAdd} operation
    *
    * @param x 
-   * @return a new instance of Asinh
-   * @see org.tensorflow.op.math.Asinh
+   * @param y 
+   * @param minX The float value that the lowest quantized `x` value represents.
+   * @param maxX The float value that the highest quantized `x` value represents.
+   * @param minY The float value that the lowest quantized `y` value represents.
+   * @param maxY The float value that the highest quantized `y` value represents.
+   * @param Toutput 
+   * @return a new instance of QuantizedAdd
+   * @see org.tensorflow.op.math.QuantizedAdd
    */
-  public <T extends TType> Asinh<T> asinh(Operand<T> x) {
-    return Asinh.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link Sin} operation
-   *
-   * @param x 
-   * @return a new instance of Sin
-   * @see org.tensorflow.op.math.Sin
-   */
-  public <T extends TType> Sin<T> sin(Operand<T> x) {
-    return Sin.create(scope, x);
+  public <V extends TType, T extends TType, U extends TType> QuantizedAdd<V> quantizedAdd(
+      Operand<T> x, Operand<U> y, Operand<TFloat32> minX, Operand<TFloat32> maxX,
+      Operand<TFloat32> minY, Operand<TFloat32> maxY, DataType<V> Toutput) {
+    return QuantizedAdd.create(scope, x, y, minX, maxX, minY, maxY, Toutput);
   }
 
   /**
@@ -1302,24 +1062,134 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link Erfc} operation
+   * Builds an {@link Real} operation
    *
-   * @param x 
-   * @return a new instance of Erfc
-   * @see org.tensorflow.op.math.Erfc
+   * @param input 
+   * @return a new instance of Real
+   * @see org.tensorflow.op.math.Real
    */
-  public <T extends TNumber> Erfc<T> erfc(Operand<T> x) {
-    return Erfc.create(scope, x);
+  public <T extends TType> Real<TFloat32> real(Operand<T> input) {
+    return Real.create(scope, input);
   }
 
   /**
-   * Builds an {@link Fact} operation
+   * Builds an {@link Real} operation
    *
-   * @return a new instance of Fact
-   * @see org.tensorflow.op.math.Fact
+   * @param input 
+   * @param Tout 
+   * @return a new instance of Real
+   * @see org.tensorflow.op.math.Real
    */
-  public Fact fact() {
-    return Fact.create(scope);
+  public <U extends TNumber, T extends TType> Real<U> real(Operand<T> input, DataType<U> Tout) {
+    return Real.create(scope, input, Tout);
+  }
+
+  /**
+   * Builds an {@link RealDiv} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of RealDiv
+   * @see org.tensorflow.op.math.RealDiv
+   */
+  public <T extends TType> RealDiv<T> realDiv(Operand<T> x, Operand<T> y) {
+    return RealDiv.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Reciprocal} operation
+   *
+   * @param x 
+   * @return a new instance of Reciprocal
+   * @see org.tensorflow.op.math.Reciprocal
+   */
+  public <T extends TType> Reciprocal<T> reciprocal(Operand<T> x) {
+    return Reciprocal.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Rint} operation
+   *
+   * @param x 
+   * @return a new instance of Rint
+   * @see org.tensorflow.op.math.Rint
+   */
+  public <T extends TNumber> Rint<T> rint(Operand<T> x) {
+    return Rint.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Round} operation
+   *
+   * @param x 
+   * @return a new instance of Round
+   * @see org.tensorflow.op.math.Round
+   */
+  public <T extends TType> Round<T> round(Operand<T> x) {
+    return Round.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Rsqrt} operation
+   *
+   * @param x 
+   * @return a new instance of Rsqrt
+   * @see org.tensorflow.op.math.Rsqrt
+   */
+  public <T extends TType> Rsqrt<T> rsqrt(Operand<T> x) {
+    return Rsqrt.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link SegmentMax} operation
+   *
+   * @param data 
+   * @param segmentIds A 1-D tensor whose size is equal to the size of `data`'s
+   * @return a new instance of SegmentMax
+   * @see org.tensorflow.op.math.SegmentMax
+   */
+  public <T extends TNumber, U extends TNumber> SegmentMax<T> segmentMax(Operand<T> data,
+      Operand<U> segmentIds) {
+    return SegmentMax.create(scope, data, segmentIds);
+  }
+
+  /**
+   * Builds an {@link SegmentMean} operation
+   *
+   * @param data 
+   * @param segmentIds A 1-D tensor whose size is equal to the size of `data`'s
+   * @return a new instance of SegmentMean
+   * @see org.tensorflow.op.math.SegmentMean
+   */
+  public <T extends TType, U extends TNumber> SegmentMean<T> segmentMean(Operand<T> data,
+      Operand<U> segmentIds) {
+    return SegmentMean.create(scope, data, segmentIds);
+  }
+
+  /**
+   * Builds an {@link SegmentMin} operation
+   *
+   * @param data 
+   * @param segmentIds A 1-D tensor whose size is equal to the size of `data`'s
+   * @return a new instance of SegmentMin
+   * @see org.tensorflow.op.math.SegmentMin
+   */
+  public <T extends TNumber, U extends TNumber> SegmentMin<T> segmentMin(Operand<T> data,
+      Operand<U> segmentIds) {
+    return SegmentMin.create(scope, data, segmentIds);
+  }
+
+  /**
+   * Builds an {@link SegmentProd} operation
+   *
+   * @param data 
+   * @param segmentIds A 1-D tensor whose size is equal to the size of `data`'s
+   * @return a new instance of SegmentProd
+   * @see org.tensorflow.op.math.SegmentProd
+   */
+  public <T extends TType, U extends TNumber> SegmentProd<T> segmentProd(Operand<T> data,
+      Operand<U> segmentIds) {
+    return SegmentProd.create(scope, data, segmentIds);
   }
 
   /**
@@ -1347,15 +1217,93 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link Xdivy} operation
+   * Builds an {@link Sign} operation
+   *
+   * @param x 
+   * @return a new instance of Sign
+   * @see org.tensorflow.op.math.Sign
+   */
+  public <T extends TType> Sign<T> sign(Operand<T> x) {
+    return Sign.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Sin} operation
+   *
+   * @param x 
+   * @return a new instance of Sin
+   * @see org.tensorflow.op.math.Sin
+   */
+  public <T extends TType> Sin<T> sin(Operand<T> x) {
+    return Sin.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Sinh} operation
+   *
+   * @param x 
+   * @return a new instance of Sinh
+   * @see org.tensorflow.op.math.Sinh
+   */
+  public <T extends TType> Sinh<T> sinh(Operand<T> x) {
+    return Sinh.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Softplus} operation
+   *
+   * @param features 
+   * @return a new instance of Softplus
+   * @see org.tensorflow.op.math.Softplus
+   */
+  public <T extends TNumber> Softplus<T> softplus(Operand<T> features) {
+    return Softplus.create(scope, features);
+  }
+
+  /**
+   * Builds an {@link Sqrt} operation
+   *
+   * @param x 
+   * @return a new instance of Sqrt
+   * @see org.tensorflow.op.math.Sqrt
+   */
+  public <T extends TType> Sqrt<T> sqrt(Operand<T> x) {
+    return Sqrt.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link Square} operation
+   *
+   * @param x 
+   * @return a new instance of Square
+   * @see org.tensorflow.op.math.Square
+   */
+  public <T extends TType> Square<T> square(Operand<T> x) {
+    return Square.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link SquaredDifference} operation
    *
    * @param x 
    * @param y 
-   * @return a new instance of Xdivy
-   * @see org.tensorflow.op.math.Xdivy
+   * @return a new instance of SquaredDifference
+   * @see org.tensorflow.op.math.SquaredDifference
    */
-  public <T extends TType> Xdivy<T> xdivy(Operand<T> x, Operand<T> y) {
-    return Xdivy.create(scope, x, y);
+  public <T extends TType> SquaredDifference<T> squaredDifference(Operand<T> x, Operand<T> y) {
+    return SquaredDifference.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Sub} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of Sub
+   * @see org.tensorflow.op.math.Sub
+   */
+  public <T extends TType> Sub<T> sub(Operand<T> x, Operand<T> y) {
+    return Sub.create(scope, x, y);
   }
 
   /**
@@ -1370,41 +1318,118 @@ public final class MathOps {
   }
 
   /**
-   * Builds an {@link ArgMin} operation
+   * Builds an {@link Tanh} operation
    *
-   * @param input 
-   * @param dimension int32 or int64, must be in the range `[-rank(input), rank(input))`.
-   * @return a new instance of ArgMin
-   * @see org.tensorflow.op.math.ArgMin
+   * @param x 
+   * @return a new instance of Tanh
+   * @see org.tensorflow.op.math.Tanh
    */
-  public <T extends TType, U extends TNumber> ArgMin<TInt64> argMin(Operand<T> input,
-      Operand<U> dimension) {
-    return ArgMin.create(scope, input, dimension);
+  public <T extends TType> Tanh<T> tanh(Operand<T> x) {
+    return Tanh.create(scope, x);
   }
 
   /**
-   * Builds an {@link CompareAndBitpack} operation
-   *
-   * @param input Values to compare against `threshold` and bitpack.
-   * @param threshold Threshold to compare against.
-   * @return a new instance of CompareAndBitpack
-   * @see org.tensorflow.op.math.CompareAndBitpack
-   */
-  public <T extends TType> CompareAndBitpack compareAndBitpack(Operand<T> input,
-      Operand<T> threshold) {
-    return CompareAndBitpack.create(scope, input, threshold);
-  }
-
-  /**
-   * Builds an {@link GreaterEqual} operation
+   * Builds an {@link TruncateDiv} operation
    *
    * @param x 
    * @param y 
-   * @return a new instance of GreaterEqual
-   * @see org.tensorflow.op.math.GreaterEqual
+   * @return a new instance of TruncateDiv
+   * @see org.tensorflow.op.math.TruncateDiv
    */
-  public <T extends TNumber> GreaterEqual greaterEqual(Operand<T> x, Operand<T> y) {
-    return GreaterEqual.create(scope, x, y);
+  public <T extends TType> TruncateDiv<T> truncateDiv(Operand<T> x, Operand<T> y) {
+    return TruncateDiv.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link TruncateMod} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of TruncateMod
+   * @see org.tensorflow.op.math.TruncateMod
+   */
+  public <T extends TNumber> TruncateMod<T> truncateMod(Operand<T> x, Operand<T> y) {
+    return TruncateMod.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link UnsortedSegmentMax} operation
+   *
+   * @param data 
+   * @param segmentIds A tensor whose shape is a prefix of `data.shape`.
+   * @param numSegments 
+   * @return a new instance of UnsortedSegmentMax
+   * @see org.tensorflow.op.math.UnsortedSegmentMax
+   */
+  public <T extends TNumber, U extends TNumber, V extends TNumber> UnsortedSegmentMax<T> unsortedSegmentMax(
+      Operand<T> data, Operand<U> segmentIds, Operand<V> numSegments) {
+    return UnsortedSegmentMax.create(scope, data, segmentIds, numSegments);
+  }
+
+  /**
+   * Builds an {@link UnsortedSegmentMin} operation
+   *
+   * @param data 
+   * @param segmentIds A tensor whose shape is a prefix of `data.shape`.
+   * @param numSegments 
+   * @return a new instance of UnsortedSegmentMin
+   * @see org.tensorflow.op.math.UnsortedSegmentMin
+   */
+  public <T extends TNumber, U extends TNumber, V extends TNumber> UnsortedSegmentMin<T> unsortedSegmentMin(
+      Operand<T> data, Operand<U> segmentIds, Operand<V> numSegments) {
+    return UnsortedSegmentMin.create(scope, data, segmentIds, numSegments);
+  }
+
+  /**
+   * Builds an {@link UnsortedSegmentProd} operation
+   *
+   * @param data 
+   * @param segmentIds A tensor whose shape is a prefix of `data.shape`.
+   * @param numSegments 
+   * @return a new instance of UnsortedSegmentProd
+   * @see org.tensorflow.op.math.UnsortedSegmentProd
+   */
+  public <T extends TType, U extends TNumber, V extends TNumber> UnsortedSegmentProd<T> unsortedSegmentProd(
+      Operand<T> data, Operand<U> segmentIds, Operand<V> numSegments) {
+    return UnsortedSegmentProd.create(scope, data, segmentIds, numSegments);
+  }
+
+  /**
+   * Builds an {@link UnsortedSegmentSum} operation
+   *
+   * @param data 
+   * @param segmentIds A tensor whose shape is a prefix of `data.shape`.
+   * @param numSegments 
+   * @return a new instance of UnsortedSegmentSum
+   * @see org.tensorflow.op.math.UnsortedSegmentSum
+   */
+  public <T extends TType, U extends TNumber, V extends TNumber> UnsortedSegmentSum<T> unsortedSegmentSum(
+      Operand<T> data, Operand<U> segmentIds, Operand<V> numSegments) {
+    return UnsortedSegmentSum.create(scope, data, segmentIds, numSegments);
+  }
+
+  /**
+   * Builds an {@link Xdivy} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of Xdivy
+   * @see org.tensorflow.op.math.Xdivy
+   */
+  public <T extends TType> Xdivy<T> xdivy(Operand<T> x, Operand<T> y) {
+    return Xdivy.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link Xlogy} operation
+   *
+   * @param x 
+   * @param y 
+   * @return a new instance of Xlogy
+   * @see org.tensorflow.op.math.Xlogy
+   */
+  public <T extends TType> Xlogy<T> xlogy(Operand<T> x, Operand<T> y) {
+    return Xlogy.create(scope, x, y);
   }
 
   /**
@@ -1417,30 +1442,5 @@ public final class MathOps {
    */
   public <T extends TNumber> Zeta<T> zeta(Operand<T> x, Operand<T> q) {
     return Zeta.create(scope, x, q);
-  }
-
-  /**
-   * Builds an {@link ComplexAbs} operation
-   *
-   * @param x 
-   * @param Tout 
-   * @return a new instance of ComplexAbs
-   * @see org.tensorflow.op.math.ComplexAbs
-   */
-  public <U extends TNumber, T extends TType> ComplexAbs<U> complexAbs(Operand<T> x,
-      DataType<U> Tout) {
-    return ComplexAbs.create(scope, x, Tout);
-  }
-
-  /**
-   * Builds an {@link Imag} operation
-   *
-   * @param input 
-   * @param Tout 
-   * @return a new instance of Imag
-   * @see org.tensorflow.op.math.Imag
-   */
-  public <U extends TNumber, T extends TType> Imag<U> imag(Operand<T> input, DataType<U> Tout) {
-    return Imag.create(scope, input, Tout);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnOps.java
@@ -92,80 +92,6 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link MaxPool} operation
-   *
-   * @param input 4-D input to pool over.
-   * @param ksize The size of the window for each dimension of the input tensor.
-   * @param strides The stride of the sliding window for each dimension of the
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of MaxPool
-   * @see org.tensorflow.op.nn.MaxPool
-   */
-  public <T extends TType> MaxPool<T> maxPool(Operand<T> input, Operand<TInt32> ksize,
-      Operand<TInt32> strides, String padding, MaxPool.Options... options) {
-    return MaxPool.create(scope, input, ksize, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link DataFormatVecPermute} operation
-   *
-   * @param x Vector of size 4 or Tensor of shape (4, 2) in source data format.
-   * @param options carries optional attributes values
-   * @return a new instance of DataFormatVecPermute
-   * @see org.tensorflow.op.nn.DataFormatVecPermute
-   */
-  public <T extends TNumber> DataFormatVecPermute<T> dataFormatVecPermute(Operand<T> x,
-      DataFormatVecPermute.Options... options) {
-    return DataFormatVecPermute.create(scope, x, options);
-  }
-
-  /**
-   * Builds an {@link DepthwiseConv2dNative} operation
-   *
-   * @param input 
-   * @param filter 
-   * @param strides 1-D of length 4.  The stride of the sliding window for each dimension
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of DepthwiseConv2dNative
-   * @see org.tensorflow.op.nn.DepthwiseConv2dNative
-   */
-  public <T extends TNumber> DepthwiseConv2dNative<T> depthwiseConv2dNative(Operand<T> input,
-      Operand<T> filter, List<Long> strides, String padding,
-      DepthwiseConv2dNative.Options... options) {
-    return DepthwiseConv2dNative.create(scope, input, filter, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link SpaceToBatch} operation
-   *
-   * @param input 4-D with shape `[batch, height, width, depth]`.
-   * @param paddings 2-D tensor of non-negative integers with shape `[2, 2]`. It specifies
-   * @param blockSize 
-   * @return a new instance of SpaceToBatch
-   * @see org.tensorflow.op.nn.SpaceToBatch
-   */
-  public <T extends TType, U extends TNumber> SpaceToBatch<T> spaceToBatch(Operand<T> input,
-      Operand<U> paddings, Long blockSize) {
-    return SpaceToBatch.create(scope, input, paddings, blockSize);
-  }
-
-  /**
-   * Builds an {@link DepthToSpace} operation
-   *
-   * @param input 
-   * @param blockSize The size of the spatial block, same as in Space2Depth.
-   * @param options carries optional attributes values
-   * @return a new instance of DepthToSpace
-   * @see org.tensorflow.op.nn.DepthToSpace
-   */
-  public <T extends TType> DepthToSpace<T> depthToSpace(Operand<T> input, Long blockSize,
-      DepthToSpace.Options... options) {
-    return DepthToSpace.create(scope, input, blockSize, options);
-  }
-
-  /**
    * Builds an {@link AvgPool} operation
    *
    * @param value 4-D with shape `[batch, height, width, channels]`.
@@ -182,121 +108,56 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link MaxPoolWithArgmax} operation
+   * Builds an {@link AvgPool3d} operation
    *
-   * @param input 4-D with shape `[batch, height, width, channels]`.  Input to pool over.
-   * @param ksize The size of the window for each dimension of the input tensor.
-   * @param strides The stride of the sliding window for each dimension of the
+   * @param input Shape `[batch, depth, rows, cols, channels]` tensor to pool over.
+   * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
+   * @param strides 1-D tensor of length 5. The stride of the sliding window for each
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attributes values
-   * @return a new instance of MaxPoolWithArgmax
-   * @see org.tensorflow.op.nn.MaxPoolWithArgmax
+   * @return a new instance of AvgPool3d
+   * @see org.tensorflow.op.nn.AvgPool3d
    */
-  public <T extends TNumber> MaxPoolWithArgmax<T, TInt64> maxPoolWithArgmax(Operand<T> input,
-      List<Long> ksize, List<Long> strides, String padding, MaxPoolWithArgmax.Options... options) {
-    return MaxPoolWithArgmax.create(scope, input, ksize, strides, padding, options);
+  public <T extends TNumber> AvgPool3d<T> avgPool3d(Operand<T> input, List<Long> ksize,
+      List<Long> strides, String padding, AvgPool3d.Options... options) {
+    return AvgPool3d.create(scope, input, ksize, strides, padding, options);
   }
 
   /**
-   * Builds an {@link CtcGreedyDecoder} operation
+   * Builds an {@link AvgPool3dGrad} operation
    *
-   * @param inputs 3-D, shape: `(max_time x batch_size x num_classes)`, the logits.
-   * @param sequenceLength A vector containing sequence lengths, size `(batch_size)`.
-   * @param options carries optional attributes values
-   * @return a new instance of CtcGreedyDecoder
-   * @see org.tensorflow.op.nn.CtcGreedyDecoder
-   */
-  public <T extends TNumber> CtcGreedyDecoder<T> ctcGreedyDecoder(Operand<T> inputs,
-      Operand<TInt32> sequenceLength, CtcGreedyDecoder.Options... options) {
-    return CtcGreedyDecoder.create(scope, inputs, sequenceLength, options);
-  }
-
-  /**
-   * Builds an {@link SpaceToDepth} operation
-   *
-   * @param input 
-   * @param blockSize The size of the spatial block.
-   * @param options carries optional attributes values
-   * @return a new instance of SpaceToDepth
-   * @see org.tensorflow.op.nn.SpaceToDepth
-   */
-  public <T extends TType> SpaceToDepth<T> spaceToDepth(Operand<T> input, Long blockSize,
-      SpaceToDepth.Options... options) {
-    return SpaceToDepth.create(scope, input, blockSize, options);
-  }
-
-  /**
-   * Builds an {@link ComputeAccidentalHits} operation
-   *
-   * @param trueClasses The true_classes output of UnpackSparseLabels.
-   * @param sampledCandidates The sampled_candidates output of CandidateSampler.
-   * @param numTrue Number of true labels per context.
-   * @param options carries optional attributes values
-   * @return a new instance of ComputeAccidentalHits
-   * @see org.tensorflow.op.nn.ComputeAccidentalHits
-   */
-  public ComputeAccidentalHits computeAccidentalHits(Operand<TInt64> trueClasses,
-      Operand<TInt64> sampledCandidates, Long numTrue, ComputeAccidentalHits.Options... options) {
-    return ComputeAccidentalHits.create(scope, trueClasses, sampledCandidates, numTrue, options);
-  }
-
-  /**
-   * Builds an {@link Conv2dBackpropInput} operation
-   *
-   * @param inputSizes An integer vector representing the shape of `input`,
-   * @param filter 4-D with shape
-   * @param outBackprop 4-D with shape `[batch, out_height, out_width, out_channels]`.
-   * @param strides The stride of the sliding window for each dimension of the input
+   * @param origInputShape The original input dimensions.
+   * @param grad Output backprop of shape `[batch, depth, rows, cols, channels]`.
+   * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
+   * @param strides 1-D tensor of length 5. The stride of the sliding window for each
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attributes values
-   * @return a new instance of Conv2dBackpropInput
-   * @see org.tensorflow.op.nn.Conv2dBackpropInput
+   * @return a new instance of AvgPool3dGrad
+   * @see org.tensorflow.op.nn.AvgPool3dGrad
    */
-  public <T extends TNumber> Conv2dBackpropInput<T> conv2dBackpropInput(Operand<TInt32> inputSizes,
-      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, String padding,
-      Conv2dBackpropInput.Options... options) {
-    return Conv2dBackpropInput.create(scope, inputSizes, filter, outBackprop, strides, padding, options);
+  public <T extends TNumber> AvgPool3dGrad<T> avgPool3dGrad(Operand<TInt32> origInputShape,
+      Operand<T> grad, List<Long> ksize, List<Long> strides, String padding,
+      AvgPool3dGrad.Options... options) {
+    return AvgPool3dGrad.create(scope, origInputShape, grad, ksize, strides, padding, options);
   }
 
   /**
-   * Builds an {@link FractionalAvgPool} operation
+   * Builds an {@link BatchNormWithGlobalNormalization} operation
    *
-   * @param value 4-D with shape `[batch, height, width, channels]`.
-   * @param poolingRatio Pooling ratio for each dimension of `value`, currently only
-   * @param options carries optional attributes values
-   * @return a new instance of FractionalAvgPool
-   * @see org.tensorflow.op.nn.FractionalAvgPool
+   * @param t A 4D input Tensor.
+   * @param m A 1D mean Tensor with size matching the last dimension of t.
+   * @param v A 1D variance Tensor with size matching the last dimension of t.
+   * @param beta A 1D beta Tensor with size matching the last dimension of t.
+   * @param gamma A 1D gamma Tensor with size matching the last dimension of t.
+   * @param varianceEpsilon A small float number to avoid dividing by 0.
+   * @param scaleAfterNormalization A bool indicating whether the resulted tensor
+   * @return a new instance of BatchNormWithGlobalNormalization
+   * @see org.tensorflow.op.nn.BatchNormWithGlobalNormalization
    */
-  public <T extends TNumber> FractionalAvgPool<T> fractionalAvgPool(Operand<T> value,
-      List<Float> poolingRatio, FractionalAvgPool.Options... options) {
-    return FractionalAvgPool.create(scope, value, poolingRatio, options);
-  }
-
-  /**
-   * Builds an {@link SparseSoftmaxCrossEntropyWithLogits} operation
-   *
-   * @param features batch_size x num_classes matrix
-   * @param labels batch_size vector with values in [0, num_classes).
-   * @return a new instance of SparseSoftmaxCrossEntropyWithLogits
-   * @see org.tensorflow.op.nn.SparseSoftmaxCrossEntropyWithLogits
-   */
-  public <T extends TNumber, U extends TNumber> SparseSoftmaxCrossEntropyWithLogits<T> sparseSoftmaxCrossEntropyWithLogits(
-      Operand<T> features, Operand<U> labels) {
-    return SparseSoftmaxCrossEntropyWithLogits.create(scope, features, labels);
-  }
-
-  /**
-   * Builds an {@link NthElement} operation
-   *
-   * @param input 1-D or higher with last dimension at least `n+1`.
-   * @param n 0-D. Position of sorted vector to select along the last dimension (along
-   * @param options carries optional attributes values
-   * @return a new instance of NthElement
-   * @see org.tensorflow.op.nn.NthElement
-   */
-  public <T extends TNumber> NthElement<T> nthElement(Operand<T> input, Operand<TInt32> n,
-      NthElement.Options... options) {
-    return NthElement.create(scope, input, n, options);
+  public <T extends TType> BatchNormWithGlobalNormalization<T> batchNormWithGlobalNormalization(
+      Operand<T> t, Operand<T> m, Operand<T> v, Operand<T> beta, Operand<T> gamma,
+      Float varianceEpsilon, Boolean scaleAfterNormalization) {
+    return BatchNormWithGlobalNormalization.create(scope, t, m, v, beta, gamma, varianceEpsilon, scaleAfterNormalization);
   }
 
   /**
@@ -319,32 +180,97 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link MaxPoolWithArgmax} operation
+   * Builds an {@link BiasAdd} operation
    *
-   * @param input 4-D with shape `[batch, height, width, channels]`.  Input to pool over.
-   * @param ksize The size of the window for each dimension of the input tensor.
-   * @param strides The stride of the sliding window for each dimension of the
-   * @param Targmax 
-   * @param padding The type of padding algorithm to use.
+   * @param value Any number of dimensions.
+   * @param bias 1-D with size the last dimension of `value`.
    * @param options carries optional attributes values
-   * @return a new instance of MaxPoolWithArgmax
-   * @see org.tensorflow.op.nn.MaxPoolWithArgmax
+   * @return a new instance of BiasAdd
+   * @see org.tensorflow.op.nn.BiasAdd
    */
-  public <T extends TNumber, U extends TNumber> MaxPoolWithArgmax<T, U> maxPoolWithArgmax(
-      Operand<T> input, List<Long> ksize, List<Long> strides, DataType<U> Targmax, String padding,
-      MaxPoolWithArgmax.Options... options) {
-    return MaxPoolWithArgmax.create(scope, input, ksize, strides, Targmax, padding, options);
+  public <T extends TType> BiasAdd<T> biasAdd(Operand<T> value, Operand<T> bias,
+      BiasAdd.Options... options) {
+    return BiasAdd.create(scope, value, bias, options);
   }
 
   /**
-   * Builds an {@link L2Loss} operation
+   * Builds an {@link BiasAddGrad} operation
    *
-   * @param t Typically 2-D, but may have any dimensions.
-   * @return a new instance of L2Loss
-   * @see org.tensorflow.op.nn.L2Loss
+   * @param outBackprop Any number of dimensions.
+   * @param options carries optional attributes values
+   * @return a new instance of BiasAddGrad
+   * @see org.tensorflow.op.nn.BiasAddGrad
    */
-  public <T extends TNumber> L2Loss<T> l2Loss(Operand<T> t) {
-    return L2Loss.create(scope, t);
+  public <T extends TType> BiasAddGrad<T> biasAddGrad(Operand<T> outBackprop,
+      BiasAddGrad.Options... options) {
+    return BiasAddGrad.create(scope, outBackprop, options);
+  }
+
+  /**
+   * Builds an {@link ComputeAccidentalHits} operation
+   *
+   * @param trueClasses The true_classes output of UnpackSparseLabels.
+   * @param sampledCandidates The sampled_candidates output of CandidateSampler.
+   * @param numTrue Number of true labels per context.
+   * @param options carries optional attributes values
+   * @return a new instance of ComputeAccidentalHits
+   * @see org.tensorflow.op.nn.ComputeAccidentalHits
+   */
+  public ComputeAccidentalHits computeAccidentalHits(Operand<TInt64> trueClasses,
+      Operand<TInt64> sampledCandidates, Long numTrue, ComputeAccidentalHits.Options... options) {
+    return ComputeAccidentalHits.create(scope, trueClasses, sampledCandidates, numTrue, options);
+  }
+
+  /**
+   * Builds an {@link Conv2d} operation
+   *
+   * @param input A 4-D tensor. The dimension order is interpreted according to the value
+   * @param filter A 4-D tensor of shape
+   * @param strides 1-D tensor of length 4.  The stride of the sliding window for each
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of Conv2d
+   * @see org.tensorflow.op.nn.Conv2d
+   */
+  public <T extends TNumber> Conv2d<T> conv2d(Operand<T> input, Operand<T> filter,
+      List<Long> strides, String padding, Conv2d.Options... options) {
+    return Conv2d.create(scope, input, filter, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link Conv2dBackpropFilter} operation
+   *
+   * @param input 4-D with shape `[batch, in_height, in_width, in_channels]`.
+   * @param filterSizes An integer vector representing the tensor shape of `filter`,
+   * @param outBackprop 4-D with shape `[batch, out_height, out_width, out_channels]`.
+   * @param strides The stride of the sliding window for each dimension of the input
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of Conv2dBackpropFilter
+   * @see org.tensorflow.op.nn.Conv2dBackpropFilter
+   */
+  public <T extends TNumber> Conv2dBackpropFilter<T> conv2dBackpropFilter(Operand<T> input,
+      Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides, String padding,
+      Conv2dBackpropFilter.Options... options) {
+    return Conv2dBackpropFilter.create(scope, input, filterSizes, outBackprop, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link Conv2dBackpropInput} operation
+   *
+   * @param inputSizes An integer vector representing the shape of `input`,
+   * @param filter 4-D with shape
+   * @param outBackprop 4-D with shape `[batch, out_height, out_width, out_channels]`.
+   * @param strides The stride of the sliding window for each dimension of the input
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of Conv2dBackpropInput
+   * @see org.tensorflow.op.nn.Conv2dBackpropInput
+   */
+  public <T extends TNumber> Conv2dBackpropInput<T> conv2dBackpropInput(Operand<TInt32> inputSizes,
+      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, String padding,
+      Conv2dBackpropInput.Options... options) {
+    return Conv2dBackpropInput.create(scope, inputSizes, filter, outBackprop, strides, padding, options);
   }
 
   /**
@@ -364,144 +290,125 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link DepthwiseConv2dNativeBackpropFilter} operation
+   * Builds an {@link Conv3dBackpropFilter} operation
    *
-   * @param input 4-D with shape based on `data_format`.  For example, if
+   * @param input Shape `[batch, depth, rows, cols, in_channels]`.
    * @param filterSizes An integer vector representing the tensor shape of `filter`,
-   * @param outBackprop 4-D with shape  based on `data_format`.
-   * @param strides The stride of the sliding window for each dimension of the input
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of DepthwiseConv2dNativeBackpropFilter
-   * @see org.tensorflow.op.nn.DepthwiseConv2dNativeBackpropFilter
-   */
-  public <T extends TNumber> DepthwiseConv2dNativeBackpropFilter<T> depthwiseConv2dNativeBackpropFilter(
-      Operand<T> input, Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides,
-      String padding, DepthwiseConv2dNativeBackpropFilter.Options... options) {
-    return DepthwiseConv2dNativeBackpropFilter.create(scope, input, filterSizes, outBackprop, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link FusedBatchNorm} operation
-   *
-   * @param x A 4D Tensor for input data.
-   * @param scale A 1D Tensor for scaling factor, to scale the normalized x.
-   * @param offset A 1D Tensor for offset, to shift to the normalized x.
-   * @param mean A 1D Tensor for population mean. Used for inference only;
-   * @param variance A 1D Tensor for population variance. Used for inference only;
-   * @param options carries optional attributes values
-   * @return a new instance of FusedBatchNorm
-   * @see org.tensorflow.op.nn.FusedBatchNorm
-   */
-  public <T extends TNumber, U extends TNumber> FusedBatchNorm<T, U> fusedBatchNorm(Operand<T> x,
-      Operand<U> scale, Operand<U> offset, Operand<U> mean, Operand<U> variance,
-      FusedBatchNorm.Options... options) {
-    return FusedBatchNorm.create(scope, x, scale, offset, mean, variance, options);
-  }
-
-  /**
-   * Builds an {@link MaxPoolGrad} operation
-   *
-   * @param origInput The original input tensor.
-   * @param origOutput The original output tensor.
-   * @param grad 4-D.  Gradients w.r.t. the output of `max_pool`.
-   * @param ksize The size of the window for each dimension of the input tensor.
-   * @param strides The stride of the sliding window for each dimension of the
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of MaxPoolGrad
-   * @see org.tensorflow.op.nn.MaxPoolGrad
-   */
-  public <T extends TNumber> MaxPoolGrad<T> maxPoolGrad(Operand<T> origInput, Operand<T> origOutput,
-      Operand<T> grad, Operand<TInt32> ksize, Operand<TInt32> strides, String padding,
-      MaxPoolGrad.Options... options) {
-    return MaxPoolGrad.create(scope, origInput, origOutput, grad, ksize, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link MaxPool3dGradGrad} operation
-   *
-   * @param origInput The original input tensor.
-   * @param origOutput The original output tensor.
-   * @param grad Output backprop of shape `[batch, depth, rows, cols, channels]`.
-   * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
+   * @param outBackprop Backprop signal of shape `[batch, out_depth, out_rows, out_cols,
    * @param strides 1-D tensor of length 5. The stride of the sliding window for each
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attributes values
-   * @return a new instance of MaxPool3dGradGrad
-   * @see org.tensorflow.op.nn.MaxPool3dGradGrad
+   * @return a new instance of Conv3dBackpropFilter
+   * @see org.tensorflow.op.nn.Conv3dBackpropFilter
    */
-  public <T extends TNumber> MaxPool3dGradGrad<T> maxPool3dGradGrad(Operand<T> origInput,
-      Operand<T> origOutput, Operand<T> grad, List<Long> ksize, List<Long> strides, String padding,
-      MaxPool3dGradGrad.Options... options) {
-    return MaxPool3dGradGrad.create(scope, origInput, origOutput, grad, ksize, strides, padding, options);
+  public <T extends TNumber> Conv3dBackpropFilter<T> conv3dBackpropFilter(Operand<T> input,
+      Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides, String padding,
+      Conv3dBackpropFilter.Options... options) {
+    return Conv3dBackpropFilter.create(scope, input, filterSizes, outBackprop, strides, padding, options);
   }
 
   /**
-   * Builds an {@link MaxPoolGradGradWithArgmax} operation
+   * Builds an {@link Conv3dBackpropInput} operation
    *
-   * @param input The original input.
-   * @param grad 4-D with shape `[batch, height, width, channels]`.  Gradients w.r.t. the
-   * @param argmax The indices of the maximum values chosen for each output of `max_pool`.
-   * @param ksize The size of the window for each dimension of the input tensor.
-   * @param strides The stride of the sliding window for each dimension of the
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of MaxPoolGradGradWithArgmax
-   * @see org.tensorflow.op.nn.MaxPoolGradGradWithArgmax
-   */
-  public <T extends TNumber, U extends TNumber> MaxPoolGradGradWithArgmax<T> maxPoolGradGradWithArgmax(
-      Operand<T> input, Operand<T> grad, Operand<U> argmax, List<Long> ksize, List<Long> strides,
-      String padding, MaxPoolGradGradWithArgmax.Options... options) {
-    return MaxPoolGradGradWithArgmax.create(scope, input, grad, argmax, ksize, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link BiasAdd} operation
-   *
-   * @param value Any number of dimensions.
-   * @param bias 1-D with size the last dimension of `value`.
-   * @param options carries optional attributes values
-   * @return a new instance of BiasAdd
-   * @see org.tensorflow.op.nn.BiasAdd
-   */
-  public <T extends TType> BiasAdd<T> biasAdd(Operand<T> value, Operand<T> bias,
-      BiasAdd.Options... options) {
-    return BiasAdd.create(scope, value, bias, options);
-  }
-
-  /**
-   * Builds an {@link QuantizedRelu6} operation
-   *
-   * @param features 
-   * @param minFeatures The float value that the lowest quantized value represents.
-   * @param maxFeatures The float value that the highest quantized value represents.
-   * @param outType 
-   * @return a new instance of QuantizedRelu6
-   * @see org.tensorflow.op.nn.QuantizedRelu6
-   */
-  public <U extends TType, T extends TType> QuantizedRelu6<U> quantizedRelu6(Operand<T> features,
-      Operand<TFloat32> minFeatures, Operand<TFloat32> maxFeatures, DataType<U> outType) {
-    return QuantizedRelu6.create(scope, features, minFeatures, maxFeatures, outType);
-  }
-
-  /**
-   * Builds an {@link MaxPool3dGrad} operation
-   *
-   * @param origInput The original input tensor.
-   * @param origOutput The original output tensor.
-   * @param grad Output backprop of shape `[batch, depth, rows, cols, channels]`.
-   * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
+   * @param inputSizes An integer vector representing the tensor shape of `input`,
+   * @param filter Shape `[depth, rows, cols, in_channels, out_channels]`.
+   * @param outBackprop Backprop signal of shape `[batch, out_depth, out_rows, out_cols,
    * @param strides 1-D tensor of length 5. The stride of the sliding window for each
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attributes values
-   * @return a new instance of MaxPool3dGrad
-   * @see org.tensorflow.op.nn.MaxPool3dGrad
+   * @return a new instance of Conv3dBackpropInput
+   * @see org.tensorflow.op.nn.Conv3dBackpropInput
    */
-  public <U extends TNumber, T extends TNumber> MaxPool3dGrad<U> maxPool3dGrad(Operand<T> origInput,
-      Operand<T> origOutput, Operand<U> grad, List<Long> ksize, List<Long> strides, String padding,
-      MaxPool3dGrad.Options... options) {
-    return MaxPool3dGrad.create(scope, origInput, origOutput, grad, ksize, strides, padding, options);
+  public <U extends TNumber, T extends TNumber> Conv3dBackpropInput<U> conv3dBackpropInput(
+      Operand<T> inputSizes, Operand<U> filter, Operand<U> outBackprop, List<Long> strides,
+      String padding, Conv3dBackpropInput.Options... options) {
+    return Conv3dBackpropInput.create(scope, inputSizes, filter, outBackprop, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link CtcBeamSearchDecoder} operation
+   *
+   * @param inputs 3-D, shape: `(max_time x batch_size x num_classes)`, the logits.
+   * @param sequenceLength A vector containing sequence lengths, size `(batch)`.
+   * @param beamWidth A scalar >= 0 (beam search beam width).
+   * @param topPaths A scalar >= 0, <= beam_width (controls output size).
+   * @param options carries optional attributes values
+   * @return a new instance of CtcBeamSearchDecoder
+   * @see org.tensorflow.op.nn.CtcBeamSearchDecoder
+   */
+  public <T extends TNumber> CtcBeamSearchDecoder<T> ctcBeamSearchDecoder(Operand<T> inputs,
+      Operand<TInt32> sequenceLength, Long beamWidth, Long topPaths,
+      CtcBeamSearchDecoder.Options... options) {
+    return CtcBeamSearchDecoder.create(scope, inputs, sequenceLength, beamWidth, topPaths, options);
+  }
+
+  /**
+   * Builds an {@link CtcGreedyDecoder} operation
+   *
+   * @param inputs 3-D, shape: `(max_time x batch_size x num_classes)`, the logits.
+   * @param sequenceLength A vector containing sequence lengths, size `(batch_size)`.
+   * @param options carries optional attributes values
+   * @return a new instance of CtcGreedyDecoder
+   * @see org.tensorflow.op.nn.CtcGreedyDecoder
+   */
+  public <T extends TNumber> CtcGreedyDecoder<T> ctcGreedyDecoder(Operand<T> inputs,
+      Operand<TInt32> sequenceLength, CtcGreedyDecoder.Options... options) {
+    return CtcGreedyDecoder.create(scope, inputs, sequenceLength, options);
+  }
+
+  /**
+   * Builds an {@link CtcLoss} operation
+   *
+   * @param inputs 3-D, shape: `(max_time x batch_size x num_classes)`, the logits.
+   * @param labelsIndices The indices of a `SparseTensor<int32, 2>`.
+   * @param labelsValues The values (labels) associated with the given batch and time.
+   * @param sequenceLength A vector containing sequence lengths (batch).
+   * @param options carries optional attributes values
+   * @return a new instance of CtcLoss
+   * @see org.tensorflow.op.nn.CtcLoss
+   */
+  public <T extends TNumber> CtcLoss<T> ctcLoss(Operand<T> inputs, Operand<TInt64> labelsIndices,
+      Operand<TInt32> labelsValues, Operand<TInt32> sequenceLength, CtcLoss.Options... options) {
+    return CtcLoss.create(scope, inputs, labelsIndices, labelsValues, sequenceLength, options);
+  }
+
+  /**
+   * Builds an {@link CudnnRNNCanonicalToParams} operation
+   *
+   * @param numLayers 
+   * @param numUnits 
+   * @param inputSize 
+   * @param weights 
+   * @param biases 
+   * @param options carries optional attributes values
+   * @return a new instance of CudnnRNNCanonicalToParams
+   * @see org.tensorflow.op.nn.CudnnRNNCanonicalToParams
+   */
+  public <T extends TNumber> CudnnRNNCanonicalToParams<T> cudnnRNNCanonicalToParams(
+      Operand<TInt32> numLayers, Operand<TInt32> numUnits, Operand<TInt32> inputSize,
+      Iterable<Operand<T>> weights, Iterable<Operand<T>> biases,
+      CudnnRNNCanonicalToParams.Options... options) {
+    return CudnnRNNCanonicalToParams.create(scope, numLayers, numUnits, inputSize, weights, biases, options);
+  }
+
+  /**
+   * Builds an {@link CudnnRNNParamsToCanonical} operation
+   *
+   * @param numLayers 
+   * @param numUnits 
+   * @param inputSize 
+   * @param params 
+   * @param numParamsWeights 
+   * @param numParamsBiases 
+   * @param options carries optional attributes values
+   * @return a new instance of CudnnRNNParamsToCanonical
+   * @see org.tensorflow.op.nn.CudnnRNNParamsToCanonical
+   */
+  public <T extends TNumber> CudnnRNNParamsToCanonical<T> cudnnRNNParamsToCanonical(
+      Operand<TInt32> numLayers, Operand<TInt32> numUnits, Operand<TInt32> inputSize,
+      Operand<T> params, Long numParamsWeights, Long numParamsBiases,
+      CudnnRNNParamsToCanonical.Options... options) {
+    return CudnnRNNParamsToCanonical.create(scope, numLayers, numUnits, inputSize, params, numParamsWeights, numParamsBiases, options);
   }
 
   /**
@@ -523,16 +430,223 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link BiasAddGrad} operation
+   * Builds an {@link DataFormatDimMap} operation
    *
-   * @param outBackprop Any number of dimensions.
+   * @param x A Tensor with each element as a dimension index in source data format.
    * @param options carries optional attributes values
-   * @return a new instance of BiasAddGrad
-   * @see org.tensorflow.op.nn.BiasAddGrad
+   * @return a new instance of DataFormatDimMap
+   * @see org.tensorflow.op.nn.DataFormatDimMap
    */
-  public <T extends TType> BiasAddGrad<T> biasAddGrad(Operand<T> outBackprop,
-      BiasAddGrad.Options... options) {
-    return BiasAddGrad.create(scope, outBackprop, options);
+  public <T extends TNumber> DataFormatDimMap<T> dataFormatDimMap(Operand<T> x,
+      DataFormatDimMap.Options... options) {
+    return DataFormatDimMap.create(scope, x, options);
+  }
+
+  /**
+   * Builds an {@link DataFormatVecPermute} operation
+   *
+   * @param x Vector of size 4 or Tensor of shape (4, 2) in source data format.
+   * @param options carries optional attributes values
+   * @return a new instance of DataFormatVecPermute
+   * @see org.tensorflow.op.nn.DataFormatVecPermute
+   */
+  public <T extends TNumber> DataFormatVecPermute<T> dataFormatVecPermute(Operand<T> x,
+      DataFormatVecPermute.Options... options) {
+    return DataFormatVecPermute.create(scope, x, options);
+  }
+
+  /**
+   * Builds an {@link DepthToSpace} operation
+   *
+   * @param input 
+   * @param blockSize The size of the spatial block, same as in Space2Depth.
+   * @param options carries optional attributes values
+   * @return a new instance of DepthToSpace
+   * @see org.tensorflow.op.nn.DepthToSpace
+   */
+  public <T extends TType> DepthToSpace<T> depthToSpace(Operand<T> input, Long blockSize,
+      DepthToSpace.Options... options) {
+    return DepthToSpace.create(scope, input, blockSize, options);
+  }
+
+  /**
+   * Builds an {@link DepthwiseConv2dNative} operation
+   *
+   * @param input 
+   * @param filter 
+   * @param strides 1-D of length 4.  The stride of the sliding window for each dimension
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of DepthwiseConv2dNative
+   * @see org.tensorflow.op.nn.DepthwiseConv2dNative
+   */
+  public <T extends TNumber> DepthwiseConv2dNative<T> depthwiseConv2dNative(Operand<T> input,
+      Operand<T> filter, List<Long> strides, String padding,
+      DepthwiseConv2dNative.Options... options) {
+    return DepthwiseConv2dNative.create(scope, input, filter, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link DepthwiseConv2dNativeBackpropFilter} operation
+   *
+   * @param input 4-D with shape based on `data_format`.  For example, if
+   * @param filterSizes An integer vector representing the tensor shape of `filter`,
+   * @param outBackprop 4-D with shape  based on `data_format`.
+   * @param strides The stride of the sliding window for each dimension of the input
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of DepthwiseConv2dNativeBackpropFilter
+   * @see org.tensorflow.op.nn.DepthwiseConv2dNativeBackpropFilter
+   */
+  public <T extends TNumber> DepthwiseConv2dNativeBackpropFilter<T> depthwiseConv2dNativeBackpropFilter(
+      Operand<T> input, Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides,
+      String padding, DepthwiseConv2dNativeBackpropFilter.Options... options) {
+    return DepthwiseConv2dNativeBackpropFilter.create(scope, input, filterSizes, outBackprop, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link DepthwiseConv2dNativeBackpropInput} operation
+   *
+   * @param inputSizes An integer vector representing the shape of `input`, based
+   * @param filter 4-D with shape
+   * @param outBackprop 4-D with shape  based on `data_format`.
+   * @param strides The stride of the sliding window for each dimension of the input
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of DepthwiseConv2dNativeBackpropInput
+   * @see org.tensorflow.op.nn.DepthwiseConv2dNativeBackpropInput
+   */
+  public <T extends TNumber> DepthwiseConv2dNativeBackpropInput<T> depthwiseConv2dNativeBackpropInput(
+      Operand<TInt32> inputSizes, Operand<T> filter, Operand<T> outBackprop, List<Long> strides,
+      String padding, DepthwiseConv2dNativeBackpropInput.Options... options) {
+    return DepthwiseConv2dNativeBackpropInput.create(scope, inputSizes, filter, outBackprop, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link Dilation2d} operation
+   *
+   * @param input 4-D with shape `[batch, in_height, in_width, depth]`.
+   * @param filter 3-D with shape `[filter_height, filter_width, depth]`.
+   * @param strides The stride of the sliding window for each dimension of the input
+   * @param rates The input stride for atrous morphological dilation. Must be:
+   * @param padding The type of padding algorithm to use.
+   * @return a new instance of Dilation2d
+   * @see org.tensorflow.op.nn.Dilation2d
+   */
+  public <T extends TNumber> Dilation2d<T> dilation2d(Operand<T> input, Operand<T> filter,
+      List<Long> strides, List<Long> rates, String padding) {
+    return Dilation2d.create(scope, input, filter, strides, rates, padding);
+  }
+
+  /**
+   * Builds an {@link Dilation2dBackpropFilter} operation
+   *
+   * @param input 4-D with shape `[batch, in_height, in_width, depth]`.
+   * @param filter 3-D with shape `[filter_height, filter_width, depth]`.
+   * @param outBackprop 4-D with shape `[batch, out_height, out_width, depth]`.
+   * @param strides 1-D of length 4. The stride of the sliding window for each dimension of
+   * @param rates 1-D of length 4. The input stride for atrous morphological dilation.
+   * @param padding The type of padding algorithm to use.
+   * @return a new instance of Dilation2dBackpropFilter
+   * @see org.tensorflow.op.nn.Dilation2dBackpropFilter
+   */
+  public <T extends TNumber> Dilation2dBackpropFilter<T> dilation2dBackpropFilter(Operand<T> input,
+      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, List<Long> rates,
+      String padding) {
+    return Dilation2dBackpropFilter.create(scope, input, filter, outBackprop, strides, rates, padding);
+  }
+
+  /**
+   * Builds an {@link Dilation2dBackpropInput} operation
+   *
+   * @param input 4-D with shape `[batch, in_height, in_width, depth]`.
+   * @param filter 3-D with shape `[filter_height, filter_width, depth]`.
+   * @param outBackprop 4-D with shape `[batch, out_height, out_width, depth]`.
+   * @param strides 1-D of length 4. The stride of the sliding window for each dimension of
+   * @param rates 1-D of length 4. The input stride for atrous morphological dilation.
+   * @param padding The type of padding algorithm to use.
+   * @return a new instance of Dilation2dBackpropInput
+   * @see org.tensorflow.op.nn.Dilation2dBackpropInput
+   */
+  public <T extends TNumber> Dilation2dBackpropInput<T> dilation2dBackpropInput(Operand<T> input,
+      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, List<Long> rates,
+      String padding) {
+    return Dilation2dBackpropInput.create(scope, input, filter, outBackprop, strides, rates, padding);
+  }
+
+  /**
+   * Builds an {@link Elu} operation
+   *
+   * @param features 
+   * @return a new instance of Elu
+   * @see org.tensorflow.op.nn.Elu
+   */
+  public <T extends TNumber> Elu<T> elu(Operand<T> features) {
+    return Elu.create(scope, features);
+  }
+
+  /**
+   * Builds an {@link FixedUnigramCandidateSampler} operation
+   *
+   * @param trueClasses A batch_size * num_true matrix, in which each row contains the
+   * @param numTrue Number of true labels per context.
+   * @param numSampled Number of candidates to randomly sample.
+   * @param unique If unique is true, we sample with rejection, so that all sampled
+   * @param rangeMax The sampler will sample integers from the interval [0, range_max).
+   * @param options carries optional attributes values
+   * @return a new instance of FixedUnigramCandidateSampler
+   * @see org.tensorflow.op.nn.FixedUnigramCandidateSampler
+   */
+  public FixedUnigramCandidateSampler fixedUnigramCandidateSampler(Operand<TInt64> trueClasses,
+      Long numTrue, Long numSampled, Boolean unique, Long rangeMax,
+      FixedUnigramCandidateSampler.Options... options) {
+    return FixedUnigramCandidateSampler.create(scope, trueClasses, numTrue, numSampled, unique, rangeMax, options);
+  }
+
+  /**
+   * Builds an {@link FractionalAvgPool} operation
+   *
+   * @param value 4-D with shape `[batch, height, width, channels]`.
+   * @param poolingRatio Pooling ratio for each dimension of `value`, currently only
+   * @param options carries optional attributes values
+   * @return a new instance of FractionalAvgPool
+   * @see org.tensorflow.op.nn.FractionalAvgPool
+   */
+  public <T extends TNumber> FractionalAvgPool<T> fractionalAvgPool(Operand<T> value,
+      List<Float> poolingRatio, FractionalAvgPool.Options... options) {
+    return FractionalAvgPool.create(scope, value, poolingRatio, options);
+  }
+
+  /**
+   * Builds an {@link FractionalMaxPool} operation
+   *
+   * @param value 4-D with shape `[batch, height, width, channels]`.
+   * @param poolingRatio Pooling ratio for each dimension of `value`, currently only
+   * @param options carries optional attributes values
+   * @return a new instance of FractionalMaxPool
+   * @see org.tensorflow.op.nn.FractionalMaxPool
+   */
+  public <T extends TNumber> FractionalMaxPool<T> fractionalMaxPool(Operand<T> value,
+      List<Float> poolingRatio, FractionalMaxPool.Options... options) {
+    return FractionalMaxPool.create(scope, value, poolingRatio, options);
+  }
+
+  /**
+   * Builds an {@link FusedBatchNorm} operation
+   *
+   * @param x A 4D Tensor for input data.
+   * @param scale A 1D Tensor for scaling factor, to scale the normalized x.
+   * @param offset A 1D Tensor for offset, to shift to the normalized x.
+   * @param mean A 1D Tensor for population mean. Used for inference only;
+   * @param variance A 1D Tensor for population variance. Used for inference only;
+   * @param options carries optional attributes values
+   * @return a new instance of FusedBatchNorm
+   * @see org.tensorflow.op.nn.FusedBatchNorm
+   */
+  public <T extends TNumber, U extends TNumber> FusedBatchNorm<T, U> fusedBatchNorm(Operand<T> x,
+      Operand<U> scale, Operand<U> offset, Operand<U> mean, Operand<U> variance,
+      FusedBatchNorm.Options... options) {
+    return FusedBatchNorm.create(scope, x, scale, offset, mean, variance, options);
   }
 
   /**
@@ -555,102 +669,66 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link MaxPoolGradGrad} operation
+   * Builds an {@link FusedPadConv2d} operation
    *
-   * @param origInput The original input tensor.
-   * @param origOutput The original output tensor.
-   * @param grad 4-D.  Gradients of gradients w.r.t. the input of `max_pool`.
-   * @param ksize The size of the window for each dimension of the input tensor.
-   * @param strides The stride of the sliding window for each dimension of the
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of MaxPoolGradGrad
-   * @see org.tensorflow.op.nn.MaxPoolGradGrad
-   */
-  public <T extends TNumber> MaxPoolGradGrad<T> maxPoolGradGrad(Operand<T> origInput,
-      Operand<T> origOutput, Operand<T> grad, Operand<TInt32> ksize, Operand<TInt32> strides,
-      String padding, MaxPoolGradGrad.Options... options) {
-    return MaxPoolGradGrad.create(scope, origInput, origOutput, grad, ksize, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link SoftmaxCrossEntropyWithLogits} operation
-   *
-   * @param features batch_size x num_classes matrix
-   * @param labels batch_size x num_classes matrix
-   * @return a new instance of SoftmaxCrossEntropyWithLogits
-   * @see org.tensorflow.op.nn.SoftmaxCrossEntropyWithLogits
-   */
-  public <T extends TNumber> SoftmaxCrossEntropyWithLogits<T> softmaxCrossEntropyWithLogits(
-      Operand<T> features, Operand<T> labels) {
-    return SoftmaxCrossEntropyWithLogits.create(scope, features, labels);
-  }
-
-  /**
-   * Builds an {@link DepthwiseConv2dNativeBackpropInput} operation
-   *
-   * @param inputSizes An integer vector representing the shape of `input`, based
+   * @param input 4-D with shape `[batch, in_height, in_width, in_channels]`.
+   * @param paddings A two-column matrix specifying the padding sizes. The number of
    * @param filter 4-D with shape
-   * @param outBackprop 4-D with shape  based on `data_format`.
-   * @param strides The stride of the sliding window for each dimension of the input
+   * @param mode 
+   * @param strides 1-D of length 4.  The stride of the sliding window for each dimension
+   * @param padding The type of padding algorithm to use.
+   * @return a new instance of FusedPadConv2d
+   * @see org.tensorflow.op.nn.FusedPadConv2d
+   */
+  public <T extends TNumber> FusedPadConv2d<T> fusedPadConv2d(Operand<T> input,
+      Operand<TInt32> paddings, Operand<T> filter, String mode, List<Long> strides,
+      String padding) {
+    return FusedPadConv2d.create(scope, input, paddings, filter, mode, strides, padding);
+  }
+
+  /**
+   * Builds an {@link FusedResizeAndPadConv2d} operation
+   *
+   * @param input 4-D with shape `[batch, in_height, in_width, in_channels]`.
+   * @param size A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
+   * @param paddings A two-column matrix specifying the padding sizes. The number of
+   * @param filter 4-D with shape
+   * @param mode 
+   * @param strides 1-D of length 4.  The stride of the sliding window for each dimension
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attributes values
-   * @return a new instance of DepthwiseConv2dNativeBackpropInput
-   * @see org.tensorflow.op.nn.DepthwiseConv2dNativeBackpropInput
+   * @return a new instance of FusedResizeAndPadConv2d
+   * @see org.tensorflow.op.nn.FusedResizeAndPadConv2d
    */
-  public <T extends TNumber> DepthwiseConv2dNativeBackpropInput<T> depthwiseConv2dNativeBackpropInput(
-      Operand<TInt32> inputSizes, Operand<T> filter, Operand<T> outBackprop, List<Long> strides,
-      String padding, DepthwiseConv2dNativeBackpropInput.Options... options) {
-    return DepthwiseConv2dNativeBackpropInput.create(scope, inputSizes, filter, outBackprop, strides, padding, options);
+  public <T extends TNumber> FusedResizeAndPadConv2d<T> fusedResizeAndPadConv2d(Operand<T> input,
+      Operand<TInt32> size, Operand<TInt32> paddings, Operand<T> filter, String mode,
+      List<Long> strides, String padding, FusedResizeAndPadConv2d.Options... options) {
+    return FusedResizeAndPadConv2d.create(scope, input, size, paddings, filter, mode, strides, padding, options);
   }
 
   /**
-   * Builds an {@link QuantizedBiasAdd} operation
+   * Builds an {@link InTopK} operation
    *
-   * @param input 
-   * @param bias A 1D bias Tensor with size matching the last dimension of 'input'.
-   * @param minInput The float value that the lowest quantized input value represents.
-   * @param maxInput The float value that the highest quantized input value represents.
-   * @param minBias The float value that the lowest quantized bias value represents.
-   * @param maxBias The float value that the highest quantized bias value represents.
-   * @param outType 
-   * @return a new instance of QuantizedBiasAdd
-   * @see org.tensorflow.op.nn.QuantizedBiasAdd
+   * @param predictions A `batch_size` x `classes` tensor.
+   * @param targets A `batch_size` vector of class ids.
+   * @param k Number of top elements to look at for computing precision.
+   * @return a new instance of InTopK
+   * @see org.tensorflow.op.nn.InTopK
    */
-  public <V extends TType, T extends TType, U extends TType> QuantizedBiasAdd<V> quantizedBiasAdd(
-      Operand<T> input, Operand<U> bias, Operand<TFloat32> minInput, Operand<TFloat32> maxInput,
-      Operand<TFloat32> minBias, Operand<TFloat32> maxBias, DataType<V> outType) {
-    return QuantizedBiasAdd.create(scope, input, bias, minInput, maxInput, minBias, maxBias, outType);
+  public <T extends TNumber> InTopK inTopK(Operand<TFloat32> predictions, Operand<T> targets,
+      Operand<T> k) {
+    return InTopK.create(scope, predictions, targets, k);
   }
 
   /**
-   * Builds an {@link CtcBeamSearchDecoder} operation
+   * Builds an {@link L2Loss} operation
    *
-   * @param inputs 3-D, shape: `(max_time x batch_size x num_classes)`, the logits.
-   * @param sequenceLength A vector containing sequence lengths, size `(batch)`.
-   * @param beamWidth A scalar >= 0 (beam search beam width).
-   * @param topPaths A scalar >= 0, <= beam_width (controls output size).
-   * @param options carries optional attributes values
-   * @return a new instance of CtcBeamSearchDecoder
-   * @see org.tensorflow.op.nn.CtcBeamSearchDecoder
+   * @param t Typically 2-D, but may have any dimensions.
+   * @return a new instance of L2Loss
+   * @see org.tensorflow.op.nn.L2Loss
    */
-  public <T extends TNumber> CtcBeamSearchDecoder<T> ctcBeamSearchDecoder(Operand<T> inputs,
-      Operand<TInt32> sequenceLength, Long beamWidth, Long topPaths,
-      CtcBeamSearchDecoder.Options... options) {
-    return CtcBeamSearchDecoder.create(scope, inputs, sequenceLength, beamWidth, topPaths, options);
-  }
-
-  /**
-   * Builds an {@link LocalResponseNormalization} operation
-   *
-   * @param input 4-D.
-   * @param options carries optional attributes values
-   * @return a new instance of LocalResponseNormalization
-   * @see org.tensorflow.op.nn.LocalResponseNormalization
-   */
-  public <T extends TNumber> LocalResponseNormalization<T> localResponseNormalization(
-      Operand<T> input, LocalResponseNormalization.Options... options) {
-    return LocalResponseNormalization.create(scope, input, options);
+  public <T extends TNumber> L2Loss<T> l2Loss(Operand<T> t) {
+    return L2Loss.create(scope, t);
   }
 
   /**
@@ -672,66 +750,220 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link AvgPool3dGrad} operation
+   * Builds an {@link LocalResponseNormalization} operation
    *
-   * @param origInputShape The original input dimensions.
-   * @param grad Output backprop of shape `[batch, depth, rows, cols, channels]`.
-   * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
-   * @param strides 1-D tensor of length 5. The stride of the sliding window for each
+   * @param input 4-D.
+   * @param options carries optional attributes values
+   * @return a new instance of LocalResponseNormalization
+   * @see org.tensorflow.op.nn.LocalResponseNormalization
+   */
+  public <T extends TNumber> LocalResponseNormalization<T> localResponseNormalization(
+      Operand<T> input, LocalResponseNormalization.Options... options) {
+    return LocalResponseNormalization.create(scope, input, options);
+  }
+
+  /**
+   * Builds an {@link LogSoftmax} operation
+   *
+   * @param logits 2-D with shape `[batch_size, num_classes]`.
+   * @return a new instance of LogSoftmax
+   * @see org.tensorflow.op.nn.LogSoftmax
+   */
+  public <T extends TNumber> LogSoftmax<T> logSoftmax(Operand<T> logits) {
+    return LogSoftmax.create(scope, logits);
+  }
+
+  /**
+   * Builds an {@link MaxPool} operation
+   *
+   * @param input 4-D input to pool over.
+   * @param ksize The size of the window for each dimension of the input tensor.
+   * @param strides The stride of the sliding window for each dimension of the
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attributes values
-   * @return a new instance of AvgPool3dGrad
-   * @see org.tensorflow.op.nn.AvgPool3dGrad
+   * @return a new instance of MaxPool
+   * @see org.tensorflow.op.nn.MaxPool
    */
-  public <T extends TNumber> AvgPool3dGrad<T> avgPool3dGrad(Operand<TInt32> origInputShape,
-      Operand<T> grad, List<Long> ksize, List<Long> strides, String padding,
-      AvgPool3dGrad.Options... options) {
-    return AvgPool3dGrad.create(scope, origInputShape, grad, ksize, strides, padding, options);
+  public <T extends TType> MaxPool<T> maxPool(Operand<T> input, Operand<TInt32> ksize,
+      Operand<TInt32> strides, String padding, MaxPool.Options... options) {
+    return MaxPool.create(scope, input, ksize, strides, padding, options);
   }
 
   /**
-   * Builds an {@link Selu} operation
-   *
-   * @param features 
-   * @return a new instance of Selu
-   * @see org.tensorflow.op.nn.Selu
-   */
-  public <T extends TNumber> Selu<T> selu(Operand<T> features) {
-    return Selu.create(scope, features);
-  }
-
-  /**
-   * Builds an {@link Conv3dBackpropFilter} operation
-   *
-   * @param input Shape `[batch, depth, rows, cols, in_channels]`.
-   * @param filterSizes An integer vector representing the tensor shape of `filter`,
-   * @param outBackprop Backprop signal of shape `[batch, out_depth, out_rows, out_cols,
-   * @param strides 1-D tensor of length 5. The stride of the sliding window for each
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of Conv3dBackpropFilter
-   * @see org.tensorflow.op.nn.Conv3dBackpropFilter
-   */
-  public <T extends TNumber> Conv3dBackpropFilter<T> conv3dBackpropFilter(Operand<T> input,
-      Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides, String padding,
-      Conv3dBackpropFilter.Options... options) {
-    return Conv3dBackpropFilter.create(scope, input, filterSizes, outBackprop, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link AvgPool3d} operation
+   * Builds an {@link MaxPool3d} operation
    *
    * @param input Shape `[batch, depth, rows, cols, channels]` tensor to pool over.
    * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
    * @param strides 1-D tensor of length 5. The stride of the sliding window for each
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attributes values
-   * @return a new instance of AvgPool3d
-   * @see org.tensorflow.op.nn.AvgPool3d
+   * @return a new instance of MaxPool3d
+   * @see org.tensorflow.op.nn.MaxPool3d
    */
-  public <T extends TNumber> AvgPool3d<T> avgPool3d(Operand<T> input, List<Long> ksize,
-      List<Long> strides, String padding, AvgPool3d.Options... options) {
-    return AvgPool3d.create(scope, input, ksize, strides, padding, options);
+  public <T extends TNumber> MaxPool3d<T> maxPool3d(Operand<T> input, List<Long> ksize,
+      List<Long> strides, String padding, MaxPool3d.Options... options) {
+    return MaxPool3d.create(scope, input, ksize, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link MaxPool3dGrad} operation
+   *
+   * @param origInput The original input tensor.
+   * @param origOutput The original output tensor.
+   * @param grad Output backprop of shape `[batch, depth, rows, cols, channels]`.
+   * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
+   * @param strides 1-D tensor of length 5. The stride of the sliding window for each
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of MaxPool3dGrad
+   * @see org.tensorflow.op.nn.MaxPool3dGrad
+   */
+  public <U extends TNumber, T extends TNumber> MaxPool3dGrad<U> maxPool3dGrad(Operand<T> origInput,
+      Operand<T> origOutput, Operand<U> grad, List<Long> ksize, List<Long> strides, String padding,
+      MaxPool3dGrad.Options... options) {
+    return MaxPool3dGrad.create(scope, origInput, origOutput, grad, ksize, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link MaxPool3dGradGrad} operation
+   *
+   * @param origInput The original input tensor.
+   * @param origOutput The original output tensor.
+   * @param grad Output backprop of shape `[batch, depth, rows, cols, channels]`.
+   * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
+   * @param strides 1-D tensor of length 5. The stride of the sliding window for each
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of MaxPool3dGradGrad
+   * @see org.tensorflow.op.nn.MaxPool3dGradGrad
+   */
+  public <T extends TNumber> MaxPool3dGradGrad<T> maxPool3dGradGrad(Operand<T> origInput,
+      Operand<T> origOutput, Operand<T> grad, List<Long> ksize, List<Long> strides, String padding,
+      MaxPool3dGradGrad.Options... options) {
+    return MaxPool3dGradGrad.create(scope, origInput, origOutput, grad, ksize, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link MaxPoolGrad} operation
+   *
+   * @param origInput The original input tensor.
+   * @param origOutput The original output tensor.
+   * @param grad 4-D.  Gradients w.r.t. the output of `max_pool`.
+   * @param ksize The size of the window for each dimension of the input tensor.
+   * @param strides The stride of the sliding window for each dimension of the
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of MaxPoolGrad
+   * @see org.tensorflow.op.nn.MaxPoolGrad
+   */
+  public <T extends TNumber> MaxPoolGrad<T> maxPoolGrad(Operand<T> origInput, Operand<T> origOutput,
+      Operand<T> grad, Operand<TInt32> ksize, Operand<TInt32> strides, String padding,
+      MaxPoolGrad.Options... options) {
+    return MaxPoolGrad.create(scope, origInput, origOutput, grad, ksize, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link MaxPoolGradGrad} operation
+   *
+   * @param origInput The original input tensor.
+   * @param origOutput The original output tensor.
+   * @param grad 4-D.  Gradients of gradients w.r.t. the input of `max_pool`.
+   * @param ksize The size of the window for each dimension of the input tensor.
+   * @param strides The stride of the sliding window for each dimension of the
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of MaxPoolGradGrad
+   * @see org.tensorflow.op.nn.MaxPoolGradGrad
+   */
+  public <T extends TNumber> MaxPoolGradGrad<T> maxPoolGradGrad(Operand<T> origInput,
+      Operand<T> origOutput, Operand<T> grad, Operand<TInt32> ksize, Operand<TInt32> strides,
+      String padding, MaxPoolGradGrad.Options... options) {
+    return MaxPoolGradGrad.create(scope, origInput, origOutput, grad, ksize, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link MaxPoolGradGradWithArgmax} operation
+   *
+   * @param input The original input.
+   * @param grad 4-D with shape `[batch, height, width, channels]`.  Gradients w.r.t. the
+   * @param argmax The indices of the maximum values chosen for each output of `max_pool`.
+   * @param ksize The size of the window for each dimension of the input tensor.
+   * @param strides The stride of the sliding window for each dimension of the
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of MaxPoolGradGradWithArgmax
+   * @see org.tensorflow.op.nn.MaxPoolGradGradWithArgmax
+   */
+  public <T extends TNumber, U extends TNumber> MaxPoolGradGradWithArgmax<T> maxPoolGradGradWithArgmax(
+      Operand<T> input, Operand<T> grad, Operand<U> argmax, List<Long> ksize, List<Long> strides,
+      String padding, MaxPoolGradGradWithArgmax.Options... options) {
+    return MaxPoolGradGradWithArgmax.create(scope, input, grad, argmax, ksize, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link MaxPoolWithArgmax} operation
+   *
+   * @param input 4-D with shape `[batch, height, width, channels]`.  Input to pool over.
+   * @param ksize The size of the window for each dimension of the input tensor.
+   * @param strides The stride of the sliding window for each dimension of the
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of MaxPoolWithArgmax
+   * @see org.tensorflow.op.nn.MaxPoolWithArgmax
+   */
+  public <T extends TNumber> MaxPoolWithArgmax<T, TInt64> maxPoolWithArgmax(Operand<T> input,
+      List<Long> ksize, List<Long> strides, String padding, MaxPoolWithArgmax.Options... options) {
+    return MaxPoolWithArgmax.create(scope, input, ksize, strides, padding, options);
+  }
+
+  /**
+   * Builds an {@link MaxPoolWithArgmax} operation
+   *
+   * @param input 4-D with shape `[batch, height, width, channels]`.  Input to pool over.
+   * @param ksize The size of the window for each dimension of the input tensor.
+   * @param strides The stride of the sliding window for each dimension of the
+   * @param Targmax 
+   * @param padding The type of padding algorithm to use.
+   * @param options carries optional attributes values
+   * @return a new instance of MaxPoolWithArgmax
+   * @see org.tensorflow.op.nn.MaxPoolWithArgmax
+   */
+  public <T extends TNumber, U extends TNumber> MaxPoolWithArgmax<T, U> maxPoolWithArgmax(
+      Operand<T> input, List<Long> ksize, List<Long> strides, DataType<U> Targmax, String padding,
+      MaxPoolWithArgmax.Options... options) {
+    return MaxPoolWithArgmax.create(scope, input, ksize, strides, Targmax, padding, options);
+  }
+
+  /**
+   * Builds an {@link NthElement} operation
+   *
+   * @param input 1-D or higher with last dimension at least `n+1`.
+   * @param n 0-D. Position of sorted vector to select along the last dimension (along
+   * @param options carries optional attributes values
+   * @return a new instance of NthElement
+   * @see org.tensorflow.op.nn.NthElement
+   */
+  public <T extends TNumber> NthElement<T> nthElement(Operand<T> input, Operand<TInt32> n,
+      NthElement.Options... options) {
+    return NthElement.create(scope, input, n, options);
+  }
+
+  /**
+   * Builds an {@link QuantizedAvgPool} operation
+   *
+   * @param input 4-D with shape `[batch, height, width, channels]`.
+   * @param minInput The float value that the lowest quantized input value represents.
+   * @param maxInput The float value that the highest quantized input value represents.
+   * @param ksize The size of the window for each dimension of the input tensor.
+   * @param strides The stride of the sliding window for each dimension of the input
+   * @param padding The type of padding algorithm to use.
+   * @return a new instance of QuantizedAvgPool
+   * @see org.tensorflow.op.nn.QuantizedAvgPool
+   */
+  public <T extends TType> QuantizedAvgPool<T> quantizedAvgPool(Operand<T> input,
+      Operand<TFloat32> minInput, Operand<TFloat32> maxInput, List<Long> ksize, List<Long> strides,
+      String padding) {
+    return QuantizedAvgPool.create(scope, input, minInput, maxInput, ksize, strides, padding);
   }
 
   /**
@@ -768,6 +1000,25 @@ public final class NnOps {
   }
 
   /**
+   * Builds an {@link QuantizedBiasAdd} operation
+   *
+   * @param input 
+   * @param bias A 1D bias Tensor with size matching the last dimension of 'input'.
+   * @param minInput The float value that the lowest quantized input value represents.
+   * @param maxInput The float value that the highest quantized input value represents.
+   * @param minBias The float value that the lowest quantized bias value represents.
+   * @param maxBias The float value that the highest quantized bias value represents.
+   * @param outType 
+   * @return a new instance of QuantizedBiasAdd
+   * @see org.tensorflow.op.nn.QuantizedBiasAdd
+   */
+  public <V extends TType, T extends TType, U extends TType> QuantizedBiasAdd<V> quantizedBiasAdd(
+      Operand<T> input, Operand<U> bias, Operand<TFloat32> minInput, Operand<TFloat32> maxInput,
+      Operand<TFloat32> minBias, Operand<TFloat32> maxBias, DataType<V> outType) {
+    return QuantizedBiasAdd.create(scope, input, bias, minInput, maxInput, minBias, maxBias, outType);
+  }
+
+  /**
    * Builds an {@link QuantizedConv2d} operation
    *
    * @param input 
@@ -791,193 +1042,18 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link InTopK} operation
+   * Builds an {@link QuantizedInstanceNorm} operation
    *
-   * @param predictions A `batch_size` x `classes` tensor.
-   * @param targets A `batch_size` vector of class ids.
-   * @param k Number of top elements to look at for computing precision.
-   * @return a new instance of InTopK
-   * @see org.tensorflow.op.nn.InTopK
-   */
-  public <T extends TNumber> InTopK inTopK(Operand<TFloat32> predictions, Operand<T> targets,
-      Operand<T> k) {
-    return InTopK.create(scope, predictions, targets, k);
-  }
-
-  /**
-   * Builds an {@link DataFormatDimMap} operation
-   *
-   * @param x A Tensor with each element as a dimension index in source data format.
+   * @param x A 4D input Tensor.
+   * @param xMin The value represented by the lowest quantized input.
+   * @param xMax The value represented by the highest quantized input.
    * @param options carries optional attributes values
-   * @return a new instance of DataFormatDimMap
-   * @see org.tensorflow.op.nn.DataFormatDimMap
+   * @return a new instance of QuantizedInstanceNorm
+   * @see org.tensorflow.op.nn.QuantizedInstanceNorm
    */
-  public <T extends TNumber> DataFormatDimMap<T> dataFormatDimMap(Operand<T> x,
-      DataFormatDimMap.Options... options) {
-    return DataFormatDimMap.create(scope, x, options);
-  }
-
-  /**
-   * Builds an {@link Relu} operation
-   *
-   * @param features 
-   * @return a new instance of Relu
-   * @see org.tensorflow.op.nn.Relu
-   */
-  public <T extends TType> Relu<T> relu(Operand<T> features) {
-    return Relu.create(scope, features);
-  }
-
-  /**
-   * Builds an {@link TopK} operation
-   *
-   * @param input 1-D or higher with last dimension at least `k`.
-   * @param k 0-D.  Number of top elements to look for along the last dimension (along each
-   * @param options carries optional attributes values
-   * @return a new instance of TopK
-   * @see org.tensorflow.op.nn.TopK
-   */
-  public <T extends TNumber> TopK<T> topK(Operand<T> input, Operand<TInt32> k,
-      TopK.Options... options) {
-    return TopK.create(scope, input, k, options);
-  }
-
-  /**
-   * Builds an {@link LogSoftmax} operation
-   *
-   * @param logits 2-D with shape `[batch_size, num_classes]`.
-   * @return a new instance of LogSoftmax
-   * @see org.tensorflow.op.nn.LogSoftmax
-   */
-  public <T extends TNumber> LogSoftmax<T> logSoftmax(Operand<T> logits) {
-    return LogSoftmax.create(scope, logits);
-  }
-
-  /**
-   * Builds an {@link QuantizedAvgPool} operation
-   *
-   * @param input 4-D with shape `[batch, height, width, channels]`.
-   * @param minInput The float value that the lowest quantized input value represents.
-   * @param maxInput The float value that the highest quantized input value represents.
-   * @param ksize The size of the window for each dimension of the input tensor.
-   * @param strides The stride of the sliding window for each dimension of the input
-   * @param padding The type of padding algorithm to use.
-   * @return a new instance of QuantizedAvgPool
-   * @see org.tensorflow.op.nn.QuantizedAvgPool
-   */
-  public <T extends TType> QuantizedAvgPool<T> quantizedAvgPool(Operand<T> input,
-      Operand<TFloat32> minInput, Operand<TFloat32> maxInput, List<Long> ksize, List<Long> strides,
-      String padding) {
-    return QuantizedAvgPool.create(scope, input, minInput, maxInput, ksize, strides, padding);
-  }
-
-  /**
-   * Builds an {@link Dilation2dBackpropInput} operation
-   *
-   * @param input 4-D with shape `[batch, in_height, in_width, depth]`.
-   * @param filter 3-D with shape `[filter_height, filter_width, depth]`.
-   * @param outBackprop 4-D with shape `[batch, out_height, out_width, depth]`.
-   * @param strides 1-D of length 4. The stride of the sliding window for each dimension of
-   * @param rates 1-D of length 4. The input stride for atrous morphological dilation.
-   * @param padding The type of padding algorithm to use.
-   * @return a new instance of Dilation2dBackpropInput
-   * @see org.tensorflow.op.nn.Dilation2dBackpropInput
-   */
-  public <T extends TNumber> Dilation2dBackpropInput<T> dilation2dBackpropInput(Operand<T> input,
-      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, List<Long> rates,
-      String padding) {
-    return Dilation2dBackpropInput.create(scope, input, filter, outBackprop, strides, rates, padding);
-  }
-
-  /**
-   * Builds an {@link Relu6} operation
-   *
-   * @param features 
-   * @return a new instance of Relu6
-   * @see org.tensorflow.op.nn.Relu6
-   */
-  public <T extends TNumber> Relu6<T> relu6(Operand<T> features) {
-    return Relu6.create(scope, features);
-  }
-
-  /**
-   * Builds an {@link Softmax} operation
-   *
-   * @param logits 2-D with shape `[batch_size, num_classes]`.
-   * @return a new instance of Softmax
-   * @see org.tensorflow.op.nn.Softmax
-   */
-  public <T extends TNumber> Softmax<T> softmax(Operand<T> logits) {
-    return Softmax.create(scope, logits);
-  }
-
-  /**
-   * Builds an {@link Conv2d} operation
-   *
-   * @param input A 4-D tensor. The dimension order is interpreted according to the value
-   * @param filter A 4-D tensor of shape
-   * @param strides 1-D tensor of length 4.  The stride of the sliding window for each
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of Conv2d
-   * @see org.tensorflow.op.nn.Conv2d
-   */
-  public <T extends TNumber> Conv2d<T> conv2d(Operand<T> input, Operand<T> filter,
-      List<Long> strides, String padding, Conv2d.Options... options) {
-    return Conv2d.create(scope, input, filter, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link CudnnRNNCanonicalToParams} operation
-   *
-   * @param numLayers 
-   * @param numUnits 
-   * @param inputSize 
-   * @param weights 
-   * @param biases 
-   * @param options carries optional attributes values
-   * @return a new instance of CudnnRNNCanonicalToParams
-   * @see org.tensorflow.op.nn.CudnnRNNCanonicalToParams
-   */
-  public <T extends TNumber> CudnnRNNCanonicalToParams<T> cudnnRNNCanonicalToParams(
-      Operand<TInt32> numLayers, Operand<TInt32> numUnits, Operand<TInt32> inputSize,
-      Iterable<Operand<T>> weights, Iterable<Operand<T>> biases,
-      CudnnRNNCanonicalToParams.Options... options) {
-    return CudnnRNNCanonicalToParams.create(scope, numLayers, numUnits, inputSize, weights, biases, options);
-  }
-
-  /**
-   * Builds an {@link CtcLoss} operation
-   *
-   * @param inputs 3-D, shape: `(max_time x batch_size x num_classes)`, the logits.
-   * @param labelsIndices The indices of a `SparseTensor<int32, 2>`.
-   * @param labelsValues The values (labels) associated with the given batch and time.
-   * @param sequenceLength A vector containing sequence lengths (batch).
-   * @param options carries optional attributes values
-   * @return a new instance of CtcLoss
-   * @see org.tensorflow.op.nn.CtcLoss
-   */
-  public <T extends TNumber> CtcLoss<T> ctcLoss(Operand<T> inputs, Operand<TInt64> labelsIndices,
-      Operand<TInt32> labelsValues, Operand<TInt32> sequenceLength, CtcLoss.Options... options) {
-    return CtcLoss.create(scope, inputs, labelsIndices, labelsValues, sequenceLength, options);
-  }
-
-  /**
-   * Builds an {@link Conv3dBackpropInput} operation
-   *
-   * @param inputSizes An integer vector representing the tensor shape of `input`,
-   * @param filter Shape `[depth, rows, cols, in_channels, out_channels]`.
-   * @param outBackprop Backprop signal of shape `[batch, out_depth, out_rows, out_cols,
-   * @param strides 1-D tensor of length 5. The stride of the sliding window for each
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of Conv3dBackpropInput
-   * @see org.tensorflow.op.nn.Conv3dBackpropInput
-   */
-  public <U extends TNumber, T extends TNumber> Conv3dBackpropInput<U> conv3dBackpropInput(
-      Operand<T> inputSizes, Operand<U> filter, Operand<U> outBackprop, List<Long> strides,
-      String padding, Conv3dBackpropInput.Options... options) {
-    return Conv3dBackpropInput.create(scope, inputSizes, filter, outBackprop, strides, padding, options);
+  public <T extends TType> QuantizedInstanceNorm<T> quantizedInstanceNorm(Operand<T> x,
+      Operand<TFloat32> xMin, Operand<TFloat32> xMax, QuantizedInstanceNorm.Options... options) {
+    return QuantizedInstanceNorm.create(scope, x, xMin, xMax, options);
   }
 
   /**
@@ -999,180 +1075,6 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link FusedPadConv2d} operation
-   *
-   * @param input 4-D with shape `[batch, in_height, in_width, in_channels]`.
-   * @param paddings A two-column matrix specifying the padding sizes. The number of
-   * @param filter 4-D with shape
-   * @param mode 
-   * @param strides 1-D of length 4.  The stride of the sliding window for each dimension
-   * @param padding The type of padding algorithm to use.
-   * @return a new instance of FusedPadConv2d
-   * @see org.tensorflow.op.nn.FusedPadConv2d
-   */
-  public <T extends TNumber> FusedPadConv2d<T> fusedPadConv2d(Operand<T> input,
-      Operand<TInt32> paddings, Operand<T> filter, String mode, List<Long> strides,
-      String padding) {
-    return FusedPadConv2d.create(scope, input, paddings, filter, mode, strides, padding);
-  }
-
-  /**
-   * Builds an {@link FixedUnigramCandidateSampler} operation
-   *
-   * @param trueClasses A batch_size * num_true matrix, in which each row contains the
-   * @param numTrue Number of true labels per context.
-   * @param numSampled Number of candidates to randomly sample.
-   * @param unique If unique is true, we sample with rejection, so that all sampled
-   * @param rangeMax The sampler will sample integers from the interval [0, range_max).
-   * @param options carries optional attributes values
-   * @return a new instance of FixedUnigramCandidateSampler
-   * @see org.tensorflow.op.nn.FixedUnigramCandidateSampler
-   */
-  public FixedUnigramCandidateSampler fixedUnigramCandidateSampler(Operand<TInt64> trueClasses,
-      Long numTrue, Long numSampled, Boolean unique, Long rangeMax,
-      FixedUnigramCandidateSampler.Options... options) {
-    return FixedUnigramCandidateSampler.create(scope, trueClasses, numTrue, numSampled, unique, rangeMax, options);
-  }
-
-  /**
-   * Builds an {@link Dilation2dBackpropFilter} operation
-   *
-   * @param input 4-D with shape `[batch, in_height, in_width, depth]`.
-   * @param filter 3-D with shape `[filter_height, filter_width, depth]`.
-   * @param outBackprop 4-D with shape `[batch, out_height, out_width, depth]`.
-   * @param strides 1-D of length 4. The stride of the sliding window for each dimension of
-   * @param rates 1-D of length 4. The input stride for atrous morphological dilation.
-   * @param padding The type of padding algorithm to use.
-   * @return a new instance of Dilation2dBackpropFilter
-   * @see org.tensorflow.op.nn.Dilation2dBackpropFilter
-   */
-  public <T extends TNumber> Dilation2dBackpropFilter<T> dilation2dBackpropFilter(Operand<T> input,
-      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, List<Long> rates,
-      String padding) {
-    return Dilation2dBackpropFilter.create(scope, input, filter, outBackprop, strides, rates, padding);
-  }
-
-  /**
-   * Builds an {@link Elu} operation
-   *
-   * @param features 
-   * @return a new instance of Elu
-   * @see org.tensorflow.op.nn.Elu
-   */
-  public <T extends TNumber> Elu<T> elu(Operand<T> features) {
-    return Elu.create(scope, features);
-  }
-
-  /**
-   * Builds an {@link Dilation2d} operation
-   *
-   * @param input 4-D with shape `[batch, in_height, in_width, depth]`.
-   * @param filter 3-D with shape `[filter_height, filter_width, depth]`.
-   * @param strides The stride of the sliding window for each dimension of the input
-   * @param rates The input stride for atrous morphological dilation. Must be:
-   * @param padding The type of padding algorithm to use.
-   * @return a new instance of Dilation2d
-   * @see org.tensorflow.op.nn.Dilation2d
-   */
-  public <T extends TNumber> Dilation2d<T> dilation2d(Operand<T> input, Operand<T> filter,
-      List<Long> strides, List<Long> rates, String padding) {
-    return Dilation2d.create(scope, input, filter, strides, rates, padding);
-  }
-
-  /**
-   * Builds an {@link MaxPool3d} operation
-   *
-   * @param input Shape `[batch, depth, rows, cols, channels]` tensor to pool over.
-   * @param ksize 1-D tensor of length 5. The size of the window for each dimension of
-   * @param strides 1-D tensor of length 5. The stride of the sliding window for each
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of MaxPool3d
-   * @see org.tensorflow.op.nn.MaxPool3d
-   */
-  public <T extends TNumber> MaxPool3d<T> maxPool3d(Operand<T> input, List<Long> ksize,
-      List<Long> strides, String padding, MaxPool3d.Options... options) {
-    return MaxPool3d.create(scope, input, ksize, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link Conv2dBackpropFilter} operation
-   *
-   * @param input 4-D with shape `[batch, in_height, in_width, in_channels]`.
-   * @param filterSizes An integer vector representing the tensor shape of `filter`,
-   * @param outBackprop 4-D with shape `[batch, out_height, out_width, out_channels]`.
-   * @param strides The stride of the sliding window for each dimension of the input
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of Conv2dBackpropFilter
-   * @see org.tensorflow.op.nn.Conv2dBackpropFilter
-   */
-  public <T extends TNumber> Conv2dBackpropFilter<T> conv2dBackpropFilter(Operand<T> input,
-      Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides, String padding,
-      Conv2dBackpropFilter.Options... options) {
-    return Conv2dBackpropFilter.create(scope, input, filterSizes, outBackprop, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link FusedResizeAndPadConv2d} operation
-   *
-   * @param input 4-D with shape `[batch, in_height, in_width, in_channels]`.
-   * @param size A 1-D int32 Tensor of 2 elements: `new_height, new_width`.  The
-   * @param paddings A two-column matrix specifying the padding sizes. The number of
-   * @param filter 4-D with shape
-   * @param mode 
-   * @param strides 1-D of length 4.  The stride of the sliding window for each dimension
-   * @param padding The type of padding algorithm to use.
-   * @param options carries optional attributes values
-   * @return a new instance of FusedResizeAndPadConv2d
-   * @see org.tensorflow.op.nn.FusedResizeAndPadConv2d
-   */
-  public <T extends TNumber> FusedResizeAndPadConv2d<T> fusedResizeAndPadConv2d(Operand<T> input,
-      Operand<TInt32> size, Operand<TInt32> paddings, Operand<T> filter, String mode,
-      List<Long> strides, String padding, FusedResizeAndPadConv2d.Options... options) {
-    return FusedResizeAndPadConv2d.create(scope, input, size, paddings, filter, mode, strides, padding, options);
-  }
-
-  /**
-   * Builds an {@link BatchNormWithGlobalNormalization} operation
-   *
-   * @param t A 4D input Tensor.
-   * @param m A 1D mean Tensor with size matching the last dimension of t.
-   * @param v A 1D variance Tensor with size matching the last dimension of t.
-   * @param beta A 1D beta Tensor with size matching the last dimension of t.
-   * @param gamma A 1D gamma Tensor with size matching the last dimension of t.
-   * @param varianceEpsilon A small float number to avoid dividing by 0.
-   * @param scaleAfterNormalization A bool indicating whether the resulted tensor
-   * @return a new instance of BatchNormWithGlobalNormalization
-   * @see org.tensorflow.op.nn.BatchNormWithGlobalNormalization
-   */
-  public <T extends TType> BatchNormWithGlobalNormalization<T> batchNormWithGlobalNormalization(
-      Operand<T> t, Operand<T> m, Operand<T> v, Operand<T> beta, Operand<T> gamma,
-      Float varianceEpsilon, Boolean scaleAfterNormalization) {
-    return BatchNormWithGlobalNormalization.create(scope, t, m, v, beta, gamma, varianceEpsilon, scaleAfterNormalization);
-  }
-
-  /**
-   * Builds an {@link CudnnRNNParamsToCanonical} operation
-   *
-   * @param numLayers 
-   * @param numUnits 
-   * @param inputSize 
-   * @param params 
-   * @param numParamsWeights 
-   * @param numParamsBiases 
-   * @param options carries optional attributes values
-   * @return a new instance of CudnnRNNParamsToCanonical
-   * @see org.tensorflow.op.nn.CudnnRNNParamsToCanonical
-   */
-  public <T extends TNumber> CudnnRNNParamsToCanonical<T> cudnnRNNParamsToCanonical(
-      Operand<TInt32> numLayers, Operand<TInt32> numUnits, Operand<TInt32> inputSize,
-      Operand<T> params, Long numParamsWeights, Long numParamsBiases,
-      CudnnRNNParamsToCanonical.Options... options) {
-    return CudnnRNNParamsToCanonical.create(scope, numLayers, numUnits, inputSize, params, numParamsWeights, numParamsBiases, options);
-  }
-
-  /**
    * Builds an {@link QuantizedRelu} operation
    *
    * @param features 
@@ -1188,28 +1090,18 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link FractionalMaxPool} operation
-   *
-   * @param value 4-D with shape `[batch, height, width, channels]`.
-   * @param poolingRatio Pooling ratio for each dimension of `value`, currently only
-   * @param options carries optional attributes values
-   * @return a new instance of FractionalMaxPool
-   * @see org.tensorflow.op.nn.FractionalMaxPool
-   */
-  public <T extends TNumber> FractionalMaxPool<T> fractionalMaxPool(Operand<T> value,
-      List<Float> poolingRatio, FractionalMaxPool.Options... options) {
-    return FractionalMaxPool.create(scope, value, poolingRatio, options);
-  }
-
-  /**
-   * Builds an {@link Softsign} operation
+   * Builds an {@link QuantizedRelu6} operation
    *
    * @param features 
-   * @return a new instance of Softsign
-   * @see org.tensorflow.op.nn.Softsign
+   * @param minFeatures The float value that the lowest quantized value represents.
+   * @param maxFeatures The float value that the highest quantized value represents.
+   * @param outType 
+   * @return a new instance of QuantizedRelu6
+   * @see org.tensorflow.op.nn.QuantizedRelu6
    */
-  public <T extends TNumber> Softsign<T> softsign(Operand<T> features) {
-    return Softsign.create(scope, features);
+  public <U extends TType, T extends TType> QuantizedRelu6<U> quantizedRelu6(Operand<T> features,
+      Operand<TFloat32> minFeatures, Operand<TFloat32> maxFeatures, DataType<U> outType) {
+    return QuantizedRelu6.create(scope, features, minFeatures, maxFeatures, outType);
   }
 
   /**
@@ -1230,17 +1122,125 @@ public final class NnOps {
   }
 
   /**
-   * Builds an {@link QuantizedInstanceNorm} operation
+   * Builds an {@link Relu} operation
    *
-   * @param x A 4D input Tensor.
-   * @param xMin The value represented by the lowest quantized input.
-   * @param xMax The value represented by the highest quantized input.
-   * @param options carries optional attributes values
-   * @return a new instance of QuantizedInstanceNorm
-   * @see org.tensorflow.op.nn.QuantizedInstanceNorm
+   * @param features 
+   * @return a new instance of Relu
+   * @see org.tensorflow.op.nn.Relu
    */
-  public <T extends TType> QuantizedInstanceNorm<T> quantizedInstanceNorm(Operand<T> x,
-      Operand<TFloat32> xMin, Operand<TFloat32> xMax, QuantizedInstanceNorm.Options... options) {
-    return QuantizedInstanceNorm.create(scope, x, xMin, xMax, options);
+  public <T extends TType> Relu<T> relu(Operand<T> features) {
+    return Relu.create(scope, features);
+  }
+
+  /**
+   * Builds an {@link Relu6} operation
+   *
+   * @param features 
+   * @return a new instance of Relu6
+   * @see org.tensorflow.op.nn.Relu6
+   */
+  public <T extends TNumber> Relu6<T> relu6(Operand<T> features) {
+    return Relu6.create(scope, features);
+  }
+
+  /**
+   * Builds an {@link Selu} operation
+   *
+   * @param features 
+   * @return a new instance of Selu
+   * @see org.tensorflow.op.nn.Selu
+   */
+  public <T extends TNumber> Selu<T> selu(Operand<T> features) {
+    return Selu.create(scope, features);
+  }
+
+  /**
+   * Builds an {@link Softmax} operation
+   *
+   * @param logits 2-D with shape `[batch_size, num_classes]`.
+   * @return a new instance of Softmax
+   * @see org.tensorflow.op.nn.Softmax
+   */
+  public <T extends TNumber> Softmax<T> softmax(Operand<T> logits) {
+    return Softmax.create(scope, logits);
+  }
+
+  /**
+   * Builds an {@link SoftmaxCrossEntropyWithLogits} operation
+   *
+   * @param features batch_size x num_classes matrix
+   * @param labels batch_size x num_classes matrix
+   * @return a new instance of SoftmaxCrossEntropyWithLogits
+   * @see org.tensorflow.op.nn.SoftmaxCrossEntropyWithLogits
+   */
+  public <T extends TNumber> SoftmaxCrossEntropyWithLogits<T> softmaxCrossEntropyWithLogits(
+      Operand<T> features, Operand<T> labels) {
+    return SoftmaxCrossEntropyWithLogits.create(scope, features, labels);
+  }
+
+  /**
+   * Builds an {@link Softsign} operation
+   *
+   * @param features 
+   * @return a new instance of Softsign
+   * @see org.tensorflow.op.nn.Softsign
+   */
+  public <T extends TNumber> Softsign<T> softsign(Operand<T> features) {
+    return Softsign.create(scope, features);
+  }
+
+  /**
+   * Builds an {@link SpaceToBatch} operation
+   *
+   * @param input 4-D with shape `[batch, height, width, depth]`.
+   * @param paddings 2-D tensor of non-negative integers with shape `[2, 2]`. It specifies
+   * @param blockSize 
+   * @return a new instance of SpaceToBatch
+   * @see org.tensorflow.op.nn.SpaceToBatch
+   */
+  public <T extends TType, U extends TNumber> SpaceToBatch<T> spaceToBatch(Operand<T> input,
+      Operand<U> paddings, Long blockSize) {
+    return SpaceToBatch.create(scope, input, paddings, blockSize);
+  }
+
+  /**
+   * Builds an {@link SpaceToDepth} operation
+   *
+   * @param input 
+   * @param blockSize The size of the spatial block.
+   * @param options carries optional attributes values
+   * @return a new instance of SpaceToDepth
+   * @see org.tensorflow.op.nn.SpaceToDepth
+   */
+  public <T extends TType> SpaceToDepth<T> spaceToDepth(Operand<T> input, Long blockSize,
+      SpaceToDepth.Options... options) {
+    return SpaceToDepth.create(scope, input, blockSize, options);
+  }
+
+  /**
+   * Builds an {@link SparseSoftmaxCrossEntropyWithLogits} operation
+   *
+   * @param features batch_size x num_classes matrix
+   * @param labels batch_size vector with values in [0, num_classes).
+   * @return a new instance of SparseSoftmaxCrossEntropyWithLogits
+   * @see org.tensorflow.op.nn.SparseSoftmaxCrossEntropyWithLogits
+   */
+  public <T extends TNumber, U extends TNumber> SparseSoftmaxCrossEntropyWithLogits<T> sparseSoftmaxCrossEntropyWithLogits(
+      Operand<T> features, Operand<U> labels) {
+    return SparseSoftmaxCrossEntropyWithLogits.create(scope, features, labels);
+  }
+
+  /**
+   * Builds an {@link TopK} operation
+   *
+   * @param input 1-D or higher with last dimension at least `k`.
+   * @param k 0-D.  Number of top elements to look for along the last dimension (along each
+   * @param options carries optional attributes values
+   * @return a new instance of TopK
+   * @see org.tensorflow.op.nn.TopK
+   */
+  public <T extends TNumber> TopK<T> topK(Operand<T> input, Operand<TInt32> k,
+      TopK.Options... options) {
+    return TopK.create(scope, input, k, options);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -333,201 +333,14 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link MutexLock} operation
+   * Builds an {@link Abort} operation
    *
-   * @param mutex The mutex resource to lock.
-   * @return a new instance of MutexLock
-   * @see org.tensorflow.op.core.MutexLock
-   */
-  public MutexLock mutexLock(Operand<?> mutex) {
-    return MutexLock.create(scope, mutex);
-  }
-
-  /**
-   * Builds an {@link BatchToSpace} operation
-   *
-   * @param input 4-D tensor with shape
-   * @param crops 2-D tensor of non-negative integers with shape `[2, 2]`. It specifies
-   * @param blockSize 
-   * @return a new instance of BatchToSpace
-   * @see org.tensorflow.op.core.BatchToSpace
-   */
-  public <T extends TType, U extends TNumber> BatchToSpace<T> batchToSpace(Operand<T> input,
-      Operand<U> crops, Long blockSize) {
-    return BatchToSpace.create(scope, input, crops, blockSize);
-  }
-
-  /**
-   * Builds an {@link ZerosLike} operation
-   *
-   * @param x a tensor of type T.
-   * @return a new instance of ZerosLike
-   * @see org.tensorflow.op.core.ZerosLike
-   */
-  public <T extends TType> ZerosLike<T> zerosLike(Operand<T> x) {
-    return ZerosLike.create(scope, x);
-  }
-
-  /**
-   * Builds an {@link ReduceMax} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
    * @param options carries optional attributes values
-   * @return a new instance of ReduceMax
-   * @see org.tensorflow.op.core.ReduceMax
+   * @return a new instance of Abort
+   * @see org.tensorflow.op.core.Abort
    */
-  public <T extends TType, U extends TNumber> ReduceMax<T> reduceMax(Operand<T> input,
-      Operand<U> axis, ReduceMax.Options... options) {
-    return ReduceMax.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link Unique} operation
-   *
-   * @param x A `Tensor`.
-   * @param axis A `Tensor` of type `int32` (default: None). The axis of the Tensor to
-   * @param outIdx 
-   * @return a new instance of Unique
-   * @see org.tensorflow.op.core.Unique
-   */
-  public <T extends TType, V extends TNumber, U extends TNumber> Unique<T, V> unique(Operand<T> x,
-      Operand<U> axis, DataType<V> outIdx) {
-    return Unique.create(scope, x, axis, outIdx);
-  }
-
-  /**
-   * Builds an {@link AssignSub} operation
-   *
-   * @param ref Should be from a `Variable` node.
-   * @param value The value to be subtracted to the variable.
-   * @param options carries optional attributes values
-   * @return a new instance of AssignSub
-   * @see org.tensorflow.op.core.AssignSub
-   */
-  public <T extends TType> AssignSub<T> assignSub(Operand<T> ref, Operand<T> value,
-      AssignSub.Options... options) {
-    return AssignSub.create(scope, ref, value, options);
-  }
-
-  /**
-   * Builds an {@link DynamicStitch} operation
-   *
-   * @param indices 
-   * @param data 
-   * @return a new instance of DynamicStitch
-   * @see org.tensorflow.op.core.DynamicStitch
-   */
-  public <T extends TType> DynamicStitch<T> dynamicStitch(Iterable<Operand<TInt32>> indices,
-      Iterable<Operand<T>> data) {
-    return DynamicStitch.create(scope, indices, data);
-  }
-
-  /**
-   * Builds an {@link SetSize} operation
-   *
-   * @param setIndices 2D `Tensor`, indices of a `SparseTensor`.
-   * @param setValues 1D `Tensor`, values of a `SparseTensor`.
-   * @param setShape 1D `Tensor`, shape of a `SparseTensor`.
-   * @param options carries optional attributes values
-   * @return a new instance of SetSize
-   * @see org.tensorflow.op.core.SetSize
-   */
-  public <T extends TType> SetSize setSize(Operand<TInt64> setIndices, Operand<T> setValues,
-      Operand<TInt64> setShape, SetSize.Options... options) {
-    return SetSize.create(scope, setIndices, setValues, setShape, options);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat32> constant(float[][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link QuantizedConcat} operation
-   *
-   * @param concatDim 0-D.  The dimension along which to concatenate.  Must be in the
-   * @param values The `N` Tensors to concatenate. Their ranks and types must match,
-   * @param inputMins The minimum scalar values for each of the input tensors.
-   * @param inputMaxes The maximum scalar values for each of the input tensors.
-   * @return a new instance of QuantizedConcat
-   * @see org.tensorflow.op.core.QuantizedConcat
-   */
-  public <T extends TType> QuantizedConcat<T> quantizedConcat(Operand<TInt32> concatDim,
-      Iterable<Operand<T>> values, Iterable<Operand<TFloat32>> inputMins,
-      Iterable<Operand<TFloat32>> inputMaxes) {
-    return QuantizedConcat.create(scope, concatDim, values, inputMins, inputMaxes);
-  }
-
-  /**
-   * Builds an {@link StopGradient} operation
-   *
-   * @param input 
-   * @return a new instance of StopGradient
-   * @see org.tensorflow.op.core.StopGradient
-   */
-  public <T extends TType> StopGradient<T> stopGradient(Operand<T> input) {
-    return StopGradient.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link ReverseSequence} operation
-   *
-   * @param input The input to reverse.
-   * @param seqLengths 1-D with length `input.dims(batch_dim)` and
-   * @param seqDim The dimension which is partially reversed.
-   * @param options carries optional attributes values
-   * @return a new instance of ReverseSequence
-   * @see org.tensorflow.op.core.ReverseSequence
-   */
-  public <T extends TType, U extends TNumber> ReverseSequence<T> reverseSequence(Operand<T> input,
-      Operand<U> seqLengths, Long seqDim, ReverseSequence.Options... options) {
-    return ReverseSequence.create(scope, input, seqLengths, seqDim, options);
-  }
-
-  /**
-   * Builds an {@link AssignSubVariableOp} operation
-   *
-   * @param resource handle to the resource in which to store the variable.
-   * @param value the value by which the variable will be incremented.
-   * @return a new instance of AssignSubVariableOp
-   * @see org.tensorflow.op.core.AssignSubVariableOp
-   */
-  public <T extends TType> AssignSubVariableOp assignSubVariableOp(Operand<?> resource,
-      Operand<T> value) {
-    return AssignSubVariableOp.create(scope, resource, value);
-  }
-
-  /**
-   * Builds an {@link ClipByValue} operation
-   *
-   * @param t A `Tensor`.
-   * @param clipValueMin A 0-D (scalar) `Tensor`, or a `Tensor` with the same shape
-   * @param clipValueMax A 0-D (scalar) `Tensor`, or a `Tensor` with the same shape
-   * @return a new instance of ClipByValue
-   * @see org.tensorflow.op.core.ClipByValue
-   */
-  public <T extends TType> ClipByValue<T> clipByValue(Operand<T> t, Operand<T> clipValueMin,
-      Operand<T> clipValueMax) {
-    return ClipByValue.create(scope, t, clipValueMin, clipValueMax);
-  }
-
-  /**
-   * Builds an {@link BroadcastTo} operation
-   *
-   * @param input A Tensor to broadcast.
-   * @param shape An 1-D `int` Tensor. The shape of the desired output.
-   * @return a new instance of BroadcastTo
-   * @see org.tensorflow.op.core.BroadcastTo
-   */
-  public <T extends TType, U extends TNumber> BroadcastTo<T> broadcastTo(Operand<T> input,
-      Operand<U> shape) {
-    return BroadcastTo.create(scope, input, shape);
+  public Abort abort(Abort.Options... options) {
+    return Abort.create(scope, options);
   }
 
   /**
@@ -545,353 +358,45 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link TensorListConcat} operation
-   *
-   * @param inputHandle 
-   * @param elementShape 
-   * @param leadingDims 
-   * @param elementDtype 
-   * @return a new instance of TensorListConcat
-   * @see org.tensorflow.op.core.TensorListConcat
-   */
-  public <U extends TType, T extends TNumber> TensorListConcat<U> tensorListConcat(
-      Operand<?> inputHandle, Operand<T> elementShape, Operand<TInt64> leadingDims,
-      DataType<U> elementDtype) {
-    return TensorListConcat.create(scope, inputHandle, elementShape, leadingDims, elementDtype);
-  }
-
-  /**
-   * Builds an {@link TensorArray} operation
-   *
-   * @param size The size of the array.
-   * @param dtype The type of the elements on the tensor_array.
-   * @param options carries optional attributes values
-   * @return a new instance of TensorArray
-   * @see org.tensorflow.op.core.TensorArray
-   */
-  public <T extends TType> TensorArray tensorArray(Operand<TInt32> size, DataType<T> dtype,
-      TensorArray.Options... options) {
-    return TensorArray.create(scope, size, dtype, options);
-  }
-
-  /**
-   * Builds an {@link ReduceProd} operation
+   * Builds an {@link Any} operation
    *
    * @param input The tensor to reduce.
    * @param axis The dimensions to reduce. Must be in the range
    * @param options carries optional attributes values
-   * @return a new instance of ReduceProd
-   * @see org.tensorflow.op.core.ReduceProd
+   * @return a new instance of Any
+   * @see org.tensorflow.op.core.Any
    */
-  public <T extends TType, U extends TNumber> ReduceProd<T> reduceProd(Operand<T> input,
-      Operand<U> axis, ReduceProd.Options... options) {
-    return ReduceProd.create(scope, input, axis, options);
+  public <T extends TNumber> Any any(Operand<TBool> input, Operand<T> axis,
+      Any.Options... options) {
+    return Any.create(scope, input, axis, options);
   }
 
   /**
-   * Builds an {@link StageClear} operation
+   * Builds an {@link AssertThat} operation
    *
-   * @param dtypes 
+   * @param condition The condition to evaluate.
+   * @param data The tensors to print out when condition is false.
    * @param options carries optional attributes values
-   * @return a new instance of StageClear
-   * @see org.tensorflow.op.core.StageClear
+   * @return a new instance of AssertThat
+   * @see org.tensorflow.op.core.AssertThat
    */
-  public StageClear stageClear(List<DataType<?>> dtypes, StageClear.Options... options) {
-    return StageClear.create(scope, dtypes, options);
+  public AssertThat assertThat(Operand<TBool> condition, Iterable<Operand<?>> data,
+      AssertThat.Options... options) {
+    return AssertThat.create(scope, condition, data, options);
   }
 
   /**
-   * Builds an {@link TensorArrayWrite} operation
+   * Builds an {@link Assign} operation
    *
-   * @param handle The handle to a TensorArray.
-   * @param index The position to write to inside the TensorArray.
-   * @param value The tensor to write to the TensorArray.
-   * @param flowIn A float scalar that enforces proper chaining of operations.
-   * @return a new instance of TensorArrayWrite
-   * @see org.tensorflow.op.core.TensorArrayWrite
-   */
-  public <T extends TType> TensorArrayWrite tensorArrayWrite(Operand<?> handle,
-      Operand<TInt32> index, Operand<T> value, Operand<TFloat32> flowIn) {
-    return TensorArrayWrite.create(scope, handle, index, value, flowIn);
-  }
-
-  /**
-   * Builds an {@link AssignAddVariableOp} operation
-   *
-   * @param resource handle to the resource in which to store the variable.
-   * @param value the value by which the variable will be incremented.
-   * @return a new instance of AssignAddVariableOp
-   * @see org.tensorflow.op.core.AssignAddVariableOp
-   */
-  public <T extends TType> AssignAddVariableOp assignAddVariableOp(Operand<?> resource,
-      Operand<T> value) {
-    return AssignAddVariableOp.create(scope, resource, value);
-  }
-
-  /**
-   * Builds an {@link LinSpace} operation
-   *
-   * @param start 0-D tensor. First entry in the range.
-   * @param stop 0-D tensor. Last entry in the range.
-   * @param num 0-D tensor. Number of values to generate.
-   * @return a new instance of LinSpace
-   * @see org.tensorflow.op.core.LinSpace
-   */
-  public <T extends TNumber, U extends TNumber> LinSpace<T> linSpace(Operand<T> start,
-      Operand<T> stop, Operand<U> num) {
-    return LinSpace.create(scope, start, stop, num);
-  }
-
-  /**
-   * Builds an {@link ReduceSum} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
+   * @param ref Should be from a `Variable` node. May be uninitialized.
+   * @param value The value to be assigned to the variable.
    * @param options carries optional attributes values
-   * @return a new instance of ReduceSum
-   * @see org.tensorflow.op.core.ReduceSum
+   * @return a new instance of Assign
+   * @see org.tensorflow.op.core.Assign
    */
-  public <T extends TType, U extends TNumber> ReduceSum<T> reduceSum(Operand<T> input,
-      Operand<U> axis, ReduceSum.Options... options) {
-    return ReduceSum.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat64> constant(double[][][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link Reverse} operation
-   *
-   * @param tensor Up to 8-D.
-   * @param axis 1-D. The indices of the dimensions to reverse. Must be in the range
-   * @return a new instance of Reverse
-   * @see org.tensorflow.op.core.Reverse
-   */
-  public <T extends TType, U extends TNumber> Reverse<T> reverse(Operand<T> tensor,
-      Operand<U> axis) {
-    return Reverse.create(scope, tensor, axis);
-  }
-
-  /**
-   * Builds an {@link ResourceScatterNdSub} operation
-   *
-   * @param ref A resource handle. Must be from a VarHandleOp.
-   * @param indices A Tensor. Must be one of the following types: int32, int64.
-   * @param updates A Tensor. Must have the same type as ref. A tensor of
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceScatterNdSub
-   * @see org.tensorflow.op.core.ResourceScatterNdSub
-   */
-  public <T extends TNumber, U extends TType> ResourceScatterNdSub resourceScatterNdSub(
-      Operand<?> ref, Operand<T> indices, Operand<U> updates,
-      ResourceScatterNdSub.Options... options) {
-    return ResourceScatterNdSub.create(scope, ref, indices, updates, options);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data The string to put into the new constant.
-   * @return a string constant
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TString> constant(String data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link BarrierIncompleteSize} operation
-   *
-   * @param handle The handle to a barrier.
-   * @return a new instance of BarrierIncompleteSize
-   * @see org.tensorflow.op.core.BarrierIncompleteSize
-   */
-  public BarrierIncompleteSize barrierIncompleteSize(Operand<TString> handle) {
-    return BarrierIncompleteSize.create(scope, handle);
-  }
-
-  /**
-   * Builds an {@link ScatterAdd} operation
-   *
-   * @param ref Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to add to `ref`.
-   * @param options carries optional attributes values
-   * @return a new instance of ScatterAdd
-   * @see org.tensorflow.op.core.ScatterAdd
-   */
-  public <T extends TType, U extends TNumber> ScatterAdd<T> scatterAdd(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterAdd.Options... options) {
-    return ScatterAdd.create(scope, ref, indices, updates, options);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt32> constant(int[] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link MutableHashTableOfTensors} operation
-   *
-   * @param keyDtype Type of the table keys.
-   * @param valueDtype Type of the table values.
-   * @param options carries optional attributes values
-   * @return a new instance of MutableHashTableOfTensors
-   * @see org.tensorflow.op.core.MutableHashTableOfTensors
-   */
-  public <T extends TType, U extends TType> MutableHashTableOfTensors mutableHashTableOfTensors(
-      DataType<T> keyDtype, DataType<U> valueDtype, MutableHashTableOfTensors.Options... options) {
-    return MutableHashTableOfTensors.create(scope, keyDtype, valueDtype, options);
-  }
-
-  /**
-   * Builds an {@link ResourceScatterNdAdd} operation
-   *
-   * @param ref A resource handle. Must be from a VarHandleOp.
-   * @param indices A Tensor. Must be one of the following types: int32, int64.
-   * @param updates A Tensor. Must have the same type as ref. A tensor of
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceScatterNdAdd
-   * @see org.tensorflow.op.core.ResourceScatterNdAdd
-   */
-  public <T extends TNumber, U extends TType> ResourceScatterNdAdd resourceScatterNdAdd(
-      Operand<?> ref, Operand<T> indices, Operand<U> updates,
-      ResourceScatterNdAdd.Options... options) {
-    return ResourceScatterNdAdd.create(scope, ref, indices, updates, options);
-  }
-
-  /**
-   * Builds an {@link InplaceSub} operation
-   *
-   * @param x A `Tensor` of type T.
-   * @param i A vector. Indices into the left-most dimension of `x`.
-   * @param v A `Tensor` of type T. Same dimension sizes as x except the first dimension, which must be the same as i's size.
-   * @return a new instance of InplaceSub
-   * @see org.tensorflow.op.core.InplaceSub
-   */
-  public <T extends TType> InplaceSub<T> inplaceSub(Operand<T> x, Operand<TInt32> i, Operand<T> v) {
-    return InplaceSub.create(scope, x, i, v);
-  }
-
-  /**
-   * Builds an {@link ScatterNdUpdate} operation
-   *
-   * @param ref A mutable Tensor. Should be from a Variable node.
-   * @param indices A Tensor. Must be one of the following types: int32, int64.
-   * @param updates A Tensor. Must have the same type as ref. A tensor of updated
-   * @param options carries optional attributes values
-   * @return a new instance of ScatterNdUpdate
-   * @see org.tensorflow.op.core.ScatterNdUpdate
-   */
-  public <T extends TType, U extends TNumber> ScatterNdUpdate<T> scatterNdUpdate(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterNdUpdate.Options... options) {
-    return ScatterNdUpdate.create(scope, ref, indices, updates, options);
-  }
-
-  /**
-   * Builds an {@link OrderedMapPeek} operation
-   *
-   * @param key 
-   * @param indices 
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of OrderedMapPeek
-   * @see org.tensorflow.op.core.OrderedMapPeek
-   */
-  public OrderedMapPeek orderedMapPeek(Operand<TInt64> key, Operand<TInt32> indices,
-      List<DataType<?>> dtypes, OrderedMapPeek.Options... options) {
-    return OrderedMapPeek.create(scope, key, indices, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link LookupTableInsert} operation
-   *
-   * @param tableHandle Handle to the table.
-   * @param keys Any shape.  Keys to look up.
-   * @param values Values to associate with keys.
-   * @return a new instance of LookupTableInsert
-   * @see org.tensorflow.op.core.LookupTableInsert
-   */
-  public <T extends TType, U extends TType> LookupTableInsert lookupTableInsert(
-      Operand<?> tableHandle, Operand<T> keys, Operand<U> values) {
-    return LookupTableInsert.create(scope, tableHandle, keys, values);
-  }
-
-  /**
-   * Builds an {@link TensorScatterNdAdd} operation
-   *
-   * @param tensor Tensor to copy/update.
-   * @param indices Index tensor.
-   * @param updates Updates to scatter into output.
-   * @return a new instance of TensorScatterNdAdd
-   * @see org.tensorflow.op.core.TensorScatterNdAdd
-   */
-  public <T extends TType, U extends TNumber> TensorScatterNdAdd<T> tensorScatterNdAdd(
-      Operand<T> tensor, Operand<U> indices, Operand<T> updates) {
-    return TensorScatterNdAdd.create(scope, tensor, indices, updates);
-  }
-
-  /**
-   * Builds an {@link ParallelConcat} operation
-   *
-   * @param values Tensors to be concatenated. All must have size 1 in the first dimension
-   * @param shape the final shape of the result; should be equal to the shapes of any input
-   * @return a new instance of ParallelConcat
-   * @see org.tensorflow.op.core.ParallelConcat
-   */
-  public <T extends TType> ParallelConcat<T> parallelConcat(Iterable<Operand<T>> values,
-      Shape shape) {
-    return ParallelConcat.create(scope, values, shape);
-  }
-
-  /**
-   * Builds an {@link AssignVariableOp} operation
-   *
-   * @param resource handle to the resource in which to store the variable.
-   * @param value the value to set the new tensor to use.
-   * @return a new instance of AssignVariableOp
-   * @see org.tensorflow.op.core.AssignVariableOp
-   */
-  public <T extends TType> AssignVariableOp assignVariableOp(Operand<?> resource,
-      Operand<T> value) {
-    return AssignVariableOp.create(scope, resource, value);
-  }
-
-  /**
-   * Builds an {@link TensorListPushBack} operation
-   *
-   * @param inputHandle 
-   * @param tensor 
-   * @return a new instance of TensorListPushBack
-   * @see org.tensorflow.op.core.TensorListPushBack
-   */
-  public <T extends TType> TensorListPushBack tensorListPushBack(Operand<?> inputHandle,
-      Operand<T> tensor) {
-    return TensorListPushBack.create(scope, inputHandle, tensor);
-  }
-
-  /**
-   * Builds an {@link RefSwitch} operation
-   *
-   * @param data The ref tensor to be forwarded to the appropriate output.
-   * @param pred A scalar that specifies which output port will receive data.
-   * @return a new instance of RefSwitch
-   * @see org.tensorflow.op.core.RefSwitch
-   */
-  public <T extends TType> RefSwitch<T> refSwitch(Operand<T> data, Operand<TBool> pred) {
-    return RefSwitch.create(scope, data, pred);
+  public <T extends TType> Assign<T> assign(Operand<T> ref, Operand<T> value,
+      Assign.Options... options) {
+    return Assign.create(scope, ref, value, options);
   }
 
   /**
@@ -909,29 +414,295 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link GatherNd} operation
+   * Builds an {@link AssignAddVariableOp} operation
    *
-   * @param params The tensor from which to gather values.
-   * @param indices Index tensor.
-   * @return a new instance of GatherNd
-   * @see org.tensorflow.op.core.GatherNd
+   * @param resource handle to the resource in which to store the variable.
+   * @param value the value by which the variable will be incremented.
+   * @return a new instance of AssignAddVariableOp
+   * @see org.tensorflow.op.core.AssignAddVariableOp
    */
-  public <T extends TType, U extends TNumber> GatherNd<T> gatherNd(Operand<T> params,
-      Operand<U> indices) {
-    return GatherNd.create(scope, params, indices);
+  public <T extends TType> AssignAddVariableOp assignAddVariableOp(Operand<?> resource,
+      Operand<T> value) {
+    return AssignAddVariableOp.create(scope, resource, value);
   }
 
   /**
-   * Builds an {@link OrderedMapSize} operation
+   * Builds an {@link AssignSub} operation
    *
-   * @param dtypes 
+   * @param ref Should be from a `Variable` node.
+   * @param value The value to be subtracted to the variable.
    * @param options carries optional attributes values
-   * @return a new instance of OrderedMapSize
-   * @see org.tensorflow.op.core.OrderedMapSize
+   * @return a new instance of AssignSub
+   * @see org.tensorflow.op.core.AssignSub
    */
-  public OrderedMapSize orderedMapSize(List<DataType<?>> dtypes,
-      OrderedMapSize.Options... options) {
-    return OrderedMapSize.create(scope, dtypes, options);
+  public <T extends TType> AssignSub<T> assignSub(Operand<T> ref, Operand<T> value,
+      AssignSub.Options... options) {
+    return AssignSub.create(scope, ref, value, options);
+  }
+
+  /**
+   * Builds an {@link AssignSubVariableOp} operation
+   *
+   * @param resource handle to the resource in which to store the variable.
+   * @param value the value by which the variable will be incremented.
+   * @return a new instance of AssignSubVariableOp
+   * @see org.tensorflow.op.core.AssignSubVariableOp
+   */
+  public <T extends TType> AssignSubVariableOp assignSubVariableOp(Operand<?> resource,
+      Operand<T> value) {
+    return AssignSubVariableOp.create(scope, resource, value);
+  }
+
+  /**
+   * Builds an {@link AssignVariableOp} operation
+   *
+   * @param resource handle to the resource in which to store the variable.
+   * @param value the value to set the new tensor to use.
+   * @return a new instance of AssignVariableOp
+   * @see org.tensorflow.op.core.AssignVariableOp
+   */
+  public <T extends TType> AssignVariableOp assignVariableOp(Operand<?> resource,
+      Operand<T> value) {
+    return AssignVariableOp.create(scope, resource, value);
+  }
+
+  /**
+   * Builds an {@link Barrier} operation
+   *
+   * @param componentTypes The type of each component in a value.
+   * @param options carries optional attributes values
+   * @return a new instance of Barrier
+   * @see org.tensorflow.op.core.Barrier
+   */
+  public Barrier barrier(List<DataType<?>> componentTypes, Barrier.Options... options) {
+    return Barrier.create(scope, componentTypes, options);
+  }
+
+  /**
+   * Builds an {@link BarrierClose} operation
+   *
+   * @param handle The handle to a barrier.
+   * @param options carries optional attributes values
+   * @return a new instance of BarrierClose
+   * @see org.tensorflow.op.core.BarrierClose
+   */
+  public BarrierClose barrierClose(Operand<TString> handle, BarrierClose.Options... options) {
+    return BarrierClose.create(scope, handle, options);
+  }
+
+  /**
+   * Builds an {@link BarrierIncompleteSize} operation
+   *
+   * @param handle The handle to a barrier.
+   * @return a new instance of BarrierIncompleteSize
+   * @see org.tensorflow.op.core.BarrierIncompleteSize
+   */
+  public BarrierIncompleteSize barrierIncompleteSize(Operand<TString> handle) {
+    return BarrierIncompleteSize.create(scope, handle);
+  }
+
+  /**
+   * Builds an {@link BarrierInsertMany} operation
+   *
+   * @param handle The handle to a barrier.
+   * @param keys A one-dimensional tensor of keys, with length n.
+   * @param values An any-dimensional tensor of values, which are associated with the
+   * @param componentIndex The component of the barrier elements that is being assigned.
+   * @return a new instance of BarrierInsertMany
+   * @see org.tensorflow.op.core.BarrierInsertMany
+   */
+  public <T extends TType> BarrierInsertMany barrierInsertMany(Operand<TString> handle,
+      Operand<TString> keys, Operand<T> values, Long componentIndex) {
+    return BarrierInsertMany.create(scope, handle, keys, values, componentIndex);
+  }
+
+  /**
+   * Builds an {@link BarrierReadySize} operation
+   *
+   * @param handle The handle to a barrier.
+   * @return a new instance of BarrierReadySize
+   * @see org.tensorflow.op.core.BarrierReadySize
+   */
+  public BarrierReadySize barrierReadySize(Operand<TString> handle) {
+    return BarrierReadySize.create(scope, handle);
+  }
+
+  /**
+   * Builds an {@link BarrierTakeMany} operation
+   *
+   * @param handle The handle to a barrier.
+   * @param numElements A single-element tensor containing the number of elements to
+   * @param componentTypes The type of each component in a value.
+   * @param options carries optional attributes values
+   * @return a new instance of BarrierTakeMany
+   * @see org.tensorflow.op.core.BarrierTakeMany
+   */
+  public BarrierTakeMany barrierTakeMany(Operand<TString> handle, Operand<TInt32> numElements,
+      List<DataType<?>> componentTypes, BarrierTakeMany.Options... options) {
+    return BarrierTakeMany.create(scope, handle, numElements, componentTypes, options);
+  }
+
+  /**
+   * Builds an {@link Batch} operation
+   *
+   * @param inTensors 
+   * @param numBatchThreads 
+   * @param maxBatchSize 
+   * @param batchTimeoutMicros 
+   * @param gradTimeoutMicros 
+   * @param options carries optional attributes values
+   * @return a new instance of Batch
+   * @see org.tensorflow.op.core.Batch
+   */
+  public Batch batch(Iterable<Operand<?>> inTensors, Long numBatchThreads, Long maxBatchSize,
+      Long batchTimeoutMicros, Long gradTimeoutMicros, Batch.Options... options) {
+    return Batch.create(scope, inTensors, numBatchThreads, maxBatchSize, batchTimeoutMicros, gradTimeoutMicros, options);
+  }
+
+  /**
+   * Builds an {@link BatchToSpace} operation
+   *
+   * @param input 4-D tensor with shape
+   * @param crops 2-D tensor of non-negative integers with shape `[2, 2]`. It specifies
+   * @param blockSize 
+   * @return a new instance of BatchToSpace
+   * @see org.tensorflow.op.core.BatchToSpace
+   */
+  public <T extends TType, U extends TNumber> BatchToSpace<T> batchToSpace(Operand<T> input,
+      Operand<U> crops, Long blockSize) {
+    return BatchToSpace.create(scope, input, crops, blockSize);
+  }
+
+  /**
+   * Builds an {@link BatchToSpaceNd} operation
+   *
+   * @param input N-D with shape `input_shape = [batch] + spatial_shape + remaining_shape`,
+   * @param blockShape 1-D with shape `[M]`, all values must be >= 1.
+   * @param crops 2-D with shape `[M, 2]`, all values must be >= 0.
+   * @return a new instance of BatchToSpaceNd
+   * @see org.tensorflow.op.core.BatchToSpaceNd
+   */
+  public <T extends TType, U extends TNumber, V extends TNumber> BatchToSpaceNd<T> batchToSpaceNd(
+      Operand<T> input, Operand<U> blockShape, Operand<V> crops) {
+    return BatchToSpaceNd.create(scope, input, blockShape, crops);
+  }
+
+  /**
+   * Builds an {@link Bitcast} operation
+   *
+   * @param input 
+   * @param type 
+   * @return a new instance of Bitcast
+   * @see org.tensorflow.op.core.Bitcast
+   */
+  public <U extends TType, T extends TType> Bitcast<U> bitcast(Operand<T> input, DataType<U> type) {
+    return Bitcast.create(scope, input, type);
+  }
+
+  /**
+   * Builds an {@link BroadcastDynamicShape} operation
+   *
+   * @param s0 
+   * @param s1 
+   * @return a new instance of BroadcastDynamicShape
+   * @see org.tensorflow.op.core.BroadcastDynamicShape
+   */
+  public <T extends TNumber> BroadcastDynamicShape<T> broadcastDynamicShape(Operand<T> s0,
+      Operand<T> s1) {
+    return BroadcastDynamicShape.create(scope, s0, s1);
+  }
+
+  /**
+   * Builds an {@link BroadcastTo} operation
+   *
+   * @param input A Tensor to broadcast.
+   * @param shape An 1-D `int` Tensor. The shape of the desired output.
+   * @return a new instance of BroadcastTo
+   * @see org.tensorflow.op.core.BroadcastTo
+   */
+  public <T extends TType, U extends TNumber> BroadcastTo<T> broadcastTo(Operand<T> input,
+      Operand<U> shape) {
+    return BroadcastTo.create(scope, input, shape);
+  }
+
+  /**
+   * Builds an {@link Bucketize} operation
+   *
+   * @param input Any shape of Tensor contains with int or float type.
+   * @param boundaries A sorted list of floats gives the boundary of the buckets.
+   * @return a new instance of Bucketize
+   * @see org.tensorflow.op.core.Bucketize
+   */
+  public <T extends TNumber> Bucketize bucketize(Operand<T> input, List<Float> boundaries) {
+    return Bucketize.create(scope, input, boundaries);
+  }
+
+  /**
+   * Builds an {@link ClipByValue} operation
+   *
+   * @param t A `Tensor`.
+   * @param clipValueMin A 0-D (scalar) `Tensor`, or a `Tensor` with the same shape
+   * @param clipValueMax A 0-D (scalar) `Tensor`, or a `Tensor` with the same shape
+   * @return a new instance of ClipByValue
+   * @see org.tensorflow.op.core.ClipByValue
+   */
+  public <T extends TType> ClipByValue<T> clipByValue(Operand<T> t, Operand<T> clipValueMin,
+      Operand<T> clipValueMax) {
+    return ClipByValue.create(scope, t, clipValueMin, clipValueMax);
+  }
+
+  /**
+   * Builds an {@link Concat} operation
+   *
+   * @param values List of `N` Tensors to concatenate. Their ranks and types must match,
+   * @param axis 0-D.  The dimension along which to concatenate.  Must be in the
+   * @return a new instance of Concat
+   * @see org.tensorflow.op.core.Concat
+   */
+  public <T extends TType, U extends TNumber> Concat<T> concat(Iterable<Operand<T>> values,
+      Operand<U> axis) {
+    return Concat.create(scope, values, axis);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat32> constant(float[][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat64> constant(double[][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data The string to put into the new constant.
+   * @return a string constant
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TString> constant(String data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt32> constant(int[] data) {
+    return Constant.create(scope, data);
   }
 
   /**
@@ -955,45 +726,6 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link IsVariableInitialized} operation
-   *
-   * @param ref Should be from a `Variable` node. May be uninitialized.
-   * @return a new instance of IsVariableInitialized
-   * @see org.tensorflow.op.core.IsVariableInitialized
-   */
-  public <T extends TType> IsVariableInitialized isVariableInitialized(Operand<T> ref) {
-    return IsVariableInitialized.create(scope, ref);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param shape the tensor shape.
-   * @param data a buffer containing the tensor data.
-   * @return a long constant
-   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt64> constant(long[] shape, LongBuffer data) {
-    return Constant.create(scope, shape, data);
-  }
-
-  /**
-   * Builds an {@link Gradients} operation
-   *
-   * @param y output of the function to derive
-   * @param x inputs of the function for which partial derivatives are computed
-   * @param options carries optional attributes values
-   * @return a new instance of {@code Gradients}
-   * @throws IllegalArgumentException if execution environment is not a graph
-   * @see org.tensorflow.op.core.Gradients
-   */
-  public Gradients gradients(Operand<?> y, Iterable<? extends Operand<?>> x,
-      Gradients.Options... options) {
-    return Gradients.create(scope, y, x, options);
-  }
-
-  /**
    * Builds an {@link Constant} operation
    *
    * @param data An array containing the values to put into the new constant. The dimensions of the
@@ -1001,59 +733,6 @@ public final class Ops {
    */
   public Constant<TInt32> constant(int[][] data) {
     return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link MutableHashTable} operation
-   *
-   * @param keyDtype Type of the table keys.
-   * @param valueDtype Type of the table values.
-   * @param options carries optional attributes values
-   * @return a new instance of MutableHashTable
-   * @see org.tensorflow.op.core.MutableHashTable
-   */
-  public <T extends TType, U extends TType> MutableHashTable mutableHashTable(DataType<T> keyDtype,
-      DataType<U> valueDtype, MutableHashTable.Options... options) {
-    return MutableHashTable.create(scope, keyDtype, valueDtype, options);
-  }
-
-  /**
-   * Builds an {@link Min} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of Min
-   * @see org.tensorflow.op.core.Min
-   */
-  public <T extends TType, U extends TNumber> Min<T> min(Operand<T> input, Operand<U> axis,
-      Min.Options... options) {
-    return Min.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link Unstage} operation
-   *
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of Unstage
-   * @see org.tensorflow.op.core.Unstage
-   */
-  public Unstage unstage(List<DataType<?>> dtypes, Unstage.Options... options) {
-    return Unstage.create(scope, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link Unique} operation
-   *
-   * @param x A `Tensor`.
-   * @param axis A `Tensor` of type `int32` (default: None). The axis of the Tensor to
-   * @return a new instance of Unique
-   * @see org.tensorflow.op.core.Unique
-   */
-  public <T extends TType, U extends TNumber> Unique<T, TInt32> unique(Operand<T> x,
-      Operand<U> axis) {
-    return Unique.create(scope, x, axis);
   }
 
   /**
@@ -1067,52 +746,6 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link StridedSliceAssign} operation
-   *
-   * @param ref 
-   * @param begin 
-   * @param end 
-   * @param strides 
-   * @param value 
-   * @param options carries optional attributes values
-   * @return a new instance of StridedSliceAssign
-   * @see org.tensorflow.op.core.StridedSliceAssign
-   */
-  public <T extends TType, U extends TNumber> StridedSliceAssign<T> stridedSliceAssign(
-      Operand<T> ref, Operand<U> begin, Operand<U> end, Operand<U> strides, Operand<T> value,
-      StridedSliceAssign.Options... options) {
-    return StridedSliceAssign.create(scope, ref, begin, end, strides, value, options);
-  }
-
-  /**
-   * Builds an {@link Unstack} operation
-   *
-   * @param value 1-D or higher, with `axis` dimension size equal to `num`.
-   * @param num 
-   * @param options carries optional attributes values
-   * @return a new instance of Unstack
-   * @see org.tensorflow.op.core.Unstack
-   */
-  public <T extends TType> Unstack<T> unstack(Operand<T> value, Long num,
-      Unstack.Options... options) {
-    return Unstack.create(scope, value, num, options);
-  }
-
-  /**
-   * Builds an {@link ReduceAll} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of ReduceAll
-   * @see org.tensorflow.op.core.ReduceAll
-   */
-  public <T extends TNumber> ReduceAll reduceAll(Operand<TBool> input, Operand<T> axis,
-      ReduceAll.Options... options) {
-    return ReduceAll.create(scope, input, axis, options);
-  }
-
-  /**
    * Builds an {@link Constant} operation
    *
    * @param data An array containing the values to put into the new constant. The dimensions of the
@@ -1120,96 +753,6 @@ public final class Ops {
    */
   public Constant<TBool> constant(boolean[][][][][] data) {
     return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link Split} operation
-   *
-   * @param axis 0-D.  The dimension along which to split.  Must be in the range
-   * @param value The tensor to split.
-   * @param numSplit The number of ways to split.  Must evenly divide
-   * @return a new instance of Split
-   * @see org.tensorflow.op.core.Split
-   */
-  public <T extends TType> Split<T> split(Operand<TInt32> axis, Operand<T> value, Long numSplit) {
-    return Split.create(scope, axis, value, numSplit);
-  }
-
-  /**
-   * Builds an {@link ResourceGather} operation
-   *
-   * @param resource 
-   * @param indices 
-   * @param dtype 
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceGather
-   * @see org.tensorflow.op.core.ResourceGather
-   */
-  public <U extends TType, T extends TNumber> ResourceGather<U> resourceGather(Operand<?> resource,
-      Operand<T> indices, DataType<U> dtype, ResourceGather.Options... options) {
-    return ResourceGather.create(scope, resource, indices, dtype, options);
-  }
-
-  /**
-   * Builds an {@link SwitchCond} operation
-   *
-   * @param data The tensor to be forwarded to the appropriate output.
-   * @param pred A scalar that specifies which output port will receive data.
-   * @return a new instance of SwitchCond
-   * @see org.tensorflow.op.core.SwitchCond
-   */
-  public <T extends TType> SwitchCond<T> switchCond(Operand<T> data, Operand<TBool> pred) {
-    return SwitchCond.create(scope, data, pred);
-  }
-
-  /**
-   * Builds an {@link TensorScatterNdUpdate} operation
-   *
-   * @param tensor Tensor to copy/update.
-   * @param indices Index tensor.
-   * @param updates Updates to scatter into output.
-   * @return a new instance of TensorScatterNdUpdate
-   * @see org.tensorflow.op.core.TensorScatterNdUpdate
-   */
-  public <T extends TType, U extends TNumber> TensorScatterNdUpdate<T> tensorScatterNdUpdate(
-      Operand<T> tensor, Operand<U> indices, Operand<T> updates) {
-    return TensorScatterNdUpdate.create(scope, tensor, indices, updates);
-  }
-
-  /**
-   * Builds an {@link BarrierReadySize} operation
-   *
-   * @param handle The handle to a barrier.
-   * @return a new instance of BarrierReadySize
-   * @see org.tensorflow.op.core.BarrierReadySize
-   */
-  public BarrierReadySize barrierReadySize(Operand<TString> handle) {
-    return BarrierReadySize.create(scope, handle);
-  }
-
-  /**
-   * Builds an {@link Rank} operation
-   *
-   * @param input 
-   * @return a new instance of Rank
-   * @see org.tensorflow.op.core.Rank
-   */
-  public <T extends TType> Rank rank(Operand<T> input) {
-    return Rank.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link InitializeTable} operation
-   *
-   * @param tableHandle Handle to a table which will be initialized.
-   * @param keys Keys of type Tkey.
-   * @param values Values of type Tval.
-   * @return a new instance of InitializeTable
-   * @see org.tensorflow.op.core.InitializeTable
-   */
-  public <T extends TType, U extends TType> InitializeTable initializeTable(Operand<?> tableHandle,
-      Operand<T> keys, Operand<U> values) {
-    return InitializeTable.create(scope, tableHandle, keys, values);
   }
 
   /**
@@ -1234,49 +777,6 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link SetDiff1d} operation
-   *
-   * @param x 1-D. Values to keep.
-   * @param y 1-D. Values to remove.
-   * @return a new instance of SetDiff1d
-   * @see org.tensorflow.op.core.SetDiff1d
-   */
-  public <T extends TType> SetDiff1d<T, TInt32> setDiff1d(Operand<T> x, Operand<T> y) {
-    return SetDiff1d.create(scope, x, y);
-  }
-
-  /**
-   * Builds an {@link TensorArrayGather} operation
-   *
-   * @param handle The handle to a TensorArray.
-   * @param indices The locations in the TensorArray from which to read tensor elements.
-   * @param flowIn A float scalar that enforces proper chaining of operations.
-   * @param dtype The type of the elem that is returned.
-   * @param options carries optional attributes values
-   * @return a new instance of TensorArrayGather
-   * @see org.tensorflow.op.core.TensorArrayGather
-   */
-  public <T extends TType> TensorArrayGather<T> tensorArrayGather(Operand<?> handle,
-      Operand<TInt32> indices, Operand<TFloat32> flowIn, DataType<T> dtype,
-      TensorArrayGather.Options... options) {
-    return TensorArrayGather.create(scope, handle, indices, flowIn, dtype, options);
-  }
-
-  /**
-   * Builds an {@link Any} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of Any
-   * @see org.tensorflow.op.core.Any
-   */
-  public <T extends TNumber> Any any(Operand<TBool> input, Operand<T> axis,
-      Any.Options... options) {
-    return Any.create(scope, input, axis, options);
-  }
-
-  /**
    * Builds an {@link Constant} operation
    *
    * @param data An array containing the values to put into the new constant. The dimensions of the
@@ -1284,35 +784,6 @@ public final class Ops {
    */
   public Constant<TInt32> constant(int[][][][] data) {
     return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link TryRpc} operation
-   *
-   * @param address `0-D` or `1-D`.  The address (i.e. host_name:port) of the RPC server.
-   * @param method `0-D` or `1-D`.  The method address on the RPC server.
-   * @param request `0-D` or `1-D`.  Serialized proto strings: the rpc request argument.
-   * @param options carries optional attributes values
-   * @return a new instance of TryRpc
-   * @see org.tensorflow.op.core.TryRpc
-   */
-  public TryRpc tryRpc(Operand<TString> address, Operand<TString> method, Operand<TString> request,
-      TryRpc.Options... options) {
-    return TryRpc.create(scope, address, method, request, options);
-  }
-
-  /**
-   * Builds an {@link Empty} operation
-   *
-   * @param shape 1-D. Represents the shape of the output tensor.
-   * @param dtype 
-   * @param options carries optional attributes values
-   * @return a new instance of Empty
-   * @see org.tensorflow.op.core.Empty
-   */
-  public <T extends TType> Empty<T> empty(Operand<TInt32> shape, DataType<T> dtype,
-      Empty.Options... options) {
-    return Empty.create(scope, shape, dtype, options);
   }
 
   /**
@@ -1326,73 +797,6 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link TensorArrayPack} operation
-   *
-   * @param handle 
-   * @param flowIn 
-   * @param dtype 
-   * @param options carries optional attributes values
-   * @return a new instance of TensorArrayPack
-   * @see org.tensorflow.op.core.TensorArrayPack
-   */
-  public <T extends TType> TensorArrayPack<T> tensorArrayPack(Operand<TString> handle,
-      Operand<TFloat32> flowIn, DataType<T> dtype, TensorArrayPack.Options... options) {
-    return TensorArrayPack.create(scope, handle, flowIn, dtype, options);
-  }
-
-  /**
-   * Builds an {@link Timestamp} operation
-   *
-   * @return a new instance of Timestamp
-   * @see org.tensorflow.op.core.Timestamp
-   */
-  public Timestamp timestamp() {
-    return Timestamp.create(scope);
-  }
-
-  /**
-   * Builds an {@link PlaceholderWithDefault} operation
-   *
-   * @param input The default value to produce when `output` is not fed.
-   * @param shape The (possibly partial) shape of the tensor.
-   * @return a new instance of PlaceholderWithDefault
-   * @see org.tensorflow.op.core.PlaceholderWithDefault
-   */
-  public <T extends TType> PlaceholderWithDefault<T> placeholderWithDefault(Operand<T> input,
-      Shape shape) {
-    return PlaceholderWithDefault.create(scope, input, shape);
-  }
-
-  /**
-   * Builds an {@link BatchToSpaceNd} operation
-   *
-   * @param input N-D with shape `input_shape = [batch] + spatial_shape + remaining_shape`,
-   * @param blockShape 1-D with shape `[M]`, all values must be >= 1.
-   * @param crops 2-D with shape `[M, 2]`, all values must be >= 0.
-   * @return a new instance of BatchToSpaceNd
-   * @see org.tensorflow.op.core.BatchToSpaceNd
-   */
-  public <T extends TType, U extends TNumber, V extends TNumber> BatchToSpaceNd<T> batchToSpaceNd(
-      Operand<T> input, Operand<U> blockShape, Operand<V> crops) {
-    return BatchToSpaceNd.create(scope, input, blockShape, crops);
-  }
-
-  /**
-   * Builds an {@link TensorListGetItem} operation
-   *
-   * @param inputHandle 
-   * @param index 
-   * @param elementShape 
-   * @param elementDtype 
-   * @return a new instance of TensorListGetItem
-   * @see org.tensorflow.op.core.TensorListGetItem
-   */
-  public <T extends TType> TensorListGetItem<T> tensorListGetItem(Operand<?> inputHandle,
-      Operand<TInt32> index, Operand<TInt32> elementShape, DataType<T> elementDtype) {
-    return TensorListGetItem.create(scope, inputHandle, index, elementShape, elementDtype);
-  }
-
-  /**
    * Builds an {@link Constant} operation
    *
    * @param data An array containing the values to put into the new constant. The dimensions of the
@@ -1400,58 +804,6 @@ public final class Ops {
    */
   public Constant<TFloat64> constant(double[][][][] data) {
     return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link NextIteration} operation
-   *
-   * @param data The tensor to be made available to the next iteration.
-   * @return a new instance of NextIteration
-   * @see org.tensorflow.op.core.NextIteration
-   */
-  public <T extends TType> NextIteration<T> nextIteration(Operand<T> data) {
-    return NextIteration.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link ShapeN} operation
-   *
-   * @param input 
-   * @return a new instance of ShapeN
-   * @see org.tensorflow.op.core.ShapeN
-   */
-  public <T extends TType> ShapeN<TInt32> shapeN(Iterable<Operand<T>> input) {
-    return ShapeN.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link MutableDenseHashTable} operation
-   *
-   * @param emptyKey The key used to represent empty key buckets internally. Must not
-   * @param deletedKey 
-   * @param valueDtype Type of the table values.
-   * @param options carries optional attributes values
-   * @return a new instance of MutableDenseHashTable
-   * @see org.tensorflow.op.core.MutableDenseHashTable
-   */
-  public <T extends TType, U extends TType> MutableDenseHashTable mutableDenseHashTable(
-      Operand<T> emptyKey, Operand<T> deletedKey, DataType<U> valueDtype,
-      MutableDenseHashTable.Options... options) {
-    return MutableDenseHashTable.create(scope, emptyKey, deletedKey, valueDtype, options);
-  }
-
-  /**
-   * Builds an {@link TensorListReserve} operation
-   *
-   * @param elementShape 
-   * @param numElements 
-   * @param elementDtype 
-   * @return a new instance of TensorListReserve
-   * @see org.tensorflow.op.core.TensorListReserve
-   */
-  public <T extends TNumber, U extends TType> TensorListReserve tensorListReserve(
-      Operand<T> elementShape, Operand<TInt32> numElements, DataType<U> elementDtype) {
-    return TensorListReserve.create(scope, elementShape, numElements, elementDtype);
   }
 
   /**
@@ -1475,88 +827,6 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link Batch} operation
-   *
-   * @param inTensors 
-   * @param numBatchThreads 
-   * @param maxBatchSize 
-   * @param batchTimeoutMicros 
-   * @param gradTimeoutMicros 
-   * @param options carries optional attributes values
-   * @return a new instance of Batch
-   * @see org.tensorflow.op.core.Batch
-   */
-  public Batch batch(Iterable<Operand<?>> inTensors, Long numBatchThreads, Long maxBatchSize,
-      Long batchTimeoutMicros, Long gradTimeoutMicros, Batch.Options... options) {
-    return Batch.create(scope, inTensors, numBatchThreads, maxBatchSize, batchTimeoutMicros, gradTimeoutMicros, options);
-  }
-
-  /**
-   * Builds an {@link ResourceCountUpTo} operation
-   *
-   * @param resource Should be from a scalar `Variable` node.
-   * @param limit If incrementing ref would bring it above limit, instead generates an
-   * @param T 
-   * @return a new instance of ResourceCountUpTo
-   * @see org.tensorflow.op.core.ResourceCountUpTo
-   */
-  public <T extends TNumber> ResourceCountUpTo<T> resourceCountUpTo(Operand<?> resource, Long limit,
-      DataType<T> T) {
-    return ResourceCountUpTo.create(scope, resource, limit, T);
-  }
-
-  /**
-   * Builds an {@link UnravelIndex} operation
-   *
-   * @param indices An 0-D or 1-D `int` Tensor whose elements are indices into the
-   * @param dims An 1-D `int` Tensor. The shape of the array to use for unraveling
-   * @return a new instance of UnravelIndex
-   * @see org.tensorflow.op.core.UnravelIndex
-   */
-  public <T extends TNumber> UnravelIndex<T> unravelIndex(Operand<T> indices, Operand<T> dims) {
-    return UnravelIndex.create(scope, indices, dims);
-  }
-
-  /**
-   * Builds an {@link Max} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of Max
-   * @see org.tensorflow.op.core.Max
-   */
-  public <T extends TType, U extends TNumber> Max<T> max(Operand<T> input, Operand<U> axis,
-      Max.Options... options) {
-    return Max.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link LookupTableFind} operation
-   *
-   * @param tableHandle Handle to the table.
-   * @param keys Any shape.  Keys to look up.
-   * @param defaultValue 
-   * @return a new instance of LookupTableFind
-   * @see org.tensorflow.op.core.LookupTableFind
-   */
-  public <U extends TType, T extends TType> LookupTableFind<U> lookupTableFind(
-      Operand<?> tableHandle, Operand<T> keys, Operand<U> defaultValue) {
-    return LookupTableFind.create(scope, tableHandle, keys, defaultValue);
-  }
-
-  /**
-   * Builds an {@link VariableShape} operation
-   *
-   * @param input 
-   * @return a new instance of VariableShape
-   * @see org.tensorflow.op.core.VariableShape
-   */
-  public VariableShape<TInt32> variableShape(Operand<?> input) {
-    return VariableShape.create(scope, input);
-  }
-
-  /**
    * Builds an {@link Constant} operation
    *
    * @param data An array containing the values to put into the new constant. The dimensions of the
@@ -1577,89 +847,369 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link Stage} operation
+   * Builds an {@link Constant} operation
    *
-   * @param values a list of tensors
-   * @param options carries optional attributes values
-   * @return a new instance of Stage
-   * @see org.tensorflow.op.core.Stage
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
    */
-  public Stage stage(Iterable<Operand<?>> values, Stage.Options... options) {
-    return Stage.create(scope, values, options);
+  public Constant<TInt64> constant(long[] data) {
+    return Constant.create(scope, data);
   }
 
   /**
-   * Builds an {@link Fill} operation
+   * Builds an {@link Constant} operation
    *
-   * @param dims 1-D. Represents the shape of the output tensor.
-   * @param value 0-D (scalar). Value to fill the returned tensor.
-   * @return a new instance of Fill
-   * @see org.tensorflow.op.core.Fill
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
    */
-  public <U extends TType, T extends TNumber> Fill<U> fill(Operand<T> dims, Operand<U> value) {
-    return Fill.create(scope, dims, value);
+  public Constant<TFloat32> constant(float[][][][] data) {
+    return Constant.create(scope, data);
   }
 
   /**
-   * Builds an {@link DeepCopy} operation
+   * Builds an {@link Constant} operation
    *
-   * @param x The source tensor of type `T`.
-   * @return a new instance of DeepCopy
-   * @see org.tensorflow.op.core.DeepCopy
+   * @param data The value to put into the new constant. 
+   * @return a float constant
+   * @see org.tensorflow.op.core.Constant
    */
-  public <T extends TType> DeepCopy<T> deepCopy(Operand<T> x) {
-    return DeepCopy.create(scope, x);
+  public Constant<TFloat32> constant(float data) {
+    return Constant.create(scope, data);
   }
 
   /**
-   * Builds an {@link ResourceScatterAdd} operation
+   * Builds an {@link Constant} operation
    *
-   * @param resource Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to add to `ref`.
-   * @return a new instance of ResourceScatterAdd
-   * @see org.tensorflow.op.core.ResourceScatterAdd
+   * @param data The value to put into the new constant.
+   * @return a double constant
+   * @see org.tensorflow.op.core.Constant
    */
-  public <T extends TNumber, U extends TType> ResourceScatterAdd resourceScatterAdd(
-      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
-    return ResourceScatterAdd.create(scope, resource, indices, updates);
+  public Constant<TFloat64> constant(double data) {
+    return Constant.create(scope, data);
   }
 
   /**
-   * Builds an {@link OnesLike} operation
+   * Builds an {@link Constant} operation
    *
-   * @param x a tensor of type T.
-   * @return a new instance of OnesLike
-   * @see org.tensorflow.op.core.OnesLike
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
    */
-  public <T extends TType> OnesLike<T> onesLike(Operand<T> x) {
-    return OnesLike.create(scope, x);
+  public Constant<TFloat64> constant(double[][] data) {
+    return Constant.create(scope, data);
   }
 
   /**
-   * Builds an {@link Bucketize} operation
+   * Builds an {@link Constant} operation
    *
-   * @param input Any shape of Tensor contains with int or float type.
-   * @param boundaries A sorted list of floats gives the boundary of the buckets.
-   * @return a new instance of Bucketize
-   * @see org.tensorflow.op.core.Bucketize
+   * @param data The value to put into the new constant.
+   * @return an integer constant
+   * @see org.tensorflow.op.core.Constant
    */
-  public <T extends TNumber> Bucketize bucketize(Operand<T> input, List<Float> boundaries) {
-    return Bucketize.create(scope, input, boundaries);
+  public Constant<TInt32> constant(int data) {
+    return Constant.create(scope, data);
   }
 
   /**
-   * Builds an {@link Slice} operation
+   * Builds an {@link Constant} operation
    *
-   * @param input 
-   * @param begin begin[i] specifies the offset into the 'i'th dimension of
-   * @param size size[i] specifies the number of elements of the 'i'th dimension
-   * @return a new instance of Slice
-   * @see org.tensorflow.op.core.Slice
+   * @param data An array containing the values to put into the new constant. String elements are
+   * @see org.tensorflow.op.core.Constant
    */
-  public <T extends TType, U extends TNumber> Slice<T> slice(Operand<T> input, Operand<U> begin,
-      Operand<U> size) {
-    return Slice.create(scope, input, begin, size);
+  public Constant<TString> constant(byte[][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat32> constant(float[][][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt64> constant(long[][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. String elements are
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TString> constant(byte[][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat32> constant(float[][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat64> constant(double[] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat32> constant(float[][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat64> constant(double[][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt32> constant(int[][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt64> constant(long[][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TBool> constant(boolean[][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat32> constant(float[] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt32> constant(int[][][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt32> constant(int[][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt64> constant(long[][][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt64> constant(long[][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat64> constant(double[][][][][][] data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param data The value to put into the new constant.
+   * @return a boolean constant
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TBool> constant(boolean data) {
+    return Constant.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param tensor a Tensor holding the constant value
+   * @return a constant of the same data type as `tensor`
+   * @see org.tensorflow.op.core.Constant
+   */
+  public <T extends TType> Constant<T> constant(Tensor<T> tensor) {
+    return Constant.create(scope, tensor);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param charset The encoding from String to bytes.
+   * @param data The string to put into the new constant.
+   * @return a string constant
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TString> constant(String data, Charset charset) {
+    return Constant.create(scope, data, charset);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param object a Java object representing the constant.
+   * @return a constant of type `type`
+   * @see org.tensorflow.Tensor#create(Object) Tensor.create
+   * @see org.tensorflow.op.core.Constant
+   */
+  public <T extends TType> Constant<T> constant(Object object, DataType<T> type) {
+    return Constant.create(scope, object, type);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   * @return a long constant
+   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt64> constant(long[] shape, LongBuffer data) {
+    return Constant.create(scope, shape, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   * @return an integer constant
+   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TInt32> constant(long[] shape, IntBuffer data) {
+    return Constant.create(scope, shape, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   * @return a float constant
+   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat32> constant(long[] shape, FloatBuffer data) {
+    return Constant.create(scope, shape, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   * @return a double constant
+   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
+   * @see org.tensorflow.op.core.Constant
+   */
+  public Constant<TFloat64> constant(long[] shape, DoubleBuffer data) {
+    return Constant.create(scope, shape, data);
+  }
+
+  /**
+   * Builds an {@link Constant} operation
+   *
+   * @param type the tensor datatype.
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   * @return a constant of type `type`
+   * @throws IllegalArgumentException If the tensor datatype or shape is not compatible with the
+   * @see org.tensorflow.op.core.Constant
+   */
+  public <T extends TType> Constant<T> constant(DataType<T> type, long[] shape, ByteBuffer data) {
+    return Constant.create(scope, type, shape, data);
+  }
+
+  /**
+   * Builds an {@link ConsumeMutexLock} operation
+   *
+   * @param mutexLock A tensor returned by `MutexLock`.
+   * @return a new instance of ConsumeMutexLock
+   * @see org.tensorflow.op.core.ConsumeMutexLock
+   */
+  public ConsumeMutexLock consumeMutexLock(Operand<?> mutexLock) {
+    return ConsumeMutexLock.create(scope, mutexLock);
+  }
+
+  /**
+   * Builds an {@link ControlTrigger} operation
+   *
+   * @return a new instance of ControlTrigger
+   * @see org.tensorflow.op.core.ControlTrigger
+   */
+  public ControlTrigger controlTrigger() {
+    return ControlTrigger.create(scope);
   }
 
   /**
@@ -1675,193 +1225,256 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link TensorArrayConcat} operation
+   * Builds an {@link DeepCopy} operation
    *
-   * @param handle The handle to a TensorArray.
-   * @param flowIn A float scalar that enforces proper chaining of operations.
-   * @param dtype The type of the elem that is returned.
-   * @param options carries optional attributes values
-   * @return a new instance of TensorArrayConcat
-   * @see org.tensorflow.op.core.TensorArrayConcat
+   * @param x The source tensor of type `T`.
+   * @return a new instance of DeepCopy
+   * @see org.tensorflow.op.core.DeepCopy
    */
-  public <T extends TType> TensorArrayConcat<T> tensorArrayConcat(Operand<?> handle,
-      Operand<TFloat32> flowIn, DataType<T> dtype, TensorArrayConcat.Options... options) {
-    return TensorArrayConcat.create(scope, handle, flowIn, dtype, options);
+  public <T extends TType> DeepCopy<T> deepCopy(Operand<T> x) {
+    return DeepCopy.create(scope, x);
   }
 
   /**
-   * Builds an {@link ScatterMin} operation
+   * Builds an {@link DeleteSessionTensor} operation
    *
-   * @param ref Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to reduce into `ref`.
-   * @param options carries optional attributes values
-   * @return a new instance of ScatterMin
-   * @see org.tensorflow.op.core.ScatterMin
+   * @param handle The handle for a tensor stored in the session state.
+   * @return a new instance of DeleteSessionTensor
+   * @see org.tensorflow.op.core.DeleteSessionTensor
    */
-  public <T extends TNumber, U extends TNumber> ScatterMin<T> scatterMin(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterMin.Options... options) {
-    return ScatterMin.create(scope, ref, indices, updates, options);
+  public DeleteSessionTensor deleteSessionTensor(Operand<TString> handle) {
+    return DeleteSessionTensor.create(scope, handle);
   }
 
   /**
-   * Builds an {@link MapPeek} operation
+   * Builds an {@link DestroyResourceOp} operation
    *
-   * @param key 
+   * @param resource handle to the resource to delete.
+   * @param options carries optional attributes values
+   * @return a new instance of DestroyResourceOp
+   * @see org.tensorflow.op.core.DestroyResourceOp
+   */
+  public DestroyResourceOp destroyResourceOp(Operand<?> resource,
+      DestroyResourceOp.Options... options) {
+    return DestroyResourceOp.create(scope, resource, options);
+  }
+
+  /**
+   * Builds an {@link DestroyTemporaryVariable} operation
+   *
+   * @param ref A reference to the temporary variable tensor.
+   * @param varName Name of the temporary variable, usually the name of the matching
+   * @return a new instance of DestroyTemporaryVariable
+   * @see org.tensorflow.op.core.DestroyTemporaryVariable
+   */
+  public <T extends TType> DestroyTemporaryVariable<T> destroyTemporaryVariable(Operand<T> ref,
+      String varName) {
+    return DestroyTemporaryVariable.create(scope, ref, varName);
+  }
+
+  /**
+   * Builds an {@link DynamicPartition} operation
+   *
+   * @param data 
+   * @param partitions Any shape.  Indices in the range `[0, num_partitions)`.
+   * @param numPartitions The number of partitions to output.
+   * @return a new instance of DynamicPartition
+   * @see org.tensorflow.op.core.DynamicPartition
+   */
+  public <T extends TType> DynamicPartition<T> dynamicPartition(Operand<T> data,
+      Operand<TInt32> partitions, Long numPartitions) {
+    return DynamicPartition.create(scope, data, partitions, numPartitions);
+  }
+
+  /**
+   * Builds an {@link DynamicStitch} operation
+   *
    * @param indices 
-   * @param dtypes 
+   * @param data 
+   * @return a new instance of DynamicStitch
+   * @see org.tensorflow.op.core.DynamicStitch
+   */
+  public <T extends TType> DynamicStitch<T> dynamicStitch(Iterable<Operand<TInt32>> indices,
+      Iterable<Operand<T>> data) {
+    return DynamicStitch.create(scope, indices, data);
+  }
+
+  /**
+   * Builds an {@link EditDistance} operation
+   *
+   * @param hypothesisIndices The indices of the hypothesis list SparseTensor.
+   * @param hypothesisValues The values of the hypothesis list SparseTensor.
+   * @param hypothesisShape The shape of the hypothesis list SparseTensor.
+   * @param truthIndices The indices of the truth list SparseTensor.
+   * @param truthValues The values of the truth list SparseTensor.
+   * @param truthShape truth indices, vector.
    * @param options carries optional attributes values
-   * @return a new instance of MapPeek
-   * @see org.tensorflow.op.core.MapPeek
+   * @return a new instance of EditDistance
+   * @see org.tensorflow.op.core.EditDistance
    */
-  public MapPeek mapPeek(Operand<TInt64> key, Operand<TInt32> indices, List<DataType<?>> dtypes,
-      MapPeek.Options... options) {
-    return MapPeek.create(scope, key, indices, dtypes, options);
+  public <T extends TType> EditDistance editDistance(Operand<TInt64> hypothesisIndices,
+      Operand<T> hypothesisValues, Operand<TInt64> hypothesisShape, Operand<TInt64> truthIndices,
+      Operand<T> truthValues, Operand<TInt64> truthShape, EditDistance.Options... options) {
+    return EditDistance.create(scope, hypothesisIndices, hypothesisValues, hypothesisShape, truthIndices, truthValues, truthShape, options);
   }
 
   /**
-   * Builds an {@link Concat} operation
+   * Builds an {@link Empty} operation
    *
-   * @param values List of `N` Tensors to concatenate. Their ranks and types must match,
-   * @param axis 0-D.  The dimension along which to concatenate.  Must be in the
-   * @return a new instance of Concat
-   * @see org.tensorflow.op.core.Concat
-   */
-  public <T extends TType, U extends TNumber> Concat<T> concat(Iterable<Operand<T>> values,
-      Operand<U> axis) {
-    return Concat.create(scope, values, axis);
-  }
-
-  /**
-   * Builds an {@link AssertThat} operation
-   *
-   * @param condition The condition to evaluate.
-   * @param data The tensors to print out when condition is false.
+   * @param shape 1-D. Represents the shape of the output tensor.
+   * @param dtype 
    * @param options carries optional attributes values
-   * @return a new instance of AssertThat
-   * @see org.tensorflow.op.core.AssertThat
+   * @return a new instance of Empty
+   * @see org.tensorflow.op.core.Empty
    */
-  public AssertThat assertThat(Operand<TBool> condition, Iterable<Operand<?>> data,
-      AssertThat.Options... options) {
-    return AssertThat.create(scope, condition, data, options);
+  public <T extends TType> Empty<T> empty(Operand<TInt32> shape, DataType<T> dtype,
+      Empty.Options... options) {
+    return Empty.create(scope, shape, dtype, options);
   }
 
   /**
-   * Builds an {@link Stack} operation
+   * Builds an {@link EmptyTensorList} operation
    *
-   * @param values Must be of same shape and type.
-   * @param options carries optional attributes values
-   * @return a new instance of Stack
-   * @see org.tensorflow.op.core.Stack
-   */
-  public <T extends TType> Stack<T> stack(Iterable<Operand<T>> values, Stack.Options... options) {
-    return Stack.create(scope, values, options);
-  }
-
-  /**
-   * Builds an {@link ScatterMul} operation
-   *
-   * @param ref Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to multiply to `ref`.
-   * @param options carries optional attributes values
-   * @return a new instance of ScatterMul
-   * @see org.tensorflow.op.core.ScatterMul
-   */
-  public <T extends TType, U extends TNumber> ScatterMul<T> scatterMul(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterMul.Options... options) {
-    return ScatterMul.create(scope, ref, indices, updates, options);
-  }
-
-  /**
-   * Builds an {@link Prod} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of Prod
-   * @see org.tensorflow.op.core.Prod
-   */
-  public <T extends TType, U extends TNumber> Prod<T> prod(Operand<T> input, Operand<U> axis,
-      Prod.Options... options) {
-    return Prod.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link TensorListScatter} operation
-   *
-   * @param tensor 
-   * @param indices 
    * @param elementShape 
-   * @param numElements 
-   * @return a new instance of TensorListScatter
-   * @see org.tensorflow.op.core.TensorListScatter
+   * @param maxNumElements 
+   * @param elementDtype 
+   * @return a new instance of EmptyTensorList
+   * @see org.tensorflow.op.core.EmptyTensorList
    */
-  public <T extends TType, U extends TNumber> TensorListScatter tensorListScatter(Operand<T> tensor,
-      Operand<TInt32> indices, Operand<U> elementShape, Operand<TInt32> numElements) {
-    return TensorListScatter.create(scope, tensor, indices, elementShape, numElements);
+  public <T extends TNumber, U extends TType> EmptyTensorList emptyTensorList(
+      Operand<T> elementShape, Operand<TInt32> maxNumElements, DataType<U> elementDtype) {
+    return EmptyTensorList.create(scope, elementShape, maxNumElements, elementDtype);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link EnsureShape} operation
    *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
+   * @param input A tensor, whose shape is to be validated.
+   * @param shape The expected (possibly partially specified) shape of the input tensor.
+   * @return a new instance of EnsureShape
+   * @see org.tensorflow.op.core.EnsureShape
    */
-  public Constant<TInt64> constant(long[] data) {
-    return Constant.create(scope, data);
+  public <T extends TType> EnsureShape<T> ensureShape(Operand<T> input, Shape shape) {
+    return EnsureShape.create(scope, input, shape);
   }
 
   /**
-   * Builds an {@link Snapshot} operation
+   * Builds an {@link ExpandDims} operation
    *
    * @param input 
-   * @return a new instance of Snapshot
-   * @see org.tensorflow.op.core.Snapshot
+   * @param axis 0-D (scalar). Specifies the dimension index at which to
+   * @return a new instance of ExpandDims
+   * @see org.tensorflow.op.core.ExpandDims
    */
-  public <T extends TType> Snapshot<T> snapshot(Operand<T> input) {
-    return Snapshot.create(scope, input);
+  public <T extends TType, U extends TNumber> ExpandDims<T> expandDims(Operand<T> input,
+      Operand<U> axis) {
+    return ExpandDims.create(scope, input, axis);
   }
 
   /**
-   * Builds an {@link Unbatch} operation
+   * Builds an {@link ExtractVolumePatches} operation
    *
-   * @param batchedTensor 
-   * @param batchIndex 
-   * @param id 
-   * @param timeoutMicros 
+   * @param input 5-D Tensor with shape `[batch, in_planes, in_rows, in_cols, depth]`.
+   * @param ksizes The size of the sliding window for each dimension of `input`.
+   * @param strides 1-D of length 5. How far the centers of two consecutive patches are in
+   * @param padding The type of padding algorithm to use.
+   * @return a new instance of ExtractVolumePatches
+   * @see org.tensorflow.op.core.ExtractVolumePatches
+   */
+  public <T extends TNumber> ExtractVolumePatches<T> extractVolumePatches(Operand<T> input,
+      List<Long> ksizes, List<Long> strides, String padding) {
+    return ExtractVolumePatches.create(scope, input, ksizes, strides, padding);
+  }
+
+  /**
+   * Builds an {@link Fill} operation
+   *
+   * @param dims 1-D. Represents the shape of the output tensor.
+   * @param value 0-D (scalar). Value to fill the returned tensor.
+   * @return a new instance of Fill
+   * @see org.tensorflow.op.core.Fill
+   */
+  public <U extends TType, T extends TNumber> Fill<U> fill(Operand<T> dims, Operand<U> value) {
+    return Fill.create(scope, dims, value);
+  }
+
+  /**
+   * Builds an {@link Fingerprint} operation
+   *
+   * @param data Must have rank 1 or higher.
+   * @param method Fingerprint method used by this op. Currently available method is
+   * @return a new instance of Fingerprint
+   * @see org.tensorflow.op.core.Fingerprint
+   */
+  public <T extends TType> Fingerprint fingerprint(Operand<T> data, Operand<TString> method) {
+    return Fingerprint.create(scope, data, method);
+  }
+
+  /**
+   * Builds an {@link Gather} operation
+   *
+   * @param params The tensor from which to gather values. Must be at least rank
+   * @param indices Index tensor. Must be in range `[0, params.shape[axis])`.
+   * @param axis The axis in `params` to gather `indices` from. Defaults to the first
    * @param options carries optional attributes values
-   * @return a new instance of Unbatch
-   * @see org.tensorflow.op.core.Unbatch
+   * @return a new instance of Gather
+   * @see org.tensorflow.op.core.Gather
    */
-  public <T extends TType> Unbatch<T> unbatch(Operand<T> batchedTensor, Operand<TInt64> batchIndex,
-      Operand<TInt64> id, Long timeoutMicros, Unbatch.Options... options) {
-    return Unbatch.create(scope, batchedTensor, batchIndex, id, timeoutMicros, options);
+  public <T extends TType, U extends TNumber, V extends TNumber> Gather<T> gather(Operand<T> params,
+      Operand<U> indices, Operand<V> axis, Gather.Options... options) {
+    return Gather.create(scope, params, indices, axis, options);
   }
 
   /**
-   * Builds an {@link TensorListConcatLists} operation
+   * Builds an {@link GatherNd} operation
    *
-   * @param inputA 
-   * @param inputB 
-   * @param elementDtype 
-   * @return a new instance of TensorListConcatLists
-   * @see org.tensorflow.op.core.TensorListConcatLists
+   * @param params The tensor from which to gather values.
+   * @param indices Index tensor.
+   * @return a new instance of GatherNd
+   * @see org.tensorflow.op.core.GatherNd
    */
-  public <T extends TType> TensorListConcatLists tensorListConcatLists(Operand<?> inputA,
-      Operand<?> inputB, DataType<T> elementDtype) {
-    return TensorListConcatLists.create(scope, inputA, inputB, elementDtype);
+  public <T extends TType, U extends TNumber> GatherNd<T> gatherNd(Operand<T> params,
+      Operand<U> indices) {
+    return GatherNd.create(scope, params, indices);
   }
 
   /**
-   * Builds an {@link Merge} operation
+   * Builds an {@link GetSessionHandle} operation
    *
-   * @param inputs The input tensors, exactly one of which will become available.
-   * @return a new instance of Merge
-   * @see org.tensorflow.op.core.Merge
+   * @param value The tensor to be stored.
+   * @return a new instance of GetSessionHandle
+   * @see org.tensorflow.op.core.GetSessionHandle
    */
-  public <T extends TType> Merge<T> merge(Iterable<Operand<T>> inputs) {
-    return Merge.create(scope, inputs);
+  public <T extends TType> GetSessionHandle getSessionHandle(Operand<T> value) {
+    return GetSessionHandle.create(scope, value);
+  }
+
+  /**
+   * Builds an {@link GetSessionTensor} operation
+   *
+   * @param handle The handle for a tensor stored in the session state.
+   * @param dtype The type of the output value.
+   * @return a new instance of GetSessionTensor
+   * @see org.tensorflow.op.core.GetSessionTensor
+   */
+  public <T extends TType> GetSessionTensor<T> getSessionTensor(Operand<TString> handle,
+      DataType<T> dtype) {
+    return GetSessionTensor.create(scope, handle, dtype);
+  }
+
+  /**
+   * Builds an {@link Gradients} operation
+   *
+   * @param y output of the function to derive
+   * @param x inputs of the function for which partial derivatives are computed
+   * @param options carries optional attributes values
+   * @return a new instance of {@code Gradients}
+   * @throws IllegalArgumentException if execution environment is not a graph
+   * @see org.tensorflow.op.core.Gradients
+   */
+  public Gradients gradients(Operand<?> y, Iterable<? extends Operand<?>> x,
+      Gradients.Options... options) {
+    return Gradients.create(scope, y, x, options);
   }
 
   /**
@@ -1880,195 +1493,107 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link NoOp} operation
-   *
-   * @return a new instance of NoOp
-   * @see org.tensorflow.op.core.NoOp
-   */
-  public NoOp noOp() {
-    return NoOp.create(scope);
-  }
-
-  /**
-   * Builds an {@link Tile} operation
-   *
-   * @param input 1-D or higher.
-   * @param multiples 1-D. Length must be the same as the number of dimensions in `input`
-   * @return a new instance of Tile
-   * @see org.tensorflow.op.core.Tile
-   */
-  public <T extends TType, U extends TNumber> Tile<T> tile(Operand<T> input, Operand<U> multiples) {
-    return Tile.create(scope, input, multiples);
-  }
-
-  /**
-   * Builds an {@link Select} operation
-   *
-   * @param condition 
-   * @param t 
-   * @param e 
-   * @return a new instance of Select
-   * @see org.tensorflow.op.core.Select
-   */
-  public <T extends TType> Select<T> select(Operand<TBool> condition, Operand<T> t, Operand<T> e) {
-    return Select.create(scope, condition, t, e);
-  }
-
-  /**
-   * Builds an {@link TensorListLength} operation
-   *
-   * @param inputHandle 
-   * @return a new instance of TensorListLength
-   * @see org.tensorflow.op.core.TensorListLength
-   */
-  public TensorListLength tensorListLength(Operand<?> inputHandle) {
-    return TensorListLength.create(scope, inputHandle);
-  }
-
-  /**
-   * Builds an {@link OrderedMapClear} operation
-   *
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of OrderedMapClear
-   * @see org.tensorflow.op.core.OrderedMapClear
-   */
-  public OrderedMapClear orderedMapClear(List<DataType<?>> dtypes,
-      OrderedMapClear.Options... options) {
-    return OrderedMapClear.create(scope, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link Skipgram} operation
-   *
-   * @param filename The corpus's text file name.
-   * @param batchSize The size of produced batch.
-   * @param options carries optional attributes values
-   * @return a new instance of Skipgram
-   * @see org.tensorflow.op.core.Skipgram
-   */
-  public Skipgram skipgram(String filename, Long batchSize, Skipgram.Options... options) {
-    return Skipgram.create(scope, filename, batchSize, options);
-  }
-
-  /**
-   * Builds an {@link TensorArrayClose} operation
-   *
-   * @param handle The handle to a TensorArray (output of TensorArray or TensorArrayGrad).
-   * @return a new instance of TensorArrayClose
-   * @see org.tensorflow.op.core.TensorArrayClose
-   */
-  public TensorArrayClose tensorArrayClose(Operand<?> handle) {
-    return TensorArrayClose.create(scope, handle);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat32> constant(float[][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link TensorArrayUnpack} operation
-   *
-   * @param handle 
-   * @param value 
-   * @param flowIn 
-   * @return a new instance of TensorArrayUnpack
-   * @see org.tensorflow.op.core.TensorArrayUnpack
-   */
-  public <T extends TType> TensorArrayUnpack tensorArrayUnpack(Operand<TString> handle,
-      Operand<T> value, Operand<TFloat32> flowIn) {
-    return TensorArrayUnpack.create(scope, handle, value, flowIn);
-  }
-
-  /**
-   * Builds an {@link Size} operation
+   * Builds an {@link GuaranteeConst} operation
    *
    * @param input 
-   * @param outType 
-   * @return a new instance of Size
-   * @see org.tensorflow.op.core.Size
+   * @return a new instance of GuaranteeConst
+   * @see org.tensorflow.op.core.GuaranteeConst
    */
-  public <U extends TNumber, T extends TType> Size<U> size(Operand<T> input, DataType<U> outType) {
-    return Size.create(scope, input, outType);
+  public <T extends TType> GuaranteeConst<T> guaranteeConst(Operand<T> input) {
+    return GuaranteeConst.create(scope, input);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link HashTable} operation
    *
-   * @param data The value to put into the new constant. 
-   * @return a float constant
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat32> constant(float data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link TensorListStack} operation
-   *
-   * @param inputHandle 
-   * @param elementShape 
-   * @param elementDtype 
+   * @param keyDtype Type of the table keys.
+   * @param valueDtype Type of the table values.
    * @param options carries optional attributes values
-   * @return a new instance of TensorListStack
-   * @see org.tensorflow.op.core.TensorListStack
+   * @return a new instance of HashTable
+   * @see org.tensorflow.op.core.HashTable
    */
-  public <T extends TType> TensorListStack<T> tensorListStack(Operand<?> inputHandle,
-      Operand<TInt32> elementShape, DataType<T> elementDtype, TensorListStack.Options... options) {
-    return TensorListStack.create(scope, inputHandle, elementShape, elementDtype, options);
+  public <T extends TType, U extends TType> HashTable hashTable(DataType<T> keyDtype,
+      DataType<U> valueDtype, HashTable.Options... options) {
+    return HashTable.create(scope, keyDtype, valueDtype, options);
   }
 
   /**
-   * Builds an {@link EnsureShape} operation
+   * Builds an {@link HistogramFixedWidth} operation
    *
-   * @param input A tensor, whose shape is to be validated.
-   * @param shape The expected (possibly partially specified) shape of the input tensor.
-   * @return a new instance of EnsureShape
-   * @see org.tensorflow.op.core.EnsureShape
+   * @param values Numeric `Tensor`.
+   * @param valueRange Shape [2] `Tensor` of same `dtype` as `values`.
+   * @param nbins Scalar `int32 Tensor`.  Number of histogram bins.
+   * @return a new instance of HistogramFixedWidth
+   * @see org.tensorflow.op.core.HistogramFixedWidth
    */
-  public <T extends TType> EnsureShape<T> ensureShape(Operand<T> input, Shape shape) {
-    return EnsureShape.create(scope, input, shape);
+  public <T extends TNumber> HistogramFixedWidth<TInt32> histogramFixedWidth(Operand<T> values,
+      Operand<T> valueRange, Operand<TInt32> nbins) {
+    return HistogramFixedWidth.create(scope, values, valueRange, nbins);
   }
 
   /**
-   * Builds an {@link Print} operation
+   * Builds an {@link HistogramFixedWidth} operation
    *
-   * @param input The string scalar to print.
-   * @param options carries optional attributes values
-   * @return a new instance of Print
-   * @see org.tensorflow.op.core.Print
+   * @param values Numeric `Tensor`.
+   * @param valueRange Shape [2] `Tensor` of same `dtype` as `values`.
+   * @param nbins Scalar `int32 Tensor`.  Number of histogram bins.
+   * @param dtype 
+   * @return a new instance of HistogramFixedWidth
+   * @see org.tensorflow.op.core.HistogramFixedWidth
    */
-  public Print print(Operand<TString> input, Print.Options... options) {
-    return Print.create(scope, input, options);
+  public <U extends TNumber, T extends TNumber> HistogramFixedWidth<U> histogramFixedWidth(
+      Operand<T> values, Operand<T> valueRange, Operand<TInt32> nbins, DataType<U> dtype) {
+    return HistogramFixedWidth.create(scope, values, valueRange, nbins, dtype);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link Identity} operation
    *
-   * @param data The value to put into the new constant.
-   * @return a double constant
-   * @see org.tensorflow.op.core.Constant
+   * @param input 
+   * @return a new instance of Identity
+   * @see org.tensorflow.op.core.Identity
    */
-  public Constant<TFloat64> constant(double data) {
-    return Constant.create(scope, data);
+  public <T extends TType> Identity<T> identity(Operand<T> input) {
+    return Identity.create(scope, input);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link IdentityN} operation
    *
-   * @param object a Java object representing the constant.
-   * @return a constant of type `type`
-   * @see org.tensorflow.Tensor#create(Object) Tensor.create
-   * @see org.tensorflow.op.core.Constant
+   * @param input 
+   * @return a new instance of IdentityN
+   * @see org.tensorflow.op.core.IdentityN
    */
-  public <T extends TType> Constant<T> constant(Object object, DataType<T> type) {
-    return Constant.create(scope, object, type);
+  public IdentityN identityN(Iterable<Operand<?>> input) {
+    return IdentityN.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link ImmutableConst} operation
+   *
+   * @param dtype Type of the returned tensor.
+   * @param shape Shape of the returned tensor.
+   * @param memoryRegionName Name of readonly memory region used by the tensor, see
+   * @return a new instance of ImmutableConst
+   * @see org.tensorflow.op.core.ImmutableConst
+   */
+  public <T extends TType> ImmutableConst<T> immutableConst(DataType<T> dtype, Shape shape,
+      String memoryRegionName) {
+    return ImmutableConst.create(scope, dtype, shape, memoryRegionName);
+  }
+
+  /**
+   * Builds an {@link InitializeTable} operation
+   *
+   * @param tableHandle Handle to a table which will be initialized.
+   * @param keys Keys of type Tkey.
+   * @param values Values of type Tval.
+   * @return a new instance of InitializeTable
+   * @see org.tensorflow.op.core.InitializeTable
+   */
+  public <T extends TType, U extends TType> InitializeTable initializeTable(Operand<?> tableHandle,
+      Operand<T> keys, Operand<U> values) {
+    return InitializeTable.create(scope, tableHandle, keys, values);
   }
 
   /**
@@ -2102,534 +1627,55 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link Mutex} operation
+   * Builds an {@link InplaceSub} operation
    *
-   * @param options carries optional attributes values
-   * @return a new instance of Mutex
-   * @see org.tensorflow.op.core.Mutex
+   * @param x A `Tensor` of type T.
+   * @param i A vector. Indices into the left-most dimension of `x`.
+   * @param v A `Tensor` of type T. Same dimension sizes as x except the first dimension, which must be the same as i's size.
+   * @return a new instance of InplaceSub
+   * @see org.tensorflow.op.core.InplaceSub
    */
-  public Mutex mutex(Mutex.Options... options) {
-    return Mutex.create(scope, options);
+  public <T extends TType> InplaceSub<T> inplaceSub(Operand<T> x, Operand<TInt32> i, Operand<T> v) {
+    return InplaceSub.create(scope, x, i, v);
   }
 
   /**
-   * Builds an {@link ResourceScatterNdUpdate} operation
+   * Builds an {@link InplaceUpdate} operation
    *
-   * @param ref A resource handle. Must be from a VarHandleOp.
-   * @param indices A Tensor. Must be one of the following types: int32, int64.
-   * @param updates A Tensor. Must have the same type as ref. A tensor of updated
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceScatterNdUpdate
-   * @see org.tensorflow.op.core.ResourceScatterNdUpdate
+   * @param x A tensor of type `T`.
+   * @param i A vector. Indices into the left-most dimension of `x`.
+   * @param v A `Tensor` of type T. Same dimension sizes as x except the first dimension, which must be the same as i's size.
+   * @return a new instance of InplaceUpdate
+   * @see org.tensorflow.op.core.InplaceUpdate
    */
-  public <T extends TNumber, U extends TType> ResourceScatterNdUpdate resourceScatterNdUpdate(
-      Operand<?> ref, Operand<T> indices, Operand<U> updates,
-      ResourceScatterNdUpdate.Options... options) {
-    return ResourceScatterNdUpdate.create(scope, ref, indices, updates, options);
+  public <T extends TType> InplaceUpdate<T> inplaceUpdate(Operand<T> x, Operand<TInt32> i,
+      Operand<T> v) {
+    return InplaceUpdate.create(scope, x, i, v);
   }
 
   /**
-   * Builds an {@link ShapeN} operation
+   * Builds an {@link IsVariableInitialized} operation
    *
-   * @param input 
-   * @param outType 
-   * @return a new instance of ShapeN
-   * @see org.tensorflow.op.core.ShapeN
+   * @param ref Should be from a `Variable` node. May be uninitialized.
+   * @return a new instance of IsVariableInitialized
+   * @see org.tensorflow.op.core.IsVariableInitialized
    */
-  public <U extends TNumber, T extends TType> ShapeN<U> shapeN(Iterable<Operand<T>> input,
-      DataType<U> outType) {
-    return ShapeN.create(scope, input, outType);
+  public <T extends TType> IsVariableInitialized isVariableInitialized(Operand<T> ref) {
+    return IsVariableInitialized.create(scope, ref);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link LinSpace} operation
    *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
+   * @param start 0-D tensor. First entry in the range.
+   * @param stop 0-D tensor. Last entry in the range.
+   * @param num 0-D tensor. Number of values to generate.
+   * @return a new instance of LinSpace
+   * @see org.tensorflow.op.core.LinSpace
    */
-  public Constant<TFloat64> constant(double[][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link RemoteFusedGraphExecute} operation
-   *
-   * @param inputs Arbitrary number of tensors with arbitrary data types
-   * @param Toutputs 
-   * @param serializedRemoteFusedGraphExecuteInfo Serialized protocol buffer
-   * @return a new instance of RemoteFusedGraphExecute
-   * @see org.tensorflow.op.core.RemoteFusedGraphExecute
-   */
-  public RemoteFusedGraphExecute remoteFusedGraphExecute(Iterable<Operand<?>> inputs,
-      List<DataType<?>> Toutputs, String serializedRemoteFusedGraphExecuteInfo) {
-    return RemoteFusedGraphExecute.create(scope, inputs, Toutputs, serializedRemoteFusedGraphExecuteInfo);
-  }
-
-  /**
-   * Builds an {@link TensorStridedSliceUpdate} operation
-   *
-   * @param input 
-   * @param begin 
-   * @param end 
-   * @param strides 
-   * @param value 
-   * @param options carries optional attributes values
-   * @return a new instance of TensorStridedSliceUpdate
-   * @see org.tensorflow.op.core.TensorStridedSliceUpdate
-   */
-  public <T extends TType, U extends TNumber> TensorStridedSliceUpdate<T> tensorStridedSliceUpdate(
-      Operand<T> input, Operand<U> begin, Operand<U> end, Operand<U> strides, Operand<T> value,
-      TensorStridedSliceUpdate.Options... options) {
-    return TensorStridedSliceUpdate.create(scope, input, begin, end, strides, value, options);
-  }
-
-  /**
-   * Builds an {@link ScatterMax} operation
-   *
-   * @param ref Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to reduce into `ref`.
-   * @param options carries optional attributes values
-   * @return a new instance of ScatterMax
-   * @see org.tensorflow.op.core.ScatterMax
-   */
-  public <T extends TNumber, U extends TNumber> ScatterMax<T> scatterMax(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterMax.Options... options) {
-    return ScatterMax.create(scope, ref, indices, updates, options);
-  }
-
-  /**
-   * Builds an {@link UniqueWithCounts} operation
-   *
-   * @param x A `Tensor`.
-   * @param axis A `Tensor` of type `int32` (default: None). The axis of the Tensor to
-   * @return a new instance of UniqueWithCounts
-   * @see org.tensorflow.op.core.UniqueWithCounts
-   */
-  public <T extends TType, U extends TNumber> UniqueWithCounts<T, TInt32> uniqueWithCounts(
-      Operand<T> x, Operand<U> axis) {
-    return UniqueWithCounts.create(scope, x, axis);
-  }
-
-  /**
-   * Builds an {@link ScatterNdAdd} operation
-   *
-   * @param ref A mutable Tensor. Should be from a Variable node.
-   * @param indices A Tensor. Must be one of the following types: int32, int64.
-   * @param updates A Tensor. Must have the same type as ref. A tensor of updated values
-   * @param options carries optional attributes values
-   * @return a new instance of ScatterNdAdd
-   * @see org.tensorflow.op.core.ScatterNdAdd
-   */
-  public <T extends TType, U extends TNumber> ScatterNdAdd<T> scatterNdAdd(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterNdAdd.Options... options) {
-    return ScatterNdAdd.create(scope, ref, indices, updates, options);
-  }
-
-  /**
-   * Builds an {@link HistogramFixedWidth} operation
-   *
-   * @param values Numeric `Tensor`.
-   * @param valueRange Shape [2] `Tensor` of same `dtype` as `values`.
-   * @param nbins Scalar `int32 Tensor`.  Number of histogram bins.
-   * @param dtype 
-   * @return a new instance of HistogramFixedWidth
-   * @see org.tensorflow.op.core.HistogramFixedWidth
-   */
-  public <U extends TNumber, T extends TNumber> HistogramFixedWidth<U> histogramFixedWidth(
-      Operand<T> values, Operand<T> valueRange, Operand<TInt32> nbins, DataType<U> dtype) {
-    return HistogramFixedWidth.create(scope, values, valueRange, nbins, dtype);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data The value to put into the new constant.
-   * @return an integer constant
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt32> constant(int data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link Size} operation
-   *
-   * @param input 
-   * @return a new instance of Size
-   * @see org.tensorflow.op.core.Size
-   */
-  public <T extends TType> Size<TInt32> size(Operand<T> input) {
-    return Size.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link OrderedMapUnstageNoKey} operation
-   *
-   * @param indices 
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of OrderedMapUnstageNoKey
-   * @see org.tensorflow.op.core.OrderedMapUnstageNoKey
-   */
-  public OrderedMapUnstageNoKey orderedMapUnstageNoKey(Operand<TInt32> indices,
-      List<DataType<?>> dtypes, OrderedMapUnstageNoKey.Options... options) {
-    return OrderedMapUnstageNoKey.create(scope, indices, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link BroadcastDynamicShape} operation
-   *
-   * @param s0 
-   * @param s1 
-   * @return a new instance of BroadcastDynamicShape
-   * @see org.tensorflow.op.core.BroadcastDynamicShape
-   */
-  public <T extends TNumber> BroadcastDynamicShape<T> broadcastDynamicShape(Operand<T> s0,
-      Operand<T> s1) {
-    return BroadcastDynamicShape.create(scope, s0, s1);
-  }
-
-  /**
-   * Builds an {@link TensorArrayScatter} operation
-   *
-   * @param handle The handle to a TensorArray.
-   * @param indices The locations at which to write the tensor elements.
-   * @param value The concatenated tensor to write to the TensorArray.
-   * @param flowIn A float scalar that enforces proper chaining of operations.
-   * @return a new instance of TensorArrayScatter
-   * @see org.tensorflow.op.core.TensorArrayScatter
-   */
-  public <T extends TType> TensorArrayScatter tensorArrayScatter(Operand<?> handle,
-      Operand<TInt32> indices, Operand<T> value, Operand<TFloat32> flowIn) {
-    return TensorArrayScatter.create(scope, handle, indices, value, flowIn);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. String elements are
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TString> constant(byte[][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link TensorListScatterIntoExistingList} operation
-   *
-   * @param inputHandle 
-   * @param tensor 
-   * @param indices 
-   * @return a new instance of TensorListScatterIntoExistingList
-   * @see org.tensorflow.op.core.TensorListScatterIntoExistingList
-   */
-  public <T extends TType> TensorListScatterIntoExistingList tensorListScatterIntoExistingList(
-      Operand<?> inputHandle, Operand<T> tensor, Operand<TInt32> indices) {
-    return TensorListScatterIntoExistingList.create(scope, inputHandle, tensor, indices);
-  }
-
-  /**
-   * Builds an {@link Rpc} operation
-   *
-   * @param address `0-D` or `1-D`.  The address (i.e. host_name:port) of the RPC server.
-   * @param method `0-D` or `1-D`.  The method address on the RPC server.
-   * @param request `0-D` or `1-D`.  Serialized proto strings: the rpc request argument.
-   * @param options carries optional attributes values
-   * @return a new instance of Rpc
-   * @see org.tensorflow.op.core.Rpc
-   */
-  public Rpc rpc(Operand<TString> address, Operand<TString> method, Operand<TString> request,
-      Rpc.Options... options) {
-    return Rpc.create(scope, address, method, request, options);
-  }
-
-  /**
-   * Builds an {@link DestroyResourceOp} operation
-   *
-   * @param resource handle to the resource to delete.
-   * @param options carries optional attributes values
-   * @return a new instance of DestroyResourceOp
-   * @see org.tensorflow.op.core.DestroyResourceOp
-   */
-  public DestroyResourceOp destroyResourceOp(Operand<?> resource,
-      DestroyResourceOp.Options... options) {
-    return DestroyResourceOp.create(scope, resource, options);
-  }
-
-  /**
-   * Builds an {@link BarrierInsertMany} operation
-   *
-   * @param handle The handle to a barrier.
-   * @param keys A one-dimensional tensor of keys, with length n.
-   * @param values An any-dimensional tensor of values, which are associated with the
-   * @param componentIndex The component of the barrier elements that is being assigned.
-   * @return a new instance of BarrierInsertMany
-   * @see org.tensorflow.op.core.BarrierInsertMany
-   */
-  public <T extends TType> BarrierInsertMany barrierInsertMany(Operand<TString> handle,
-      Operand<TString> keys, Operand<T> values, Long componentIndex) {
-    return BarrierInsertMany.create(scope, handle, keys, values, componentIndex);
-  }
-
-  /**
-   * Builds an {@link Placeholder} operation
-   *
-   * @param dtype The type of elements in the tensor.
-   * @param options carries optional attributes values
-   * @return a new instance of Placeholder
-   * @see org.tensorflow.op.core.Placeholder
-   */
-  public <T extends TType> Placeholder<T> placeholder(DataType<T> dtype,
-      Placeholder.Options... options) {
-    return Placeholder.create(scope, dtype, options);
-  }
-
-  /**
-   * Builds an {@link ConsumeMutexLock} operation
-   *
-   * @param mutexLock A tensor returned by `MutexLock`.
-   * @return a new instance of ConsumeMutexLock
-   * @see org.tensorflow.op.core.ConsumeMutexLock
-   */
-  public ConsumeMutexLock consumeMutexLock(Operand<?> mutexLock) {
-    return ConsumeMutexLock.create(scope, mutexLock);
-  }
-
-  /**
-   * Builds an {@link MirrorPad} operation
-   *
-   * @param input The input tensor to be padded.
-   * @param paddings A two-column matrix specifying the padding sizes. The number of
-   * @param mode Either `REFLECT` or `SYMMETRIC`. In reflect mode the padded regions
-   * @return a new instance of MirrorPad
-   * @see org.tensorflow.op.core.MirrorPad
-   */
-  public <T extends TType, U extends TNumber> MirrorPad<T> mirrorPad(Operand<T> input,
-      Operand<U> paddings, String mode) {
-    return MirrorPad.create(scope, input, paddings, mode);
-  }
-
-  /**
-   * Builds an {@link ResourceScatterUpdate} operation
-   *
-   * @param resource Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to add to `ref`.
-   * @return a new instance of ResourceScatterUpdate
-   * @see org.tensorflow.op.core.ResourceScatterUpdate
-   */
-  public <T extends TNumber, U extends TType> ResourceScatterUpdate resourceScatterUpdate(
-      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
-    return ResourceScatterUpdate.create(scope, resource, indices, updates);
-  }
-
-  /**
-   * Builds an {@link MapSize} operation
-   *
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of MapSize
-   * @see org.tensorflow.op.core.MapSize
-   */
-  public MapSize mapSize(List<DataType<?>> dtypes, MapSize.Options... options) {
-    return MapSize.create(scope, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat32> constant(float[][][][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link ResourceScatterSub} operation
-   *
-   * @param resource Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to add to `ref`.
-   * @return a new instance of ResourceScatterSub
-   * @see org.tensorflow.op.core.ResourceScatterSub
-   */
-  public <T extends TNumber, U extends TType> ResourceScatterSub resourceScatterSub(
-      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
-    return ResourceScatterSub.create(scope, resource, indices, updates);
-  }
-
-  /**
-   * Builds an {@link VarHandleOp} operation
-   *
-   * @param dtype the type of this variable. Must agree with the dtypes
-   * @param shape The (possibly partially specified) shape of this variable.
-   * @param options carries optional attributes values
-   * @return a new instance of VarHandleOp
-   * @see org.tensorflow.op.core.VarHandleOp
-   */
-  public <T extends TType> VarHandleOp varHandleOp(DataType<T> dtype, Shape shape,
-      VarHandleOp.Options... options) {
-    return VarHandleOp.create(scope, dtype, shape, options);
-  }
-
-  /**
-   * Builds an {@link Squeeze} operation
-   *
-   * @param input The `input` to squeeze.
-   * @param options carries optional attributes values
-   * @return a new instance of Squeeze
-   * @see org.tensorflow.op.core.Squeeze
-   */
-  public <T extends TType> Squeeze<T> squeeze(Operand<T> input, Squeeze.Options... options) {
-    return Squeeze.create(scope, input, options);
-  }
-
-  /**
-   * Builds an {@link TensorListResize} operation
-   *
-   * @param inputHandle 
-   * @param size 
-   * @return a new instance of TensorListResize
-   * @see org.tensorflow.op.core.TensorListResize
-   */
-  public TensorListResize tensorListResize(Operand<?> inputHandle, Operand<TInt32> size) {
-    return TensorListResize.create(scope, inputHandle, size);
-  }
-
-  /**
-   * Builds an {@link OrderedMapUnstage} operation
-   *
-   * @param key 
-   * @param indices 
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of OrderedMapUnstage
-   * @see org.tensorflow.op.core.OrderedMapUnstage
-   */
-  public OrderedMapUnstage orderedMapUnstage(Operand<TInt64> key, Operand<TInt32> indices,
-      List<DataType<?>> dtypes, OrderedMapUnstage.Options... options) {
-    return OrderedMapUnstage.create(scope, key, indices, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link Abort} operation
-   *
-   * @param options carries optional attributes values
-   * @return a new instance of Abort
-   * @see org.tensorflow.op.core.Abort
-   */
-  public Abort abort(Abort.Options... options) {
-    return Abort.create(scope, options);
-  }
-
-  /**
-   * Builds an {@link Where} operation
-   *
-   * @param condition 
-   * @return a new instance of Where
-   * @see org.tensorflow.op.core.Where
-   */
-  public <T extends TType> Where where(Operand<T> condition) {
-    return Where.create(scope, condition);
-  }
-
-  /**
-   * Builds an {@link Shape} operation
-   *
-   * @param input 
-   * @return a new instance of Shape
-   * @see org.tensorflow.op.core.Shape
-   */
-  public <T extends TType> org.tensorflow.op.core.Shape<TInt32> shape(Operand<T> input) {
-    return org.tensorflow.op.core.Shape.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt64> constant(long[][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. String elements are
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TString> constant(byte[][][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link VarIsInitializedOp} operation
-   *
-   * @param resource the input resource handle.
-   * @return a new instance of VarIsInitializedOp
-   * @see org.tensorflow.op.core.VarIsInitializedOp
-   */
-  public VarIsInitializedOp varIsInitializedOp(Operand<?> resource) {
-    return VarIsInitializedOp.create(scope, resource);
-  }
-
-  /**
-   * Builds an {@link OrderedMapIncompleteSize} operation
-   *
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of OrderedMapIncompleteSize
-   * @see org.tensorflow.op.core.OrderedMapIncompleteSize
-   */
-  public OrderedMapIncompleteSize orderedMapIncompleteSize(List<DataType<?>> dtypes,
-      OrderedMapIncompleteSize.Options... options) {
-    return OrderedMapIncompleteSize.create(scope, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link TensorListElementShape} operation
-   *
-   * @param inputHandle 
-   * @param shapeType 
-   * @return a new instance of TensorListElementShape
-   * @see org.tensorflow.op.core.TensorListElementShape
-   */
-  public <T extends TNumber> TensorListElementShape<T> tensorListElementShape(
-      Operand<?> inputHandle, DataType<T> shapeType) {
-    return TensorListElementShape.create(scope, inputHandle, shapeType);
-  }
-
-  /**
-   * Builds an {@link ResourceScatterMax} operation
-   *
-   * @param resource Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to add to `ref`.
-   * @return a new instance of ResourceScatterMax
-   * @see org.tensorflow.op.core.ResourceScatterMax
-   */
-  public <T extends TNumber, U extends TType> ResourceScatterMax resourceScatterMax(
-      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
-    return ResourceScatterMax.create(scope, resource, indices, updates);
-  }
-
-  /**
-   * Builds an {@link QuantizedReshape} operation
-   *
-   * @param tensor 
-   * @param shape Defines the shape of the output tensor.
-   * @param inputMin The minimum value of the input.
-   * @param inputMax The maximum value of the input.
-   * @return a new instance of QuantizedReshape
-   * @see org.tensorflow.op.core.QuantizedReshape
-   */
-  public <T extends TType, U extends TNumber> QuantizedReshape<T> quantizedReshape(
-      Operand<T> tensor, Operand<U> shape, Operand<TFloat32> inputMin, Operand<TFloat32> inputMax) {
-    return QuantizedReshape.create(scope, tensor, shape, inputMin, inputMax);
+  public <T extends TNumber, U extends TNumber> LinSpace<T> linSpace(Operand<T> start,
+      Operand<T> stop, Operand<U> num) {
+    return LinSpace.create(scope, start, stop, num);
   }
 
   /**
@@ -2647,108 +1693,119 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link LookupTableFind} operation
    *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
+   * @param tableHandle Handle to the table.
+   * @param keys Any shape.  Keys to look up.
+   * @param defaultValue 
+   * @return a new instance of LookupTableFind
+   * @see org.tensorflow.op.core.LookupTableFind
    */
-  public Constant<TFloat32> constant(float[][][][][] data) {
-    return Constant.create(scope, data);
+  public <U extends TType, T extends TType> LookupTableFind<U> lookupTableFind(
+      Operand<?> tableHandle, Operand<T> keys, Operand<U> defaultValue) {
+    return LookupTableFind.create(scope, tableHandle, keys, defaultValue);
   }
 
   /**
-   * Builds an {@link UniqueWithCounts} operation
+   * Builds an {@link LookupTableImport} operation
    *
-   * @param x A `Tensor`.
-   * @param axis A `Tensor` of type `int32` (default: None). The axis of the Tensor to
-   * @param outIdx 
-   * @return a new instance of UniqueWithCounts
-   * @see org.tensorflow.op.core.UniqueWithCounts
+   * @param tableHandle Handle to the table.
+   * @param keys Any shape.  Keys to look up.
+   * @param values Values to associate with keys.
+   * @return a new instance of LookupTableImport
+   * @see org.tensorflow.op.core.LookupTableImport
    */
-  public <T extends TType, V extends TNumber, U extends TNumber> UniqueWithCounts<T, V> uniqueWithCounts(
-      Operand<T> x, Operand<U> axis, DataType<V> outIdx) {
-    return UniqueWithCounts.create(scope, x, axis, outIdx);
+  public <T extends TType, U extends TType> LookupTableImport lookupTableImport(
+      Operand<?> tableHandle, Operand<T> keys, Operand<U> values) {
+    return LookupTableImport.create(scope, tableHandle, keys, values);
   }
 
   /**
-   * Builds an {@link HashTable} operation
+   * Builds an {@link LookupTableInsert} operation
    *
-   * @param keyDtype Type of the table keys.
-   * @param valueDtype Type of the table values.
-   * @param options carries optional attributes values
-   * @return a new instance of HashTable
-   * @see org.tensorflow.op.core.HashTable
+   * @param tableHandle Handle to the table.
+   * @param keys Any shape.  Keys to look up.
+   * @param values Values to associate with keys.
+   * @return a new instance of LookupTableInsert
+   * @see org.tensorflow.op.core.LookupTableInsert
    */
-  public <T extends TType, U extends TType> HashTable hashTable(DataType<T> keyDtype,
-      DataType<U> valueDtype, HashTable.Options... options) {
-    return HashTable.create(scope, keyDtype, valueDtype, options);
+  public <T extends TType, U extends TType> LookupTableInsert lookupTableInsert(
+      Operand<?> tableHandle, Operand<T> keys, Operand<U> values) {
+    return LookupTableInsert.create(scope, tableHandle, keys, values);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link LookupTableSize} operation
    *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
+   * @param tableHandle Handle to the table.
+   * @return a new instance of LookupTableSize
+   * @see org.tensorflow.op.core.LookupTableSize
    */
-  public Constant<TFloat64> constant(double[] data) {
-    return Constant.create(scope, data);
+  public LookupTableSize lookupTableSize(Operand<?> tableHandle) {
+    return LookupTableSize.create(scope, tableHandle);
   }
 
   /**
-   * Builds an {@link Assign} operation
+   * Builds an {@link LoopCond} operation
    *
-   * @param ref Should be from a `Variable` node. May be uninitialized.
-   * @param value The value to be assigned to the variable.
-   * @param options carries optional attributes values
-   * @return a new instance of Assign
-   * @see org.tensorflow.op.core.Assign
+   * @param input A boolean scalar, representing the branch predicate of the Switch op.
+   * @return a new instance of LoopCond
+   * @see org.tensorflow.op.core.LoopCond
    */
-  public <T extends TType> Assign<T> assign(Operand<T> ref, Operand<T> value,
-      Assign.Options... options) {
-    return Assign.create(scope, ref, value, options);
+  public LoopCond loopCond(Operand<TBool> input) {
+    return LoopCond.create(scope, input);
   }
 
   /**
-   * Builds an {@link Zeros} operation
+   * Builds an {@link MapClear} operation
    *
-   * @param dims a 1-D operand that represents the shape of the output tensor
-   * @param type the output tensor datatype
-   * @return a constant tensor initialized with zeros
-   * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with zeros.
-   * @see org.tensorflow.op.core.Zeros
-   */
-  public <T extends TType, U extends TNumber> Zeros<T> zeros(Operand<U> dims, DataType<T> type) {
-    return Zeros.create(scope, dims, type);
-  }
-
-  /**
-   * Builds an {@link OrderedMapStage} operation
-   *
-   * @param key int64
-   * @param indices 
-   * @param values a list of tensors
    * @param dtypes 
    * @param options carries optional attributes values
-   * @return a new instance of OrderedMapStage
-   * @see org.tensorflow.op.core.OrderedMapStage
+   * @return a new instance of MapClear
+   * @see org.tensorflow.op.core.MapClear
    */
-  public OrderedMapStage orderedMapStage(Operand<TInt64> key, Operand<TInt32> indices,
-      Iterable<Operand<?>> values, List<DataType<?>> dtypes, OrderedMapStage.Options... options) {
-    return OrderedMapStage.create(scope, key, indices, values, dtypes, options);
+  public MapClear mapClear(List<DataType<?>> dtypes, MapClear.Options... options) {
+    return MapClear.create(scope, dtypes, options);
   }
 
   /**
-   * Builds an {@link ResourceScatterMin} operation
+   * Builds an {@link MapIncompleteSize} operation
    *
-   * @param resource Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to add to `ref`.
-   * @return a new instance of ResourceScatterMin
-   * @see org.tensorflow.op.core.ResourceScatterMin
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of MapIncompleteSize
+   * @see org.tensorflow.op.core.MapIncompleteSize
    */
-  public <T extends TNumber, U extends TType> ResourceScatterMin resourceScatterMin(
-      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
-    return ResourceScatterMin.create(scope, resource, indices, updates);
+  public MapIncompleteSize mapIncompleteSize(List<DataType<?>> dtypes,
+      MapIncompleteSize.Options... options) {
+    return MapIncompleteSize.create(scope, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link MapPeek} operation
+   *
+   * @param key 
+   * @param indices 
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of MapPeek
+   * @see org.tensorflow.op.core.MapPeek
+   */
+  public MapPeek mapPeek(Operand<TInt64> key, Operand<TInt32> indices, List<DataType<?>> dtypes,
+      MapPeek.Options... options) {
+    return MapPeek.create(scope, key, indices, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link MapSize} operation
+   *
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of MapSize
+   * @see org.tensorflow.op.core.MapSize
+   */
+  public MapSize mapSize(List<DataType<?>> dtypes, MapSize.Options... options) {
+    return MapSize.create(scope, dtypes, options);
   }
 
   /**
@@ -2768,245 +1825,6 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat32> constant(float[][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link ResourceStridedSliceAssign} operation
-   *
-   * @param ref 
-   * @param begin 
-   * @param end 
-   * @param strides 
-   * @param value 
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceStridedSliceAssign
-   * @see org.tensorflow.op.core.ResourceStridedSliceAssign
-   */
-  public <T extends TNumber, U extends TType> ResourceStridedSliceAssign resourceStridedSliceAssign(
-      Operand<?> ref, Operand<T> begin, Operand<T> end, Operand<T> strides, Operand<U> value,
-      ResourceStridedSliceAssign.Options... options) {
-    return ResourceStridedSliceAssign.create(scope, ref, begin, end, strides, value, options);
-  }
-
-  /**
-   * Builds an {@link Fingerprint} operation
-   *
-   * @param data Must have rank 1 or higher.
-   * @param method Fingerprint method used by this op. Currently available method is
-   * @return a new instance of Fingerprint
-   * @see org.tensorflow.op.core.Fingerprint
-   */
-  public <T extends TType> Fingerprint fingerprint(Operand<T> data, Operand<TString> method) {
-    return Fingerprint.create(scope, data, method);
-  }
-
-  /**
-   * Builds an {@link ExpandDims} operation
-   *
-   * @param input 
-   * @param axis 0-D (scalar). Specifies the dimension index at which to
-   * @return a new instance of ExpandDims
-   * @see org.tensorflow.op.core.ExpandDims
-   */
-  public <T extends TType, U extends TNumber> ExpandDims<T> expandDims(Operand<T> input,
-      Operand<U> axis) {
-    return ExpandDims.create(scope, input, axis);
-  }
-
-  /**
-   * Builds an {@link TensorArraySize} operation
-   *
-   * @param handle The handle to a TensorArray (output of TensorArray or TensorArrayGrad).
-   * @param flowIn A float scalar that enforces proper chaining of operations.
-   * @return a new instance of TensorArraySize
-   * @see org.tensorflow.op.core.TensorArraySize
-   */
-  public TensorArraySize tensorArraySize(Operand<?> handle, Operand<TFloat32> flowIn) {
-    return TensorArraySize.create(scope, handle, flowIn);
-  }
-
-  /**
-   * Builds an {@link GuaranteeConst} operation
-   *
-   * @param input 
-   * @return a new instance of GuaranteeConst
-   * @see org.tensorflow.op.core.GuaranteeConst
-   */
-  public <T extends TType> GuaranteeConst<T> guaranteeConst(Operand<T> input) {
-    return GuaranteeConst.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Reshape} operation
-   *
-   * @param tensor 
-   * @param shape Defines the shape of the output tensor.
-   * @return a new instance of Reshape
-   * @see org.tensorflow.op.core.Reshape
-   */
-  public <T extends TType, U extends TNumber> Reshape<T> reshape(Operand<T> tensor,
-      Operand<U> shape) {
-    return Reshape.create(scope, tensor, shape);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat64> constant(double[][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link DynamicPartition} operation
-   *
-   * @param data 
-   * @param partitions Any shape.  Indices in the range `[0, num_partitions)`.
-   * @param numPartitions The number of partitions to output.
-   * @return a new instance of DynamicPartition
-   * @see org.tensorflow.op.core.DynamicPartition
-   */
-  public <T extends TType> DynamicPartition<T> dynamicPartition(Operand<T> data,
-      Operand<TInt32> partitions, Long numPartitions) {
-    return DynamicPartition.create(scope, data, partitions, numPartitions);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param tensor a Tensor holding the constant value
-   * @return a constant of the same data type as `tensor`
-   * @see org.tensorflow.op.core.Constant
-   */
-  public <T extends TType> Constant<T> constant(Tensor<T> tensor) {
-    return Constant.create(scope, tensor);
-  }
-
-  /**
-   * Builds an {@link LookupTableImport} operation
-   *
-   * @param tableHandle Handle to the table.
-   * @param keys Any shape.  Keys to look up.
-   * @param values Values to associate with keys.
-   * @return a new instance of LookupTableImport
-   * @see org.tensorflow.op.core.LookupTableImport
-   */
-  public <T extends TType, U extends TType> LookupTableImport lookupTableImport(
-      Operand<?> tableHandle, Operand<T> keys, Operand<U> values) {
-    return LookupTableImport.create(scope, tableHandle, keys, values);
-  }
-
-  /**
-   * Builds an {@link TensorArrayRead} operation
-   *
-   * @param handle The handle to a TensorArray.
-   * @param index 
-   * @param flowIn A float scalar that enforces proper chaining of operations.
-   * @param dtype The type of the elem that is returned.
-   * @return a new instance of TensorArrayRead
-   * @see org.tensorflow.op.core.TensorArrayRead
-   */
-  public <T extends TType> TensorArrayRead<T> tensorArrayRead(Operand<?> handle,
-      Operand<TInt32> index, Operand<TFloat32> flowIn, DataType<T> dtype) {
-    return TensorArrayRead.create(scope, handle, index, flowIn, dtype);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt32> constant(int[][][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param shape the tensor shape.
-   * @param data a buffer containing the tensor data.
-   * @return an integer constant
-   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt32> constant(long[] shape, IntBuffer data) {
-    return Constant.create(scope, shape, data);
-  }
-
-  /**
-   * Builds an {@link TensorArrayGradWithShape} operation
-   *
-   * @param handle The handle to the forward TensorArray.
-   * @param flowIn A float scalar that enforces proper chaining of operations.
-   * @param shapeToPrepend An int32 vector representing a shape. Elements in the gradient accumulator will
-   * @param source The gradient source string, used to decide which gradient TensorArray
-   * @return a new instance of TensorArrayGradWithShape
-   * @see org.tensorflow.op.core.TensorArrayGradWithShape
-   */
-  public TensorArrayGradWithShape tensorArrayGradWithShape(Operand<?> handle,
-      Operand<TFloat32> flowIn, Operand<TInt32> shapeToPrepend, String source) {
-    return TensorArrayGradWithShape.create(scope, handle, flowIn, shapeToPrepend, source);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt64> constant(long[][][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link SetDiff1d} operation
-   *
-   * @param x 1-D. Values to keep.
-   * @param y 1-D. Values to remove.
-   * @param outIdx 
-   * @return a new instance of SetDiff1d
-   * @see org.tensorflow.op.core.SetDiff1d
-   */
-  public <T extends TType, U extends TNumber> SetDiff1d<T, U> setDiff1d(Operand<T> x, Operand<T> y,
-      DataType<U> outIdx) {
-    return SetDiff1d.create(scope, x, y, outIdx);
-  }
-
-  /**
-   * Builds an {@link HistogramFixedWidth} operation
-   *
-   * @param values Numeric `Tensor`.
-   * @param valueRange Shape [2] `Tensor` of same `dtype` as `values`.
-   * @param nbins Scalar `int32 Tensor`.  Number of histogram bins.
-   * @return a new instance of HistogramFixedWidth
-   * @see org.tensorflow.op.core.HistogramFixedWidth
-   */
-  public <T extends TNumber> HistogramFixedWidth<TInt32> histogramFixedWidth(Operand<T> values,
-      Operand<T> valueRange, Operand<TInt32> nbins) {
-    return HistogramFixedWidth.create(scope, values, valueRange, nbins);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TBool> constant(boolean[][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
    * Builds an {@link MapUnstage} operation
    *
    * @param key 
@@ -3022,124 +1840,444 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link VariableShape} operation
+   * Builds an {@link MapUnstageNoKey} operation
+   *
+   * @param indices 
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of MapUnstageNoKey
+   * @see org.tensorflow.op.core.MapUnstageNoKey
+   */
+  public MapUnstageNoKey mapUnstageNoKey(Operand<TInt32> indices, List<DataType<?>> dtypes,
+      MapUnstageNoKey.Options... options) {
+    return MapUnstageNoKey.create(scope, indices, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link Max} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of Max
+   * @see org.tensorflow.op.core.Max
+   */
+  public <T extends TType, U extends TNumber> Max<T> max(Operand<T> input, Operand<U> axis,
+      Max.Options... options) {
+    return Max.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link Merge} operation
+   *
+   * @param inputs The input tensors, exactly one of which will become available.
+   * @return a new instance of Merge
+   * @see org.tensorflow.op.core.Merge
+   */
+  public <T extends TType> Merge<T> merge(Iterable<Operand<T>> inputs) {
+    return Merge.create(scope, inputs);
+  }
+
+  /**
+   * Builds an {@link Min} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of Min
+   * @see org.tensorflow.op.core.Min
+   */
+  public <T extends TType, U extends TNumber> Min<T> min(Operand<T> input, Operand<U> axis,
+      Min.Options... options) {
+    return Min.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link MirrorPad} operation
+   *
+   * @param input The input tensor to be padded.
+   * @param paddings A two-column matrix specifying the padding sizes. The number of
+   * @param mode Either `REFLECT` or `SYMMETRIC`. In reflect mode the padded regions
+   * @return a new instance of MirrorPad
+   * @see org.tensorflow.op.core.MirrorPad
+   */
+  public <T extends TType, U extends TNumber> MirrorPad<T> mirrorPad(Operand<T> input,
+      Operand<U> paddings, String mode) {
+    return MirrorPad.create(scope, input, paddings, mode);
+  }
+
+  /**
+   * Builds an {@link MlirPassthroughOp} operation
+   *
+   * @param inputs 
+   * @param mlirModule 
+   * @param Toutputs 
+   * @return a new instance of MlirPassthroughOp
+   * @see org.tensorflow.op.core.MlirPassthroughOp
+   */
+  public MlirPassthroughOp mlirPassthroughOp(Iterable<Operand<?>> inputs, String mlirModule,
+      List<DataType<?>> Toutputs) {
+    return MlirPassthroughOp.create(scope, inputs, mlirModule, Toutputs);
+  }
+
+  /**
+   * Builds an {@link MutableDenseHashTable} operation
+   *
+   * @param emptyKey The key used to represent empty key buckets internally. Must not
+   * @param deletedKey 
+   * @param valueDtype Type of the table values.
+   * @param options carries optional attributes values
+   * @return a new instance of MutableDenseHashTable
+   * @see org.tensorflow.op.core.MutableDenseHashTable
+   */
+  public <T extends TType, U extends TType> MutableDenseHashTable mutableDenseHashTable(
+      Operand<T> emptyKey, Operand<T> deletedKey, DataType<U> valueDtype,
+      MutableDenseHashTable.Options... options) {
+    return MutableDenseHashTable.create(scope, emptyKey, deletedKey, valueDtype, options);
+  }
+
+  /**
+   * Builds an {@link MutableHashTable} operation
+   *
+   * @param keyDtype Type of the table keys.
+   * @param valueDtype Type of the table values.
+   * @param options carries optional attributes values
+   * @return a new instance of MutableHashTable
+   * @see org.tensorflow.op.core.MutableHashTable
+   */
+  public <T extends TType, U extends TType> MutableHashTable mutableHashTable(DataType<T> keyDtype,
+      DataType<U> valueDtype, MutableHashTable.Options... options) {
+    return MutableHashTable.create(scope, keyDtype, valueDtype, options);
+  }
+
+  /**
+   * Builds an {@link MutableHashTableOfTensors} operation
+   *
+   * @param keyDtype Type of the table keys.
+   * @param valueDtype Type of the table values.
+   * @param options carries optional attributes values
+   * @return a new instance of MutableHashTableOfTensors
+   * @see org.tensorflow.op.core.MutableHashTableOfTensors
+   */
+  public <T extends TType, U extends TType> MutableHashTableOfTensors mutableHashTableOfTensors(
+      DataType<T> keyDtype, DataType<U> valueDtype, MutableHashTableOfTensors.Options... options) {
+    return MutableHashTableOfTensors.create(scope, keyDtype, valueDtype, options);
+  }
+
+  /**
+   * Builds an {@link Mutex} operation
+   *
+   * @param options carries optional attributes values
+   * @return a new instance of Mutex
+   * @see org.tensorflow.op.core.Mutex
+   */
+  public Mutex mutex(Mutex.Options... options) {
+    return Mutex.create(scope, options);
+  }
+
+  /**
+   * Builds an {@link MutexLock} operation
+   *
+   * @param mutex The mutex resource to lock.
+   * @return a new instance of MutexLock
+   * @see org.tensorflow.op.core.MutexLock
+   */
+  public MutexLock mutexLock(Operand<?> mutex) {
+    return MutexLock.create(scope, mutex);
+  }
+
+  /**
+   * Builds an {@link NextIteration} operation
+   *
+   * @param data The tensor to be made available to the next iteration.
+   * @return a new instance of NextIteration
+   * @see org.tensorflow.op.core.NextIteration
+   */
+  public <T extends TType> NextIteration<T> nextIteration(Operand<T> data) {
+    return NextIteration.create(scope, data);
+  }
+
+  /**
+   * Builds an {@link NoOp} operation
+   *
+   * @return a new instance of NoOp
+   * @see org.tensorflow.op.core.NoOp
+   */
+  public NoOp noOp() {
+    return NoOp.create(scope);
+  }
+
+  /**
+   * Builds an {@link OneHot} operation
+   *
+   * @param indices A tensor of indices.
+   * @param depth A scalar defining the depth of the one hot dimension.
+   * @param onValue A scalar defining the value to fill in output when `indices[j] = i`.
+   * @param offValue A scalar defining the value to fill in output when `indices[j] != i`.
+   * @param options carries optional attributes values
+   * @return a new instance of OneHot
+   * @see org.tensorflow.op.core.OneHot
+   */
+  public <U extends TType, T extends TNumber> OneHot<U> oneHot(Operand<T> indices,
+      Operand<TInt32> depth, Operand<U> onValue, Operand<U> offValue, OneHot.Options... options) {
+    return OneHot.create(scope, indices, depth, onValue, offValue, options);
+  }
+
+  /**
+   * Builds an {@link OnesLike} operation
+   *
+   * @param x a tensor of type T.
+   * @return a new instance of OnesLike
+   * @see org.tensorflow.op.core.OnesLike
+   */
+  public <T extends TType> OnesLike<T> onesLike(Operand<T> x) {
+    return OnesLike.create(scope, x);
+  }
+
+  /**
+   * Builds an {@link OrderedMapClear} operation
+   *
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of OrderedMapClear
+   * @see org.tensorflow.op.core.OrderedMapClear
+   */
+  public OrderedMapClear orderedMapClear(List<DataType<?>> dtypes,
+      OrderedMapClear.Options... options) {
+    return OrderedMapClear.create(scope, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link OrderedMapIncompleteSize} operation
+   *
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of OrderedMapIncompleteSize
+   * @see org.tensorflow.op.core.OrderedMapIncompleteSize
+   */
+  public OrderedMapIncompleteSize orderedMapIncompleteSize(List<DataType<?>> dtypes,
+      OrderedMapIncompleteSize.Options... options) {
+    return OrderedMapIncompleteSize.create(scope, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link OrderedMapPeek} operation
+   *
+   * @param key 
+   * @param indices 
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of OrderedMapPeek
+   * @see org.tensorflow.op.core.OrderedMapPeek
+   */
+  public OrderedMapPeek orderedMapPeek(Operand<TInt64> key, Operand<TInt32> indices,
+      List<DataType<?>> dtypes, OrderedMapPeek.Options... options) {
+    return OrderedMapPeek.create(scope, key, indices, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link OrderedMapSize} operation
+   *
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of OrderedMapSize
+   * @see org.tensorflow.op.core.OrderedMapSize
+   */
+  public OrderedMapSize orderedMapSize(List<DataType<?>> dtypes,
+      OrderedMapSize.Options... options) {
+    return OrderedMapSize.create(scope, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link OrderedMapStage} operation
+   *
+   * @param key int64
+   * @param indices 
+   * @param values a list of tensors
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of OrderedMapStage
+   * @see org.tensorflow.op.core.OrderedMapStage
+   */
+  public OrderedMapStage orderedMapStage(Operand<TInt64> key, Operand<TInt32> indices,
+      Iterable<Operand<?>> values, List<DataType<?>> dtypes, OrderedMapStage.Options... options) {
+    return OrderedMapStage.create(scope, key, indices, values, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link OrderedMapUnstage} operation
+   *
+   * @param key 
+   * @param indices 
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of OrderedMapUnstage
+   * @see org.tensorflow.op.core.OrderedMapUnstage
+   */
+  public OrderedMapUnstage orderedMapUnstage(Operand<TInt64> key, Operand<TInt32> indices,
+      List<DataType<?>> dtypes, OrderedMapUnstage.Options... options) {
+    return OrderedMapUnstage.create(scope, key, indices, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link OrderedMapUnstageNoKey} operation
+   *
+   * @param indices 
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of OrderedMapUnstageNoKey
+   * @see org.tensorflow.op.core.OrderedMapUnstageNoKey
+   */
+  public OrderedMapUnstageNoKey orderedMapUnstageNoKey(Operand<TInt32> indices,
+      List<DataType<?>> dtypes, OrderedMapUnstageNoKey.Options... options) {
+    return OrderedMapUnstageNoKey.create(scope, indices, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link Pad} operation
    *
    * @param input 
-   * @param outType 
-   * @return a new instance of VariableShape
-   * @see org.tensorflow.op.core.VariableShape
+   * @param paddings 
+   * @param constantValues 
+   * @return a new instance of Pad
+   * @see org.tensorflow.op.core.Pad
    */
-  public <T extends TNumber> VariableShape<T> variableShape(Operand<?> input, DataType<T> outType) {
-    return VariableShape.create(scope, input, outType);
+  public <T extends TType, U extends TNumber> Pad<T> pad(Operand<T> input, Operand<U> paddings,
+      Operand<T> constantValues) {
+    return Pad.create(scope, input, paddings, constantValues);
   }
 
   /**
-   * Builds an {@link ScatterNd} operation
+   * Builds an {@link ParallelConcat} operation
    *
-   * @param indices Index tensor.
-   * @param updates Updates to scatter into output.
-   * @param shape 1-D. The shape of the resulting tensor.
-   * @return a new instance of ScatterNd
-   * @see org.tensorflow.op.core.ScatterNd
+   * @param values Tensors to be concatenated. All must have size 1 in the first dimension
+   * @param shape the final shape of the result; should be equal to the shapes of any input
+   * @return a new instance of ParallelConcat
+   * @see org.tensorflow.op.core.ParallelConcat
    */
-  public <U extends TType, T extends TNumber> ScatterNd<U> scatterNd(Operand<T> indices,
-      Operand<U> updates, Operand<T> shape) {
-    return ScatterNd.create(scope, indices, updates, shape);
+  public <T extends TType> ParallelConcat<T> parallelConcat(Iterable<Operand<T>> values,
+      Shape shape) {
+    return ParallelConcat.create(scope, values, shape);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link ParallelDynamicStitch} operation
    *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
+   * @param indices 
+   * @param data 
+   * @return a new instance of ParallelDynamicStitch
+   * @see org.tensorflow.op.core.ParallelDynamicStitch
    */
-  public Constant<TFloat32> constant(float[] data) {
-    return Constant.create(scope, data);
+  public <T extends TType> ParallelDynamicStitch<T> parallelDynamicStitch(
+      Iterable<Operand<TInt32>> indices, Iterable<Operand<T>> data) {
+    return ParallelDynamicStitch.create(scope, indices, data);
   }
 
   /**
-   * Builds an {@link ScatterSub} operation
+   * Builds an {@link Placeholder} operation
    *
-   * @param ref Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to subtract from `ref`.
+   * @param dtype The type of elements in the tensor.
    * @param options carries optional attributes values
-   * @return a new instance of ScatterSub
-   * @see org.tensorflow.op.core.ScatterSub
+   * @return a new instance of Placeholder
+   * @see org.tensorflow.op.core.Placeholder
    */
-  public <T extends TType, U extends TNumber> ScatterSub<T> scatterSub(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterSub.Options... options) {
-    return ScatterSub.create(scope, ref, indices, updates, options);
+  public <T extends TType> Placeholder<T> placeholder(DataType<T> dtype,
+      Placeholder.Options... options) {
+    return Placeholder.create(scope, dtype, options);
   }
 
   /**
-   * Builds an {@link BarrierClose} operation
+   * Builds an {@link PlaceholderWithDefault} operation
    *
-   * @param handle The handle to a barrier.
+   * @param input The default value to produce when `output` is not fed.
+   * @param shape The (possibly partial) shape of the tensor.
+   * @return a new instance of PlaceholderWithDefault
+   * @see org.tensorflow.op.core.PlaceholderWithDefault
+   */
+  public <T extends TType> PlaceholderWithDefault<T> placeholderWithDefault(Operand<T> input,
+      Shape shape) {
+    return PlaceholderWithDefault.create(scope, input, shape);
+  }
+
+  /**
+   * Builds an {@link Print} operation
+   *
+   * @param input The string scalar to print.
    * @param options carries optional attributes values
-   * @return a new instance of BarrierClose
-   * @see org.tensorflow.op.core.BarrierClose
+   * @return a new instance of Print
+   * @see org.tensorflow.op.core.Print
    */
-  public BarrierClose barrierClose(Operand<TString> handle, BarrierClose.Options... options) {
-    return BarrierClose.create(scope, handle, options);
+  public Print print(Operand<TString> input, Print.Options... options) {
+    return Print.create(scope, input, options);
   }
 
   /**
-   * Builds an {@link UnbatchGrad} operation
+   * Builds an {@link Prod} operation
    *
-   * @param originalInput 
-   * @param batchIndex 
-   * @param grad 
-   * @param id 
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
    * @param options carries optional attributes values
-   * @return a new instance of UnbatchGrad
-   * @see org.tensorflow.op.core.UnbatchGrad
+   * @return a new instance of Prod
+   * @see org.tensorflow.op.core.Prod
    */
-  public <T extends TType> UnbatchGrad<T> unbatchGrad(Operand<T> originalInput,
-      Operand<TInt64> batchIndex, Operand<T> grad, Operand<TInt64> id,
-      UnbatchGrad.Options... options) {
-    return UnbatchGrad.create(scope, originalInput, batchIndex, grad, id, options);
+  public <T extends TType, U extends TNumber> Prod<T> prod(Operand<T> input, Operand<U> axis,
+      Prod.Options... options) {
+    return Prod.create(scope, input, axis, options);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link QuantizedConcat} operation
    *
-   * @param type the tensor datatype.
-   * @param shape the tensor shape.
-   * @param data a buffer containing the tensor data.
-   * @return a constant of type `type`
-   * @throws IllegalArgumentException If the tensor datatype or shape is not compatible with the
-   * @see org.tensorflow.op.core.Constant
+   * @param concatDim 0-D.  The dimension along which to concatenate.  Must be in the
+   * @param values The `N` Tensors to concatenate. Their ranks and types must match,
+   * @param inputMins The minimum scalar values for each of the input tensors.
+   * @param inputMaxes The maximum scalar values for each of the input tensors.
+   * @return a new instance of QuantizedConcat
+   * @see org.tensorflow.op.core.QuantizedConcat
    */
-  public <T extends TType> Constant<T> constant(DataType<T> type, long[] shape, ByteBuffer data) {
-    return Constant.create(scope, type, shape, data);
+  public <T extends TType> QuantizedConcat<T> quantizedConcat(Operand<TInt32> concatDim,
+      Iterable<Operand<T>> values, Iterable<Operand<TFloat32>> inputMins,
+      Iterable<Operand<TFloat32>> inputMaxes) {
+    return QuantizedConcat.create(scope, concatDim, values, inputMins, inputMaxes);
   }
 
   /**
-   * Builds an {@link IdentityN} operation
+   * Builds an {@link QuantizedReshape} operation
+   *
+   * @param tensor 
+   * @param shape Defines the shape of the output tensor.
+   * @param inputMin The minimum value of the input.
+   * @param inputMax The maximum value of the input.
+   * @return a new instance of QuantizedReshape
+   * @see org.tensorflow.op.core.QuantizedReshape
+   */
+  public <T extends TType, U extends TNumber> QuantizedReshape<T> quantizedReshape(
+      Operand<T> tensor, Operand<U> shape, Operand<TFloat32> inputMin, Operand<TFloat32> inputMax) {
+    return QuantizedReshape.create(scope, tensor, shape, inputMin, inputMax);
+  }
+
+  /**
+   * Builds an {@link Range} operation
+   *
+   * @param start 0-D (scalar). First entry in the sequence.
+   * @param limit 0-D (scalar). Upper limit of sequence, exclusive.
+   * @param delta 0-D (scalar). Optional. Default is 1. Number that increments `start`.
+   * @return a new instance of Range
+   * @see org.tensorflow.op.core.Range
+   */
+  public <T extends TNumber> Range<T> range(Operand<T> start, Operand<T> limit, Operand<T> delta) {
+    return Range.create(scope, start, limit, delta);
+  }
+
+  /**
+   * Builds an {@link Rank} operation
    *
    * @param input 
-   * @return a new instance of IdentityN
-   * @see org.tensorflow.op.core.IdentityN
+   * @return a new instance of Rank
+   * @see org.tensorflow.op.core.Rank
    */
-  public IdentityN identityN(Iterable<Operand<?>> input) {
-    return IdentityN.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link StridedSlice} operation
-   *
-   * @param input 
-   * @param begin `begin[k]` specifies the offset into the `k`th range specification.
-   * @param end `end[i]` is like `begin` with the exception that `end_mask` is
-   * @param strides `strides[i]` specifies the increment in the `i`th specification
-   * @param options carries optional attributes values
-   * @return a new instance of StridedSlice
-   * @see org.tensorflow.op.core.StridedSlice
-   */
-  public <T extends TType, U extends TNumber> StridedSlice<T> stridedSlice(Operand<T> input,
-      Operand<U> begin, Operand<U> end, Operand<U> strides, StridedSlice.Options... options) {
-    return StridedSlice.create(scope, input, begin, end, strides, options);
+  public <T extends TType> Rank rank(Operand<T> input) {
+    return Rank.create(scope, input);
   }
 
   /**
@@ -3153,6 +2291,90 @@ public final class Ops {
   public <T extends TType> ReadVariableOp<T> readVariableOp(Operand<?> resource,
       DataType<T> dtype) {
     return ReadVariableOp.create(scope, resource, dtype);
+  }
+
+  /**
+   * Builds an {@link ReduceAll} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of ReduceAll
+   * @see org.tensorflow.op.core.ReduceAll
+   */
+  public <T extends TNumber> ReduceAll reduceAll(Operand<TBool> input, Operand<T> axis,
+      ReduceAll.Options... options) {
+    return ReduceAll.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link ReduceAny} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of ReduceAny
+   * @see org.tensorflow.op.core.ReduceAny
+   */
+  public <T extends TNumber> ReduceAny reduceAny(Operand<TBool> input, Operand<T> axis,
+      ReduceAny.Options... options) {
+    return ReduceAny.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link ReduceMax} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of ReduceMax
+   * @see org.tensorflow.op.core.ReduceMax
+   */
+  public <T extends TType, U extends TNumber> ReduceMax<T> reduceMax(Operand<T> input,
+      Operand<U> axis, ReduceMax.Options... options) {
+    return ReduceMax.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link ReduceMin} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of ReduceMin
+   * @see org.tensorflow.op.core.ReduceMin
+   */
+  public <T extends TType, U extends TNumber> ReduceMin<T> reduceMin(Operand<T> input,
+      Operand<U> axis, ReduceMin.Options... options) {
+    return ReduceMin.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link ReduceProd} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of ReduceProd
+   * @see org.tensorflow.op.core.ReduceProd
+   */
+  public <T extends TType, U extends TNumber> ReduceProd<T> reduceProd(Operand<T> input,
+      Operand<U> axis, ReduceProd.Options... options) {
+    return ReduceProd.create(scope, input, axis, options);
+  }
+
+  /**
+   * Builds an {@link ReduceSum} operation
+   *
+   * @param input The tensor to reduce.
+   * @param axis The dimensions to reduce. Must be in the range
+   * @param options carries optional attributes values
+   * @return a new instance of ReduceSum
+   * @see org.tensorflow.op.core.ReduceSum
+   */
+  public <T extends TType, U extends TNumber> ReduceSum<T> reduceSum(Operand<T> input,
+      Operand<U> axis, ReduceSum.Options... options) {
+    return ReduceSum.create(scope, input, axis, options);
   }
 
   /**
@@ -3180,97 +2402,277 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link ScatterNdSub} operation
+   * Builds an {@link RefSwitch} operation
    *
-   * @param ref A mutable Tensor. Should be from a Variable node.
-   * @param indices A Tensor. Must be one of the following types: int32, int64.
-   * @param updates A Tensor. Must have the same type as ref. A tensor of updated values
+   * @param data The ref tensor to be forwarded to the appropriate output.
+   * @param pred A scalar that specifies which output port will receive data.
+   * @return a new instance of RefSwitch
+   * @see org.tensorflow.op.core.RefSwitch
+   */
+  public <T extends TType> RefSwitch<T> refSwitch(Operand<T> data, Operand<TBool> pred) {
+    return RefSwitch.create(scope, data, pred);
+  }
+
+  /**
+   * Builds an {@link RemoteFusedGraphExecute} operation
+   *
+   * @param inputs Arbitrary number of tensors with arbitrary data types
+   * @param Toutputs 
+   * @param serializedRemoteFusedGraphExecuteInfo Serialized protocol buffer
+   * @return a new instance of RemoteFusedGraphExecute
+   * @see org.tensorflow.op.core.RemoteFusedGraphExecute
+   */
+  public RemoteFusedGraphExecute remoteFusedGraphExecute(Iterable<Operand<?>> inputs,
+      List<DataType<?>> Toutputs, String serializedRemoteFusedGraphExecuteInfo) {
+    return RemoteFusedGraphExecute.create(scope, inputs, Toutputs, serializedRemoteFusedGraphExecuteInfo);
+  }
+
+  /**
+   * Builds an {@link Reshape} operation
+   *
+   * @param tensor 
+   * @param shape Defines the shape of the output tensor.
+   * @return a new instance of Reshape
+   * @see org.tensorflow.op.core.Reshape
+   */
+  public <T extends TType, U extends TNumber> Reshape<T> reshape(Operand<T> tensor,
+      Operand<U> shape) {
+    return Reshape.create(scope, tensor, shape);
+  }
+
+  /**
+   * Builds an {@link ResourceCountUpTo} operation
+   *
+   * @param resource Should be from a scalar `Variable` node.
+   * @param limit If incrementing ref would bring it above limit, instead generates an
+   * @param T 
+   * @return a new instance of ResourceCountUpTo
+   * @see org.tensorflow.op.core.ResourceCountUpTo
+   */
+  public <T extends TNumber> ResourceCountUpTo<T> resourceCountUpTo(Operand<?> resource, Long limit,
+      DataType<T> T) {
+    return ResourceCountUpTo.create(scope, resource, limit, T);
+  }
+
+  /**
+   * Builds an {@link ResourceGather} operation
+   *
+   * @param resource 
+   * @param indices 
+   * @param dtype 
    * @param options carries optional attributes values
-   * @return a new instance of ScatterNdSub
-   * @see org.tensorflow.op.core.ScatterNdSub
+   * @return a new instance of ResourceGather
+   * @see org.tensorflow.op.core.ResourceGather
    */
-  public <T extends TType, U extends TNumber> ScatterNdSub<T> scatterNdSub(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterNdSub.Options... options) {
-    return ScatterNdSub.create(scope, ref, indices, updates, options);
+  public <U extends TType, T extends TNumber> ResourceGather<U> resourceGather(Operand<?> resource,
+      Operand<T> indices, DataType<U> dtype, ResourceGather.Options... options) {
+    return ResourceGather.create(scope, resource, indices, dtype, options);
   }
 
   /**
-   * Builds an {@link TemporaryVariable} operation
+   * Builds an {@link ResourceGatherNd} operation
    *
-   * @param shape The shape of the variable tensor.
-   * @param dtype The type of elements in the variable tensor.
-   * @param options carries optional attributes values
-   * @return a new instance of TemporaryVariable
-   * @see org.tensorflow.op.core.TemporaryVariable
+   * @param resource 
+   * @param indices 
+   * @param dtype 
+   * @return a new instance of ResourceGatherNd
+   * @see org.tensorflow.op.core.ResourceGatherNd
    */
-  public <T extends TType> TemporaryVariable<T> temporaryVariable(Shape shape, DataType<T> dtype,
-      TemporaryVariable.Options... options) {
-    return TemporaryVariable.create(scope, shape, dtype, options);
+  public <U extends TType, T extends TNumber> ResourceGatherNd<U> resourceGatherNd(
+      Operand<?> resource, Operand<T> indices, DataType<U> dtype) {
+    return ResourceGatherNd.create(scope, resource, indices, dtype);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link ResourceScatterAdd} operation
    *
-   * @param shape the tensor shape.
-   * @param data a buffer containing the tensor data.
-   * @return a float constant
-   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat32> constant(long[] shape, FloatBuffer data) {
-    return Constant.create(scope, shape, data);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt32> constant(int[][][][][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link GetSessionTensor} operation
-   *
-   * @param handle The handle for a tensor stored in the session state.
-   * @param dtype The type of the output value.
-   * @return a new instance of GetSessionTensor
-   * @see org.tensorflow.op.core.GetSessionTensor
-   */
-  public <T extends TType> GetSessionTensor<T> getSessionTensor(Operand<TString> handle,
-      DataType<T> dtype) {
-    return GetSessionTensor.create(scope, handle, dtype);
-  }
-
-  /**
-   * Builds an {@link StagePeek} operation
-   *
-   * @param index 
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of StagePeek
-   * @see org.tensorflow.op.core.StagePeek
-   */
-  public StagePeek stagePeek(Operand<TInt32> index, List<DataType<?>> dtypes,
-      StagePeek.Options... options) {
-    return StagePeek.create(scope, index, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link ScatterUpdate} operation
-   *
-   * @param ref Should be from a `Variable` node.
+   * @param resource Should be from a `Variable` node.
    * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to store in `ref`.
-   * @param options carries optional attributes values
-   * @return a new instance of ScatterUpdate
-   * @see org.tensorflow.op.core.ScatterUpdate
+   * @param updates A tensor of updated values to add to `ref`.
+   * @return a new instance of ResourceScatterAdd
+   * @see org.tensorflow.op.core.ResourceScatterAdd
    */
-  public <T extends TType, U extends TNumber> ScatterUpdate<T> scatterUpdate(Operand<T> ref,
-      Operand<U> indices, Operand<T> updates, ScatterUpdate.Options... options) {
-    return ScatterUpdate.create(scope, ref, indices, updates, options);
+  public <T extends TNumber, U extends TType> ResourceScatterAdd resourceScatterAdd(
+      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
+    return ResourceScatterAdd.create(scope, resource, indices, updates);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterDiv} operation
+   *
+   * @param resource Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to add to `ref`.
+   * @return a new instance of ResourceScatterDiv
+   * @see org.tensorflow.op.core.ResourceScatterDiv
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterDiv resourceScatterDiv(
+      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
+    return ResourceScatterDiv.create(scope, resource, indices, updates);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterMax} operation
+   *
+   * @param resource Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to add to `ref`.
+   * @return a new instance of ResourceScatterMax
+   * @see org.tensorflow.op.core.ResourceScatterMax
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterMax resourceScatterMax(
+      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
+    return ResourceScatterMax.create(scope, resource, indices, updates);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterMin} operation
+   *
+   * @param resource Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to add to `ref`.
+   * @return a new instance of ResourceScatterMin
+   * @see org.tensorflow.op.core.ResourceScatterMin
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterMin resourceScatterMin(
+      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
+    return ResourceScatterMin.create(scope, resource, indices, updates);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterMul} operation
+   *
+   * @param resource Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to add to `ref`.
+   * @return a new instance of ResourceScatterMul
+   * @see org.tensorflow.op.core.ResourceScatterMul
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterMul resourceScatterMul(
+      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
+    return ResourceScatterMul.create(scope, resource, indices, updates);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterNdAdd} operation
+   *
+   * @param ref A resource handle. Must be from a VarHandleOp.
+   * @param indices A Tensor. Must be one of the following types: int32, int64.
+   * @param updates A Tensor. Must have the same type as ref. A tensor of
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceScatterNdAdd
+   * @see org.tensorflow.op.core.ResourceScatterNdAdd
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterNdAdd resourceScatterNdAdd(
+      Operand<?> ref, Operand<T> indices, Operand<U> updates,
+      ResourceScatterNdAdd.Options... options) {
+    return ResourceScatterNdAdd.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterNdSub} operation
+   *
+   * @param ref A resource handle. Must be from a VarHandleOp.
+   * @param indices A Tensor. Must be one of the following types: int32, int64.
+   * @param updates A Tensor. Must have the same type as ref. A tensor of
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceScatterNdSub
+   * @see org.tensorflow.op.core.ResourceScatterNdSub
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterNdSub resourceScatterNdSub(
+      Operand<?> ref, Operand<T> indices, Operand<U> updates,
+      ResourceScatterNdSub.Options... options) {
+    return ResourceScatterNdSub.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterNdUpdate} operation
+   *
+   * @param ref A resource handle. Must be from a VarHandleOp.
+   * @param indices A Tensor. Must be one of the following types: int32, int64.
+   * @param updates A Tensor. Must have the same type as ref. A tensor of updated
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceScatterNdUpdate
+   * @see org.tensorflow.op.core.ResourceScatterNdUpdate
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterNdUpdate resourceScatterNdUpdate(
+      Operand<?> ref, Operand<T> indices, Operand<U> updates,
+      ResourceScatterNdUpdate.Options... options) {
+    return ResourceScatterNdUpdate.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterSub} operation
+   *
+   * @param resource Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to add to `ref`.
+   * @return a new instance of ResourceScatterSub
+   * @see org.tensorflow.op.core.ResourceScatterSub
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterSub resourceScatterSub(
+      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
+    return ResourceScatterSub.create(scope, resource, indices, updates);
+  }
+
+  /**
+   * Builds an {@link ResourceScatterUpdate} operation
+   *
+   * @param resource Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to add to `ref`.
+   * @return a new instance of ResourceScatterUpdate
+   * @see org.tensorflow.op.core.ResourceScatterUpdate
+   */
+  public <T extends TNumber, U extends TType> ResourceScatterUpdate resourceScatterUpdate(
+      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
+    return ResourceScatterUpdate.create(scope, resource, indices, updates);
+  }
+
+  /**
+   * Builds an {@link ResourceStridedSliceAssign} operation
+   *
+   * @param ref 
+   * @param begin 
+   * @param end 
+   * @param strides 
+   * @param value 
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceStridedSliceAssign
+   * @see org.tensorflow.op.core.ResourceStridedSliceAssign
+   */
+  public <T extends TNumber, U extends TType> ResourceStridedSliceAssign resourceStridedSliceAssign(
+      Operand<?> ref, Operand<T> begin, Operand<T> end, Operand<T> strides, Operand<U> value,
+      ResourceStridedSliceAssign.Options... options) {
+    return ResourceStridedSliceAssign.create(scope, ref, begin, end, strides, value, options);
+  }
+
+  /**
+   * Builds an {@link Reverse} operation
+   *
+   * @param tensor Up to 8-D.
+   * @param axis 1-D. The indices of the dimensions to reverse. Must be in the range
+   * @return a new instance of Reverse
+   * @see org.tensorflow.op.core.Reverse
+   */
+  public <T extends TType, U extends TNumber> Reverse<T> reverse(Operand<T> tensor,
+      Operand<U> axis) {
+    return Reverse.create(scope, tensor, axis);
+  }
+
+  /**
+   * Builds an {@link ReverseSequence} operation
+   *
+   * @param input The input to reverse.
+   * @param seqLengths 1-D with length `input.dims(batch_dim)` and
+   * @param seqDim The dimension which is partially reversed.
+   * @param options carries optional attributes values
+   * @return a new instance of ReverseSequence
+   * @see org.tensorflow.op.core.ReverseSequence
+   */
+  public <T extends TType, U extends TNumber> ReverseSequence<T> reverseSequence(Operand<T> input,
+      Operand<U> seqLengths, Long seqDim, ReverseSequence.Options... options) {
+    return ReverseSequence.create(scope, input, seqLengths, seqDim, options);
   }
 
   /**
@@ -3288,96 +2690,33 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link Bitcast} operation
+   * Builds an {@link Rpc} operation
    *
-   * @param input 
-   * @param type 
-   * @return a new instance of Bitcast
-   * @see org.tensorflow.op.core.Bitcast
-   */
-  public <U extends TType, T extends TType> Bitcast<U> bitcast(Operand<T> input, DataType<U> type) {
-    return Bitcast.create(scope, input, type);
-  }
-
-  /**
-   * Builds an {@link MapIncompleteSize} operation
-   *
-   * @param dtypes 
+   * @param address `0-D` or `1-D`.  The address (i.e. host_name:port) of the RPC server.
+   * @param method `0-D` or `1-D`.  The method address on the RPC server.
+   * @param request `0-D` or `1-D`.  Serialized proto strings: the rpc request argument.
    * @param options carries optional attributes values
-   * @return a new instance of MapIncompleteSize
-   * @see org.tensorflow.op.core.MapIncompleteSize
+   * @return a new instance of Rpc
+   * @see org.tensorflow.op.core.Rpc
    */
-  public MapIncompleteSize mapIncompleteSize(List<DataType<?>> dtypes,
-      MapIncompleteSize.Options... options) {
-    return MapIncompleteSize.create(scope, dtypes, options);
+  public Rpc rpc(Operand<TString> address, Operand<TString> method, Operand<TString> request,
+      Rpc.Options... options) {
+    return Rpc.create(scope, address, method, request, options);
   }
 
   /**
-   * Builds an {@link TensorListPopBack} operation
+   * Builds an {@link ScatterAdd} operation
    *
-   * @param inputHandle 
-   * @param elementShape 
-   * @param elementDtype 
-   * @return a new instance of TensorListPopBack
-   * @see org.tensorflow.op.core.TensorListPopBack
-   */
-  public <T extends TType> TensorListPopBack<T> tensorListPopBack(Operand<?> inputHandle,
-      Operand<TInt32> elementShape, DataType<T> elementDtype) {
-    return TensorListPopBack.create(scope, inputHandle, elementShape, elementDtype);
-  }
-
-  /**
-   * Builds an {@link MapUnstageNoKey} operation
-   *
-   * @param indices 
-   * @param dtypes 
+   * @param ref Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to add to `ref`.
    * @param options carries optional attributes values
-   * @return a new instance of MapUnstageNoKey
-   * @see org.tensorflow.op.core.MapUnstageNoKey
+   * @return a new instance of ScatterAdd
+   * @see org.tensorflow.op.core.ScatterAdd
    */
-  public MapUnstageNoKey mapUnstageNoKey(Operand<TInt32> indices, List<DataType<?>> dtypes,
-      MapUnstageNoKey.Options... options) {
-    return MapUnstageNoKey.create(scope, indices, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link ReduceMin} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of ReduceMin
-   * @see org.tensorflow.op.core.ReduceMin
-   */
-  public <T extends TType, U extends TNumber> ReduceMin<T> reduceMin(Operand<T> input,
-      Operand<U> axis, ReduceMin.Options... options) {
-    return ReduceMin.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link ExtractVolumePatches} operation
-   *
-   * @param input 5-D Tensor with shape `[batch, in_planes, in_rows, in_cols, depth]`.
-   * @param ksizes The size of the sliding window for each dimension of `input`.
-   * @param strides 1-D of length 5. How far the centers of two consecutive patches are in
-   * @param padding The type of padding algorithm to use.
-   * @return a new instance of ExtractVolumePatches
-   * @see org.tensorflow.op.core.ExtractVolumePatches
-   */
-  public <T extends TNumber> ExtractVolumePatches<T> extractVolumePatches(Operand<T> input,
-      List<Long> ksizes, List<Long> strides, String padding) {
-    return ExtractVolumePatches.create(scope, input, ksizes, strides, padding);
-  }
-
-  /**
-   * Builds an {@link Identity} operation
-   *
-   * @param input 
-   * @return a new instance of Identity
-   * @see org.tensorflow.op.core.Identity
-   */
-  public <T extends TType> Identity<T> identity(Operand<T> input) {
-    return Identity.create(scope, input);
+  public <T extends TType, U extends TNumber> ScatterAdd<T> scatterAdd(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterAdd.Options... options) {
+    return ScatterAdd.create(scope, ref, indices, updates, options);
   }
 
   /**
@@ -3396,17 +2735,475 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link ResourceScatterMul} operation
+   * Builds an {@link ScatterMax} operation
    *
-   * @param resource Should be from a `Variable` node.
+   * @param ref Should be from a `Variable` node.
    * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to add to `ref`.
-   * @return a new instance of ResourceScatterMul
-   * @see org.tensorflow.op.core.ResourceScatterMul
+   * @param updates A tensor of updated values to reduce into `ref`.
+   * @param options carries optional attributes values
+   * @return a new instance of ScatterMax
+   * @see org.tensorflow.op.core.ScatterMax
    */
-  public <T extends TNumber, U extends TType> ResourceScatterMul resourceScatterMul(
-      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
-    return ResourceScatterMul.create(scope, resource, indices, updates);
+  public <T extends TNumber, U extends TNumber> ScatterMax<T> scatterMax(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterMax.Options... options) {
+    return ScatterMax.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ScatterMin} operation
+   *
+   * @param ref Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to reduce into `ref`.
+   * @param options carries optional attributes values
+   * @return a new instance of ScatterMin
+   * @see org.tensorflow.op.core.ScatterMin
+   */
+  public <T extends TNumber, U extends TNumber> ScatterMin<T> scatterMin(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterMin.Options... options) {
+    return ScatterMin.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ScatterMul} operation
+   *
+   * @param ref Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to multiply to `ref`.
+   * @param options carries optional attributes values
+   * @return a new instance of ScatterMul
+   * @see org.tensorflow.op.core.ScatterMul
+   */
+  public <T extends TType, U extends TNumber> ScatterMul<T> scatterMul(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterMul.Options... options) {
+    return ScatterMul.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ScatterNd} operation
+   *
+   * @param indices Index tensor.
+   * @param updates Updates to scatter into output.
+   * @param shape 1-D. The shape of the resulting tensor.
+   * @return a new instance of ScatterNd
+   * @see org.tensorflow.op.core.ScatterNd
+   */
+  public <U extends TType, T extends TNumber> ScatterNd<U> scatterNd(Operand<T> indices,
+      Operand<U> updates, Operand<T> shape) {
+    return ScatterNd.create(scope, indices, updates, shape);
+  }
+
+  /**
+   * Builds an {@link ScatterNdAdd} operation
+   *
+   * @param ref A mutable Tensor. Should be from a Variable node.
+   * @param indices A Tensor. Must be one of the following types: int32, int64.
+   * @param updates A Tensor. Must have the same type as ref. A tensor of updated values
+   * @param options carries optional attributes values
+   * @return a new instance of ScatterNdAdd
+   * @see org.tensorflow.op.core.ScatterNdAdd
+   */
+  public <T extends TType, U extends TNumber> ScatterNdAdd<T> scatterNdAdd(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterNdAdd.Options... options) {
+    return ScatterNdAdd.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ScatterNdNonAliasingAdd} operation
+   *
+   * @param input A Tensor.
+   * @param indices A Tensor. Must be one of the following types: `int32`, `int64`.
+   * @param updates A Tensor. Must have the same type as ref. A tensor of updated values
+   * @return a new instance of ScatterNdNonAliasingAdd
+   * @see org.tensorflow.op.core.ScatterNdNonAliasingAdd
+   */
+  public <T extends TType, U extends TNumber> ScatterNdNonAliasingAdd<T> scatterNdNonAliasingAdd(
+      Operand<T> input, Operand<U> indices, Operand<T> updates) {
+    return ScatterNdNonAliasingAdd.create(scope, input, indices, updates);
+  }
+
+  /**
+   * Builds an {@link ScatterNdSub} operation
+   *
+   * @param ref A mutable Tensor. Should be from a Variable node.
+   * @param indices A Tensor. Must be one of the following types: int32, int64.
+   * @param updates A Tensor. Must have the same type as ref. A tensor of updated values
+   * @param options carries optional attributes values
+   * @return a new instance of ScatterNdSub
+   * @see org.tensorflow.op.core.ScatterNdSub
+   */
+  public <T extends TType, U extends TNumber> ScatterNdSub<T> scatterNdSub(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterNdSub.Options... options) {
+    return ScatterNdSub.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ScatterNdUpdate} operation
+   *
+   * @param ref A mutable Tensor. Should be from a Variable node.
+   * @param indices A Tensor. Must be one of the following types: int32, int64.
+   * @param updates A Tensor. Must have the same type as ref. A tensor of updated
+   * @param options carries optional attributes values
+   * @return a new instance of ScatterNdUpdate
+   * @see org.tensorflow.op.core.ScatterNdUpdate
+   */
+  public <T extends TType, U extends TNumber> ScatterNdUpdate<T> scatterNdUpdate(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterNdUpdate.Options... options) {
+    return ScatterNdUpdate.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ScatterSub} operation
+   *
+   * @param ref Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to subtract from `ref`.
+   * @param options carries optional attributes values
+   * @return a new instance of ScatterSub
+   * @see org.tensorflow.op.core.ScatterSub
+   */
+  public <T extends TType, U extends TNumber> ScatterSub<T> scatterSub(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterSub.Options... options) {
+    return ScatterSub.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link ScatterUpdate} operation
+   *
+   * @param ref Should be from a `Variable` node.
+   * @param indices A tensor of indices into the first dimension of `ref`.
+   * @param updates A tensor of updated values to store in `ref`.
+   * @param options carries optional attributes values
+   * @return a new instance of ScatterUpdate
+   * @see org.tensorflow.op.core.ScatterUpdate
+   */
+  public <T extends TType, U extends TNumber> ScatterUpdate<T> scatterUpdate(Operand<T> ref,
+      Operand<U> indices, Operand<T> updates, ScatterUpdate.Options... options) {
+    return ScatterUpdate.create(scope, ref, indices, updates, options);
+  }
+
+  /**
+   * Builds an {@link Select} operation
+   *
+   * @param condition 
+   * @param t 
+   * @param e 
+   * @return a new instance of Select
+   * @see org.tensorflow.op.core.Select
+   */
+  public <T extends TType> Select<T> select(Operand<TBool> condition, Operand<T> t, Operand<T> e) {
+    return Select.create(scope, condition, t, e);
+  }
+
+  /**
+   * Builds an {@link SetDiff1d} operation
+   *
+   * @param x 1-D. Values to keep.
+   * @param y 1-D. Values to remove.
+   * @return a new instance of SetDiff1d
+   * @see org.tensorflow.op.core.SetDiff1d
+   */
+  public <T extends TType> SetDiff1d<T, TInt32> setDiff1d(Operand<T> x, Operand<T> y) {
+    return SetDiff1d.create(scope, x, y);
+  }
+
+  /**
+   * Builds an {@link SetDiff1d} operation
+   *
+   * @param x 1-D. Values to keep.
+   * @param y 1-D. Values to remove.
+   * @param outIdx 
+   * @return a new instance of SetDiff1d
+   * @see org.tensorflow.op.core.SetDiff1d
+   */
+  public <T extends TType, U extends TNumber> SetDiff1d<T, U> setDiff1d(Operand<T> x, Operand<T> y,
+      DataType<U> outIdx) {
+    return SetDiff1d.create(scope, x, y, outIdx);
+  }
+
+  /**
+   * Builds an {@link SetSize} operation
+   *
+   * @param setIndices 2D `Tensor`, indices of a `SparseTensor`.
+   * @param setValues 1D `Tensor`, values of a `SparseTensor`.
+   * @param setShape 1D `Tensor`, shape of a `SparseTensor`.
+   * @param options carries optional attributes values
+   * @return a new instance of SetSize
+   * @see org.tensorflow.op.core.SetSize
+   */
+  public <T extends TType> SetSize setSize(Operand<TInt64> setIndices, Operand<T> setValues,
+      Operand<TInt64> setShape, SetSize.Options... options) {
+    return SetSize.create(scope, setIndices, setValues, setShape, options);
+  }
+
+  /**
+   * Builds an {@link Shape} operation
+   *
+   * @param input 
+   * @return a new instance of Shape
+   * @see org.tensorflow.op.core.Shape
+   */
+  public <T extends TType> org.tensorflow.op.core.Shape<TInt32> shape(Operand<T> input) {
+    return org.tensorflow.op.core.Shape.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Shape} operation
+   *
+   * @param input 
+   * @param outType 
+   * @return a new instance of Shape
+   * @see org.tensorflow.op.core.Shape
+   */
+  public <U extends TNumber, T extends TType> org.tensorflow.op.core.Shape<U> shape(
+      Operand<T> input, DataType<U> outType) {
+    return org.tensorflow.op.core.Shape.create(scope, input, outType);
+  }
+
+  /**
+   * Builds an {@link ShapeN} operation
+   *
+   * @param input 
+   * @return a new instance of ShapeN
+   * @see org.tensorflow.op.core.ShapeN
+   */
+  public <T extends TType> ShapeN<TInt32> shapeN(Iterable<Operand<T>> input) {
+    return ShapeN.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link ShapeN} operation
+   *
+   * @param input 
+   * @param outType 
+   * @return a new instance of ShapeN
+   * @see org.tensorflow.op.core.ShapeN
+   */
+  public <U extends TNumber, T extends TType> ShapeN<U> shapeN(Iterable<Operand<T>> input,
+      DataType<U> outType) {
+    return ShapeN.create(scope, input, outType);
+  }
+
+  /**
+   * Builds an {@link Size} operation
+   *
+   * @param input 
+   * @return a new instance of Size
+   * @see org.tensorflow.op.core.Size
+   */
+  public <T extends TType> Size<TInt32> size(Operand<T> input) {
+    return Size.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Size} operation
+   *
+   * @param input 
+   * @param outType 
+   * @return a new instance of Size
+   * @see org.tensorflow.op.core.Size
+   */
+  public <U extends TNumber, T extends TType> Size<U> size(Operand<T> input, DataType<U> outType) {
+    return Size.create(scope, input, outType);
+  }
+
+  /**
+   * Builds an {@link Skipgram} operation
+   *
+   * @param filename The corpus's text file name.
+   * @param batchSize The size of produced batch.
+   * @param options carries optional attributes values
+   * @return a new instance of Skipgram
+   * @see org.tensorflow.op.core.Skipgram
+   */
+  public Skipgram skipgram(String filename, Long batchSize, Skipgram.Options... options) {
+    return Skipgram.create(scope, filename, batchSize, options);
+  }
+
+  /**
+   * Builds an {@link Slice} operation
+   *
+   * @param input 
+   * @param begin begin[i] specifies the offset into the 'i'th dimension of
+   * @param size size[i] specifies the number of elements of the 'i'th dimension
+   * @return a new instance of Slice
+   * @see org.tensorflow.op.core.Slice
+   */
+  public <T extends TType, U extends TNumber> Slice<T> slice(Operand<T> input, Operand<U> begin,
+      Operand<U> size) {
+    return Slice.create(scope, input, begin, size);
+  }
+
+  /**
+   * Builds an {@link Snapshot} operation
+   *
+   * @param input 
+   * @return a new instance of Snapshot
+   * @see org.tensorflow.op.core.Snapshot
+   */
+  public <T extends TType> Snapshot<T> snapshot(Operand<T> input) {
+    return Snapshot.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link SpaceToBatchNd} operation
+   *
+   * @param input N-D with shape `input_shape = [batch] + spatial_shape + remaining_shape`,
+   * @param blockShape 1-D with shape `[M]`, all values must be >= 1.
+   * @param paddings 2-D with shape `[M, 2]`, all values must be >= 0.
+   * @return a new instance of SpaceToBatchNd
+   * @see org.tensorflow.op.core.SpaceToBatchNd
+   */
+  public <T extends TType, U extends TNumber, V extends TNumber> SpaceToBatchNd<T> spaceToBatchNd(
+      Operand<T> input, Operand<U> blockShape, Operand<V> paddings) {
+    return SpaceToBatchNd.create(scope, input, blockShape, paddings);
+  }
+
+  /**
+   * Builds an {@link Split} operation
+   *
+   * @param axis 0-D.  The dimension along which to split.  Must be in the range
+   * @param value The tensor to split.
+   * @param numSplit The number of ways to split.  Must evenly divide
+   * @return a new instance of Split
+   * @see org.tensorflow.op.core.Split
+   */
+  public <T extends TType> Split<T> split(Operand<TInt32> axis, Operand<T> value, Long numSplit) {
+    return Split.create(scope, axis, value, numSplit);
+  }
+
+  /**
+   * Builds an {@link SplitV} operation
+   *
+   * @param value The tensor to split.
+   * @param sizeSplits list containing the sizes of each output tensor along the split
+   * @param axis 0-D.  The dimension along which to split.  Must be in the range
+   * @param numSplit 
+   * @return a new instance of SplitV
+   * @see org.tensorflow.op.core.SplitV
+   */
+  public <T extends TType, U extends TNumber> SplitV<T> splitV(Operand<T> value,
+      Operand<U> sizeSplits, Operand<TInt32> axis, Long numSplit) {
+    return SplitV.create(scope, value, sizeSplits, axis, numSplit);
+  }
+
+  /**
+   * Builds an {@link Squeeze} operation
+   *
+   * @param input The `input` to squeeze.
+   * @param options carries optional attributes values
+   * @return a new instance of Squeeze
+   * @see org.tensorflow.op.core.Squeeze
+   */
+  public <T extends TType> Squeeze<T> squeeze(Operand<T> input, Squeeze.Options... options) {
+    return Squeeze.create(scope, input, options);
+  }
+
+  /**
+   * Builds an {@link Stack} operation
+   *
+   * @param values Must be of same shape and type.
+   * @param options carries optional attributes values
+   * @return a new instance of Stack
+   * @see org.tensorflow.op.core.Stack
+   */
+  public <T extends TType> Stack<T> stack(Iterable<Operand<T>> values, Stack.Options... options) {
+    return Stack.create(scope, values, options);
+  }
+
+  /**
+   * Builds an {@link Stage} operation
+   *
+   * @param values a list of tensors
+   * @param options carries optional attributes values
+   * @return a new instance of Stage
+   * @see org.tensorflow.op.core.Stage
+   */
+  public Stage stage(Iterable<Operand<?>> values, Stage.Options... options) {
+    return Stage.create(scope, values, options);
+  }
+
+  /**
+   * Builds an {@link StageClear} operation
+   *
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of StageClear
+   * @see org.tensorflow.op.core.StageClear
+   */
+  public StageClear stageClear(List<DataType<?>> dtypes, StageClear.Options... options) {
+    return StageClear.create(scope, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link StagePeek} operation
+   *
+   * @param index 
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of StagePeek
+   * @see org.tensorflow.op.core.StagePeek
+   */
+  public StagePeek stagePeek(Operand<TInt32> index, List<DataType<?>> dtypes,
+      StagePeek.Options... options) {
+    return StagePeek.create(scope, index, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link StageSize} operation
+   *
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of StageSize
+   * @see org.tensorflow.op.core.StageSize
+   */
+  public StageSize stageSize(List<DataType<?>> dtypes, StageSize.Options... options) {
+    return StageSize.create(scope, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link StopGradient} operation
+   *
+   * @param input 
+   * @return a new instance of StopGradient
+   * @see org.tensorflow.op.core.StopGradient
+   */
+  public <T extends TType> StopGradient<T> stopGradient(Operand<T> input) {
+    return StopGradient.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link StridedSlice} operation
+   *
+   * @param input 
+   * @param begin `begin[k]` specifies the offset into the `k`th range specification.
+   * @param end `end[i]` is like `begin` with the exception that `end_mask` is
+   * @param strides `strides[i]` specifies the increment in the `i`th specification
+   * @param options carries optional attributes values
+   * @return a new instance of StridedSlice
+   * @see org.tensorflow.op.core.StridedSlice
+   */
+  public <T extends TType, U extends TNumber> StridedSlice<T> stridedSlice(Operand<T> input,
+      Operand<U> begin, Operand<U> end, Operand<U> strides, StridedSlice.Options... options) {
+    return StridedSlice.create(scope, input, begin, end, strides, options);
+  }
+
+  /**
+   * Builds an {@link StridedSliceAssign} operation
+   *
+   * @param ref 
+   * @param begin 
+   * @param end 
+   * @param strides 
+   * @param value 
+   * @param options carries optional attributes values
+   * @return a new instance of StridedSliceAssign
+   * @see org.tensorflow.op.core.StridedSliceAssign
+   */
+  public <T extends TType, U extends TNumber> StridedSliceAssign<T> stridedSliceAssign(
+      Operand<T> ref, Operand<U> begin, Operand<U> end, Operand<U> strides, Operand<T> value,
+      StridedSliceAssign.Options... options) {
+    return StridedSliceAssign.create(scope, ref, begin, end, strides, value, options);
   }
 
   /**
@@ -3428,236 +3225,6 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link SpaceToBatchNd} operation
-   *
-   * @param input N-D with shape `input_shape = [batch] + spatial_shape + remaining_shape`,
-   * @param blockShape 1-D with shape `[M]`, all values must be >= 1.
-   * @param paddings 2-D with shape `[M, 2]`, all values must be >= 0.
-   * @return a new instance of SpaceToBatchNd
-   * @see org.tensorflow.op.core.SpaceToBatchNd
-   */
-  public <T extends TType, U extends TNumber, V extends TNumber> SpaceToBatchNd<T> spaceToBatchNd(
-      Operand<T> input, Operand<U> blockShape, Operand<V> paddings) {
-    return SpaceToBatchNd.create(scope, input, blockShape, paddings);
-  }
-
-  /**
-   * Builds an {@link TensorListGather} operation
-   *
-   * @param inputHandle 
-   * @param indices 
-   * @param elementShape 
-   * @param elementDtype 
-   * @return a new instance of TensorListGather
-   * @see org.tensorflow.op.core.TensorListGather
-   */
-  public <T extends TType> TensorListGather<T> tensorListGather(Operand<?> inputHandle,
-      Operand<TInt32> indices, Operand<TInt32> elementShape, DataType<T> elementDtype) {
-    return TensorListGather.create(scope, inputHandle, indices, elementShape, elementDtype);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt32> constant(int[][][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link EmptyTensorList} operation
-   *
-   * @param elementShape 
-   * @param maxNumElements 
-   * @param elementDtype 
-   * @return a new instance of EmptyTensorList
-   * @see org.tensorflow.op.core.EmptyTensorList
-   */
-  public <T extends TNumber, U extends TType> EmptyTensorList emptyTensorList(
-      Operand<T> elementShape, Operand<TInt32> maxNumElements, DataType<U> elementDtype) {
-    return EmptyTensorList.create(scope, elementShape, maxNumElements, elementDtype);
-  }
-
-  /**
-   * Builds an {@link Gather} operation
-   *
-   * @param params The tensor from which to gather values. Must be at least rank
-   * @param indices Index tensor. Must be in range `[0, params.shape[axis])`.
-   * @param axis The axis in `params` to gather `indices` from. Defaults to the first
-   * @param options carries optional attributes values
-   * @return a new instance of Gather
-   * @see org.tensorflow.op.core.Gather
-   */
-  public <T extends TType, U extends TNumber, V extends TNumber> Gather<T> gather(Operand<T> params,
-      Operand<U> indices, Operand<V> axis, Gather.Options... options) {
-    return Gather.create(scope, params, indices, axis, options);
-  }
-
-  /**
-   * Builds an {@link Variable} operation
-   *
-   * @param shape The shape of the variable tensor.
-   * @param dtype The type of elements in the variable tensor.
-   * @param options carries optional attributes values
-   * @return a new instance of Variable
-   * @see org.tensorflow.op.core.Variable
-   */
-  public <T extends TType> Variable<T> variable(Shape shape, DataType<T> dtype,
-      Variable.Options... options) {
-    return Variable.create(scope, shape, dtype, options);
-  }
-
-  /**
-   * Builds an {@link DeleteSessionTensor} operation
-   *
-   * @param handle The handle for a tensor stored in the session state.
-   * @return a new instance of DeleteSessionTensor
-   * @see org.tensorflow.op.core.DeleteSessionTensor
-   */
-  public DeleteSessionTensor deleteSessionTensor(Operand<TString> handle) {
-    return DeleteSessionTensor.create(scope, handle);
-  }
-
-  /**
-   * Builds an {@link TensorListPushBackBatch} operation
-   *
-   * @param inputHandles 
-   * @param tensor 
-   * @return a new instance of TensorListPushBackBatch
-   * @see org.tensorflow.op.core.TensorListPushBackBatch
-   */
-  public <T extends TType> TensorListPushBackBatch tensorListPushBackBatch(Operand<?> inputHandles,
-      Operand<T> tensor) {
-    return TensorListPushBackBatch.create(scope, inputHandles, tensor);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param shape the tensor shape.
-   * @param data a buffer containing the tensor data.
-   * @return a double constant
-   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TFloat64> constant(long[] shape, DoubleBuffer data) {
-    return Constant.create(scope, shape, data);
-  }
-
-  /**
-   * Builds an {@link TensorListSplit} operation
-   *
-   * @param tensor 
-   * @param elementShape 
-   * @param lengths 
-   * @return a new instance of TensorListSplit
-   * @see org.tensorflow.op.core.TensorListSplit
-   */
-  public <T extends TType, U extends TNumber> TensorListSplit tensorListSplit(Operand<T> tensor,
-      Operand<U> elementShape, Operand<TInt64> lengths) {
-    return TensorListSplit.create(scope, tensor, elementShape, lengths);
-  }
-
-  /**
-   * Builds an {@link TensorListFromTensor} operation
-   *
-   * @param tensor 
-   * @param elementShape 
-   * @return a new instance of TensorListFromTensor
-   * @see org.tensorflow.op.core.TensorListFromTensor
-   */
-  public <T extends TType, U extends TNumber> TensorListFromTensor tensorListFromTensor(
-      Operand<T> tensor, Operand<U> elementShape) {
-    return TensorListFromTensor.create(scope, tensor, elementShape);
-  }
-
-  /**
-   * Builds an {@link TensorScatterNdSub} operation
-   *
-   * @param tensor Tensor to copy/update.
-   * @param indices Index tensor.
-   * @param updates Updates to scatter into output.
-   * @return a new instance of TensorScatterNdSub
-   * @see org.tensorflow.op.core.TensorScatterNdSub
-   */
-  public <T extends TType, U extends TNumber> TensorScatterNdSub<T> tensorScatterNdSub(
-      Operand<T> tensor, Operand<U> indices, Operand<T> updates) {
-    return TensorScatterNdSub.create(scope, tensor, indices, updates);
-  }
-
-  /**
-   * Builds an {@link ImmutableConst} operation
-   *
-   * @param dtype Type of the returned tensor.
-   * @param shape Shape of the returned tensor.
-   * @param memoryRegionName Name of readonly memory region used by the tensor, see
-   * @return a new instance of ImmutableConst
-   * @see org.tensorflow.op.core.ImmutableConst
-   */
-  public <T extends TType> ImmutableConst<T> immutableConst(DataType<T> dtype, Shape shape,
-      String memoryRegionName) {
-    return ImmutableConst.create(scope, dtype, shape, memoryRegionName);
-  }
-
-  /**
-   * Builds an {@link Pad} operation
-   *
-   * @param input 
-   * @param paddings 
-   * @param constantValues 
-   * @return a new instance of Pad
-   * @see org.tensorflow.op.core.Pad
-   */
-  public <T extends TType, U extends TNumber> Pad<T> pad(Operand<T> input, Operand<U> paddings,
-      Operand<T> constantValues) {
-    return Pad.create(scope, input, paddings, constantValues);
-  }
-
-  /**
-   * Builds an {@link Range} operation
-   *
-   * @param start 0-D (scalar). First entry in the sequence.
-   * @param limit 0-D (scalar). Upper limit of sequence, exclusive.
-   * @param delta 0-D (scalar). Optional. Default is 1. Number that increments `start`.
-   * @return a new instance of Range
-   * @see org.tensorflow.op.core.Range
-   */
-  public <T extends TNumber> Range<T> range(Operand<T> start, Operand<T> limit, Operand<T> delta) {
-    return Range.create(scope, start, limit, delta);
-  }
-
-  /**
-   * Builds an {@link BarrierTakeMany} operation
-   *
-   * @param handle The handle to a barrier.
-   * @param numElements A single-element tensor containing the number of elements to
-   * @param componentTypes The type of each component in a value.
-   * @param options carries optional attributes values
-   * @return a new instance of BarrierTakeMany
-   * @see org.tensorflow.op.core.BarrierTakeMany
-   */
-  public BarrierTakeMany barrierTakeMany(Operand<TString> handle, Operand<TInt32> numElements,
-      List<DataType<?>> componentTypes, BarrierTakeMany.Options... options) {
-    return BarrierTakeMany.create(scope, handle, numElements, componentTypes, options);
-  }
-
-  /**
-   * Builds an {@link MlirPassthroughOp} operation
-   *
-   * @param inputs 
-   * @param mlirModule 
-   * @param Toutputs 
-   * @return a new instance of MlirPassthroughOp
-   * @see org.tensorflow.op.core.MlirPassthroughOp
-   */
-  public MlirPassthroughOp mlirPassthroughOp(Iterable<Operand<?>> inputs, String mlirModule,
-      List<DataType<?>> Toutputs) {
-    return MlirPassthroughOp.create(scope, inputs, mlirModule, Toutputs);
-  }
-
-  /**
    * Builds an {@link Sum} operation
    *
    * @param input The tensor to reduce.
@@ -3672,16 +3239,172 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link Shape} operation
+   * Builds an {@link SwitchCond} operation
    *
-   * @param input 
-   * @param outType 
-   * @return a new instance of Shape
-   * @see org.tensorflow.op.core.Shape
+   * @param data The tensor to be forwarded to the appropriate output.
+   * @param pred A scalar that specifies which output port will receive data.
+   * @return a new instance of SwitchCond
+   * @see org.tensorflow.op.core.SwitchCond
    */
-  public <U extends TNumber, T extends TType> org.tensorflow.op.core.Shape<U> shape(
-      Operand<T> input, DataType<U> outType) {
-    return org.tensorflow.op.core.Shape.create(scope, input, outType);
+  public <T extends TType> SwitchCond<T> switchCond(Operand<T> data, Operand<TBool> pred) {
+    return SwitchCond.create(scope, data, pred);
+  }
+
+  /**
+   * Builds an {@link TemporaryVariable} operation
+   *
+   * @param shape The shape of the variable tensor.
+   * @param dtype The type of elements in the variable tensor.
+   * @param options carries optional attributes values
+   * @return a new instance of TemporaryVariable
+   * @see org.tensorflow.op.core.TemporaryVariable
+   */
+  public <T extends TType> TemporaryVariable<T> temporaryVariable(Shape shape, DataType<T> dtype,
+      TemporaryVariable.Options... options) {
+    return TemporaryVariable.create(scope, shape, dtype, options);
+  }
+
+  /**
+   * Builds an {@link TensorArray} operation
+   *
+   * @param size The size of the array.
+   * @param dtype The type of the elements on the tensor_array.
+   * @param options carries optional attributes values
+   * @return a new instance of TensorArray
+   * @see org.tensorflow.op.core.TensorArray
+   */
+  public <T extends TType> TensorArray tensorArray(Operand<TInt32> size, DataType<T> dtype,
+      TensorArray.Options... options) {
+    return TensorArray.create(scope, size, dtype, options);
+  }
+
+  /**
+   * Builds an {@link TensorArrayClose} operation
+   *
+   * @param handle The handle to a TensorArray (output of TensorArray or TensorArrayGrad).
+   * @return a new instance of TensorArrayClose
+   * @see org.tensorflow.op.core.TensorArrayClose
+   */
+  public TensorArrayClose tensorArrayClose(Operand<?> handle) {
+    return TensorArrayClose.create(scope, handle);
+  }
+
+  /**
+   * Builds an {@link TensorArrayConcat} operation
+   *
+   * @param handle The handle to a TensorArray.
+   * @param flowIn A float scalar that enforces proper chaining of operations.
+   * @param dtype The type of the elem that is returned.
+   * @param options carries optional attributes values
+   * @return a new instance of TensorArrayConcat
+   * @see org.tensorflow.op.core.TensorArrayConcat
+   */
+  public <T extends TType> TensorArrayConcat<T> tensorArrayConcat(Operand<?> handle,
+      Operand<TFloat32> flowIn, DataType<T> dtype, TensorArrayConcat.Options... options) {
+    return TensorArrayConcat.create(scope, handle, flowIn, dtype, options);
+  }
+
+  /**
+   * Builds an {@link TensorArrayGather} operation
+   *
+   * @param handle The handle to a TensorArray.
+   * @param indices The locations in the TensorArray from which to read tensor elements.
+   * @param flowIn A float scalar that enforces proper chaining of operations.
+   * @param dtype The type of the elem that is returned.
+   * @param options carries optional attributes values
+   * @return a new instance of TensorArrayGather
+   * @see org.tensorflow.op.core.TensorArrayGather
+   */
+  public <T extends TType> TensorArrayGather<T> tensorArrayGather(Operand<?> handle,
+      Operand<TInt32> indices, Operand<TFloat32> flowIn, DataType<T> dtype,
+      TensorArrayGather.Options... options) {
+    return TensorArrayGather.create(scope, handle, indices, flowIn, dtype, options);
+  }
+
+  /**
+   * Builds an {@link TensorArrayGrad} operation
+   *
+   * @param handle The handle to the forward TensorArray.
+   * @param flowIn A float scalar that enforces proper chaining of operations.
+   * @param source The gradient source string, used to decide which gradient TensorArray
+   * @return a new instance of TensorArrayGrad
+   * @see org.tensorflow.op.core.TensorArrayGrad
+   */
+  public TensorArrayGrad tensorArrayGrad(Operand<?> handle, Operand<TFloat32> flowIn,
+      String source) {
+    return TensorArrayGrad.create(scope, handle, flowIn, source);
+  }
+
+  /**
+   * Builds an {@link TensorArrayGradWithShape} operation
+   *
+   * @param handle The handle to the forward TensorArray.
+   * @param flowIn A float scalar that enforces proper chaining of operations.
+   * @param shapeToPrepend An int32 vector representing a shape. Elements in the gradient accumulator will
+   * @param source The gradient source string, used to decide which gradient TensorArray
+   * @return a new instance of TensorArrayGradWithShape
+   * @see org.tensorflow.op.core.TensorArrayGradWithShape
+   */
+  public TensorArrayGradWithShape tensorArrayGradWithShape(Operand<?> handle,
+      Operand<TFloat32> flowIn, Operand<TInt32> shapeToPrepend, String source) {
+    return TensorArrayGradWithShape.create(scope, handle, flowIn, shapeToPrepend, source);
+  }
+
+  /**
+   * Builds an {@link TensorArrayPack} operation
+   *
+   * @param handle 
+   * @param flowIn 
+   * @param dtype 
+   * @param options carries optional attributes values
+   * @return a new instance of TensorArrayPack
+   * @see org.tensorflow.op.core.TensorArrayPack
+   */
+  public <T extends TType> TensorArrayPack<T> tensorArrayPack(Operand<TString> handle,
+      Operand<TFloat32> flowIn, DataType<T> dtype, TensorArrayPack.Options... options) {
+    return TensorArrayPack.create(scope, handle, flowIn, dtype, options);
+  }
+
+  /**
+   * Builds an {@link TensorArrayRead} operation
+   *
+   * @param handle The handle to a TensorArray.
+   * @param index 
+   * @param flowIn A float scalar that enforces proper chaining of operations.
+   * @param dtype The type of the elem that is returned.
+   * @return a new instance of TensorArrayRead
+   * @see org.tensorflow.op.core.TensorArrayRead
+   */
+  public <T extends TType> TensorArrayRead<T> tensorArrayRead(Operand<?> handle,
+      Operand<TInt32> index, Operand<TFloat32> flowIn, DataType<T> dtype) {
+    return TensorArrayRead.create(scope, handle, index, flowIn, dtype);
+  }
+
+  /**
+   * Builds an {@link TensorArrayScatter} operation
+   *
+   * @param handle The handle to a TensorArray.
+   * @param indices The locations at which to write the tensor elements.
+   * @param value The concatenated tensor to write to the TensorArray.
+   * @param flowIn A float scalar that enforces proper chaining of operations.
+   * @return a new instance of TensorArrayScatter
+   * @see org.tensorflow.op.core.TensorArrayScatter
+   */
+  public <T extends TType> TensorArrayScatter tensorArrayScatter(Operand<?> handle,
+      Operand<TInt32> indices, Operand<T> value, Operand<TFloat32> flowIn) {
+    return TensorArrayScatter.create(scope, handle, indices, value, flowIn);
+  }
+
+  /**
+   * Builds an {@link TensorArraySize} operation
+   *
+   * @param handle The handle to a TensorArray (output of TensorArray or TensorArrayGrad).
+   * @param flowIn A float scalar that enforces proper chaining of operations.
+   * @return a new instance of TensorArraySize
+   * @see org.tensorflow.op.core.TensorArraySize
+   */
+  public TensorArraySize tensorArraySize(Operand<?> handle, Operand<TFloat32> flowIn) {
+    return TensorArraySize.create(scope, handle, flowIn);
   }
 
   /**
@@ -3700,258 +3423,224 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link GetSessionHandle} operation
+   * Builds an {@link TensorArrayUnpack} operation
    *
-   * @param value The tensor to be stored.
-   * @return a new instance of GetSessionHandle
-   * @see org.tensorflow.op.core.GetSessionHandle
+   * @param handle 
+   * @param value 
+   * @param flowIn 
+   * @return a new instance of TensorArrayUnpack
+   * @see org.tensorflow.op.core.TensorArrayUnpack
    */
-  public <T extends TType> GetSessionHandle getSessionHandle(Operand<T> value) {
-    return GetSessionHandle.create(scope, value);
+  public <T extends TType> TensorArrayUnpack tensorArrayUnpack(Operand<TString> handle,
+      Operand<T> value, Operand<TFloat32> flowIn) {
+    return TensorArrayUnpack.create(scope, handle, value, flowIn);
   }
 
   /**
-   * Builds an {@link EditDistance} operation
+   * Builds an {@link TensorArrayWrite} operation
    *
-   * @param hypothesisIndices The indices of the hypothesis list SparseTensor.
-   * @param hypothesisValues The values of the hypothesis list SparseTensor.
-   * @param hypothesisShape The shape of the hypothesis list SparseTensor.
-   * @param truthIndices The indices of the truth list SparseTensor.
-   * @param truthValues The values of the truth list SparseTensor.
-   * @param truthShape truth indices, vector.
-   * @param options carries optional attributes values
-   * @return a new instance of EditDistance
-   * @see org.tensorflow.op.core.EditDistance
-   */
-  public <T extends TType> EditDistance editDistance(Operand<TInt64> hypothesisIndices,
-      Operand<T> hypothesisValues, Operand<TInt64> hypothesisShape, Operand<TInt64> truthIndices,
-      Operand<T> truthValues, Operand<TInt64> truthShape, EditDistance.Options... options) {
-    return EditDistance.create(scope, hypothesisIndices, hypothesisValues, hypothesisShape, truthIndices, truthValues, truthShape, options);
-  }
-
-  /**
-   * Builds an {@link MapClear} operation
-   *
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of MapClear
-   * @see org.tensorflow.op.core.MapClear
-   */
-  public MapClear mapClear(List<DataType<?>> dtypes, MapClear.Options... options) {
-    return MapClear.create(scope, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link LookupTableSize} operation
-   *
-   * @param tableHandle Handle to the table.
-   * @return a new instance of LookupTableSize
-   * @see org.tensorflow.op.core.LookupTableSize
-   */
-  public LookupTableSize lookupTableSize(Operand<?> tableHandle) {
-    return LookupTableSize.create(scope, tableHandle);
-  }
-
-  /**
-   * Builds an {@link ReduceAny} operation
-   *
-   * @param input The tensor to reduce.
-   * @param axis The dimensions to reduce. Must be in the range
-   * @param options carries optional attributes values
-   * @return a new instance of ReduceAny
-   * @see org.tensorflow.op.core.ReduceAny
-   */
-  public <T extends TNumber> ReduceAny reduceAny(Operand<TBool> input, Operand<T> axis,
-      ReduceAny.Options... options) {
-    return ReduceAny.create(scope, input, axis, options);
-  }
-
-  /**
-   * Builds an {@link ParallelDynamicStitch} operation
-   *
-   * @param indices 
-   * @param data 
-   * @return a new instance of ParallelDynamicStitch
-   * @see org.tensorflow.op.core.ParallelDynamicStitch
-   */
-  public <T extends TType> ParallelDynamicStitch<T> parallelDynamicStitch(
-      Iterable<Operand<TInt32>> indices, Iterable<Operand<T>> data) {
-    return ParallelDynamicStitch.create(scope, indices, data);
-  }
-
-  /**
-   * Builds an {@link TensorArrayGrad} operation
-   *
-   * @param handle The handle to the forward TensorArray.
+   * @param handle The handle to a TensorArray.
+   * @param index The position to write to inside the TensorArray.
+   * @param value The tensor to write to the TensorArray.
    * @param flowIn A float scalar that enforces proper chaining of operations.
-   * @param source The gradient source string, used to decide which gradient TensorArray
-   * @return a new instance of TensorArrayGrad
-   * @see org.tensorflow.op.core.TensorArrayGrad
+   * @return a new instance of TensorArrayWrite
+   * @see org.tensorflow.op.core.TensorArrayWrite
    */
-  public TensorArrayGrad tensorArrayGrad(Operand<?> handle, Operand<TFloat32> flowIn,
-      String source) {
-    return TensorArrayGrad.create(scope, handle, flowIn, source);
+  public <T extends TType> TensorArrayWrite tensorArrayWrite(Operand<?> handle,
+      Operand<TInt32> index, Operand<T> value, Operand<TFloat32> flowIn) {
+    return TensorArrayWrite.create(scope, handle, index, value, flowIn);
   }
 
   /**
-   * Builds an {@link ScatterNdNonAliasingAdd} operation
+   * Builds an {@link TensorListConcat} operation
    *
-   * @param input A Tensor.
-   * @param indices A Tensor. Must be one of the following types: `int32`, `int64`.
-   * @param updates A Tensor. Must have the same type as ref. A tensor of updated values
-   * @return a new instance of ScatterNdNonAliasingAdd
-   * @see org.tensorflow.op.core.ScatterNdNonAliasingAdd
+   * @param inputHandle 
+   * @param elementShape 
+   * @param leadingDims 
+   * @param elementDtype 
+   * @return a new instance of TensorListConcat
+   * @see org.tensorflow.op.core.TensorListConcat
    */
-  public <T extends TType, U extends TNumber> ScatterNdNonAliasingAdd<T> scatterNdNonAliasingAdd(
-      Operand<T> input, Operand<U> indices, Operand<T> updates) {
-    return ScatterNdNonAliasingAdd.create(scope, input, indices, updates);
+  public <U extends TType, T extends TNumber> TensorListConcat<U> tensorListConcat(
+      Operand<?> inputHandle, Operand<T> elementShape, Operand<TInt64> leadingDims,
+      DataType<U> elementDtype) {
+    return TensorListConcat.create(scope, inputHandle, elementShape, leadingDims, elementDtype);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link TensorListConcatLists} operation
    *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
+   * @param inputA 
+   * @param inputB 
+   * @param elementDtype 
+   * @return a new instance of TensorListConcatLists
+   * @see org.tensorflow.op.core.TensorListConcatLists
    */
-  public Constant<TInt64> constant(long[][][][][][] data) {
-    return Constant.create(scope, data);
+  public <T extends TType> TensorListConcatLists tensorListConcatLists(Operand<?> inputA,
+      Operand<?> inputB, DataType<T> elementDtype) {
+    return TensorListConcatLists.create(scope, inputA, inputB, elementDtype);
   }
 
   /**
-   * Builds an {@link SplitV} operation
+   * Builds an {@link TensorListElementShape} operation
    *
-   * @param value The tensor to split.
-   * @param sizeSplits list containing the sizes of each output tensor along the split
-   * @param axis 0-D.  The dimension along which to split.  Must be in the range
-   * @param numSplit 
-   * @return a new instance of SplitV
-   * @see org.tensorflow.op.core.SplitV
+   * @param inputHandle 
+   * @param shapeType 
+   * @return a new instance of TensorListElementShape
+   * @see org.tensorflow.op.core.TensorListElementShape
    */
-  public <T extends TType, U extends TNumber> SplitV<T> splitV(Operand<T> value,
-      Operand<U> sizeSplits, Operand<TInt32> axis, Long numSplit) {
-    return SplitV.create(scope, value, sizeSplits, axis, numSplit);
+  public <T extends TNumber> TensorListElementShape<T> tensorListElementShape(
+      Operand<?> inputHandle, DataType<T> shapeType) {
+    return TensorListElementShape.create(scope, inputHandle, shapeType);
   }
 
   /**
-   * Builds an {@link DestroyTemporaryVariable} operation
+   * Builds an {@link TensorListFromTensor} operation
    *
-   * @param ref A reference to the temporary variable tensor.
-   * @param varName Name of the temporary variable, usually the name of the matching
-   * @return a new instance of DestroyTemporaryVariable
-   * @see org.tensorflow.op.core.DestroyTemporaryVariable
+   * @param tensor 
+   * @param elementShape 
+   * @return a new instance of TensorListFromTensor
+   * @see org.tensorflow.op.core.TensorListFromTensor
    */
-  public <T extends TType> DestroyTemporaryVariable<T> destroyTemporaryVariable(Operand<T> ref,
-      String varName) {
-    return DestroyTemporaryVariable.create(scope, ref, varName);
+  public <T extends TType, U extends TNumber> TensorListFromTensor tensorListFromTensor(
+      Operand<T> tensor, Operand<U> elementShape) {
+    return TensorListFromTensor.create(scope, tensor, elementShape);
   }
 
   /**
-   * Builds an {@link StageSize} operation
+   * Builds an {@link TensorListGather} operation
    *
-   * @param dtypes 
-   * @param options carries optional attributes values
-   * @return a new instance of StageSize
-   * @see org.tensorflow.op.core.StageSize
-   */
-  public StageSize stageSize(List<DataType<?>> dtypes, StageSize.Options... options) {
-    return StageSize.create(scope, dtypes, options);
-  }
-
-  /**
-   * Builds an {@link InplaceUpdate} operation
-   *
-   * @param x A tensor of type `T`.
-   * @param i A vector. Indices into the left-most dimension of `x`.
-   * @param v A `Tensor` of type T. Same dimension sizes as x except the first dimension, which must be the same as i's size.
-   * @return a new instance of InplaceUpdate
-   * @see org.tensorflow.op.core.InplaceUpdate
-   */
-  public <T extends TType> InplaceUpdate<T> inplaceUpdate(Operand<T> x, Operand<TInt32> i,
-      Operand<T> v) {
-    return InplaceUpdate.create(scope, x, i, v);
-  }
-
-  /**
-   * Builds an {@link Constant} operation
-   *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TInt64> constant(long[][] data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link LoopCond} operation
-   *
-   * @param input A boolean scalar, representing the branch predicate of the Switch op.
-   * @return a new instance of LoopCond
-   * @see org.tensorflow.op.core.LoopCond
-   */
-  public LoopCond loopCond(Operand<TBool> input) {
-    return LoopCond.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link ResourceGatherNd} operation
-   *
-   * @param resource 
+   * @param inputHandle 
    * @param indices 
-   * @param dtype 
-   * @return a new instance of ResourceGatherNd
-   * @see org.tensorflow.op.core.ResourceGatherNd
+   * @param elementShape 
+   * @param elementDtype 
+   * @return a new instance of TensorListGather
+   * @see org.tensorflow.op.core.TensorListGather
    */
-  public <U extends TType, T extends TNumber> ResourceGatherNd<U> resourceGatherNd(
-      Operand<?> resource, Operand<T> indices, DataType<U> dtype) {
-    return ResourceGatherNd.create(scope, resource, indices, dtype);
+  public <T extends TType> TensorListGather<T> tensorListGather(Operand<?> inputHandle,
+      Operand<TInt32> indices, Operand<TInt32> elementShape, DataType<T> elementDtype) {
+    return TensorListGather.create(scope, inputHandle, indices, elementShape, elementDtype);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link TensorListGetItem} operation
    *
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   * @see org.tensorflow.op.core.Constant
+   * @param inputHandle 
+   * @param index 
+   * @param elementShape 
+   * @param elementDtype 
+   * @return a new instance of TensorListGetItem
+   * @see org.tensorflow.op.core.TensorListGetItem
    */
-  public Constant<TFloat64> constant(double[][][][][][] data) {
-    return Constant.create(scope, data);
+  public <T extends TType> TensorListGetItem<T> tensorListGetItem(Operand<?> inputHandle,
+      Operand<TInt32> index, Operand<TInt32> elementShape, DataType<T> elementDtype) {
+    return TensorListGetItem.create(scope, inputHandle, index, elementShape, elementDtype);
   }
 
   /**
-   * Builds an {@link ResourceScatterDiv} operation
+   * Builds an {@link TensorListLength} operation
    *
-   * @param resource Should be from a `Variable` node.
-   * @param indices A tensor of indices into the first dimension of `ref`.
-   * @param updates A tensor of updated values to add to `ref`.
-   * @return a new instance of ResourceScatterDiv
-   * @see org.tensorflow.op.core.ResourceScatterDiv
+   * @param inputHandle 
+   * @return a new instance of TensorListLength
+   * @see org.tensorflow.op.core.TensorListLength
    */
-  public <T extends TNumber, U extends TType> ResourceScatterDiv resourceScatterDiv(
-      Operand<?> resource, Operand<T> indices, Operand<U> updates) {
-    return ResourceScatterDiv.create(scope, resource, indices, updates);
+  public TensorListLength tensorListLength(Operand<?> inputHandle) {
+    return TensorListLength.create(scope, inputHandle);
   }
 
   /**
-   * Builds an {@link Barrier} operation
+   * Builds an {@link TensorListPopBack} operation
    *
-   * @param componentTypes The type of each component in a value.
-   * @param options carries optional attributes values
-   * @return a new instance of Barrier
-   * @see org.tensorflow.op.core.Barrier
+   * @param inputHandle 
+   * @param elementShape 
+   * @param elementDtype 
+   * @return a new instance of TensorListPopBack
+   * @see org.tensorflow.op.core.TensorListPopBack
    */
-  public Barrier barrier(List<DataType<?>> componentTypes, Barrier.Options... options) {
-    return Barrier.create(scope, componentTypes, options);
+  public <T extends TType> TensorListPopBack<T> tensorListPopBack(Operand<?> inputHandle,
+      Operand<TInt32> elementShape, DataType<T> elementDtype) {
+    return TensorListPopBack.create(scope, inputHandle, elementShape, elementDtype);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link TensorListPushBack} operation
    *
-   * @param charset The encoding from String to bytes.
-   * @param data The string to put into the new constant.
-   * @return a string constant
-   * @see org.tensorflow.op.core.Constant
+   * @param inputHandle 
+   * @param tensor 
+   * @return a new instance of TensorListPushBack
+   * @see org.tensorflow.op.core.TensorListPushBack
    */
-  public Constant<TString> constant(String data, Charset charset) {
-    return Constant.create(scope, data, charset);
+  public <T extends TType> TensorListPushBack tensorListPushBack(Operand<?> inputHandle,
+      Operand<T> tensor) {
+    return TensorListPushBack.create(scope, inputHandle, tensor);
+  }
+
+  /**
+   * Builds an {@link TensorListPushBackBatch} operation
+   *
+   * @param inputHandles 
+   * @param tensor 
+   * @return a new instance of TensorListPushBackBatch
+   * @see org.tensorflow.op.core.TensorListPushBackBatch
+   */
+  public <T extends TType> TensorListPushBackBatch tensorListPushBackBatch(Operand<?> inputHandles,
+      Operand<T> tensor) {
+    return TensorListPushBackBatch.create(scope, inputHandles, tensor);
+  }
+
+  /**
+   * Builds an {@link TensorListReserve} operation
+   *
+   * @param elementShape 
+   * @param numElements 
+   * @param elementDtype 
+   * @return a new instance of TensorListReserve
+   * @see org.tensorflow.op.core.TensorListReserve
+   */
+  public <T extends TNumber, U extends TType> TensorListReserve tensorListReserve(
+      Operand<T> elementShape, Operand<TInt32> numElements, DataType<U> elementDtype) {
+    return TensorListReserve.create(scope, elementShape, numElements, elementDtype);
+  }
+
+  /**
+   * Builds an {@link TensorListResize} operation
+   *
+   * @param inputHandle 
+   * @param size 
+   * @return a new instance of TensorListResize
+   * @see org.tensorflow.op.core.TensorListResize
+   */
+  public TensorListResize tensorListResize(Operand<?> inputHandle, Operand<TInt32> size) {
+    return TensorListResize.create(scope, inputHandle, size);
+  }
+
+  /**
+   * Builds an {@link TensorListScatter} operation
+   *
+   * @param tensor 
+   * @param indices 
+   * @param elementShape 
+   * @param numElements 
+   * @return a new instance of TensorListScatter
+   * @see org.tensorflow.op.core.TensorListScatter
+   */
+  public <T extends TType, U extends TNumber> TensorListScatter tensorListScatter(Operand<T> tensor,
+      Operand<TInt32> indices, Operand<U> elementShape, Operand<TInt32> numElements) {
+    return TensorListScatter.create(scope, tensor, indices, elementShape, numElements);
+  }
+
+  /**
+   * Builds an {@link TensorListScatterIntoExistingList} operation
+   *
+   * @param inputHandle 
+   * @param tensor 
+   * @param indices 
+   * @return a new instance of TensorListScatterIntoExistingList
+   * @see org.tensorflow.op.core.TensorListScatterIntoExistingList
+   */
+  public <T extends TType> TensorListScatterIntoExistingList tensorListScatterIntoExistingList(
+      Operand<?> inputHandle, Operand<T> tensor, Operand<TInt32> indices) {
+    return TensorListScatterIntoExistingList.create(scope, inputHandle, tensor, indices);
   }
 
   /**
@@ -3969,40 +3658,351 @@ public final class Ops {
   }
 
   /**
-   * Builds an {@link ControlTrigger} operation
+   * Builds an {@link TensorListSplit} operation
    *
-   * @return a new instance of ControlTrigger
-   * @see org.tensorflow.op.core.ControlTrigger
+   * @param tensor 
+   * @param elementShape 
+   * @param lengths 
+   * @return a new instance of TensorListSplit
+   * @see org.tensorflow.op.core.TensorListSplit
    */
-  public ControlTrigger controlTrigger() {
-    return ControlTrigger.create(scope);
+  public <T extends TType, U extends TNumber> TensorListSplit tensorListSplit(Operand<T> tensor,
+      Operand<U> elementShape, Operand<TInt64> lengths) {
+    return TensorListSplit.create(scope, tensor, elementShape, lengths);
   }
 
   /**
-   * Builds an {@link Constant} operation
+   * Builds an {@link TensorListStack} operation
    *
-   * @param data The value to put into the new constant.
-   * @return a boolean constant
-   * @see org.tensorflow.op.core.Constant
-   */
-  public Constant<TBool> constant(boolean data) {
-    return Constant.create(scope, data);
-  }
-
-  /**
-   * Builds an {@link OneHot} operation
-   *
-   * @param indices A tensor of indices.
-   * @param depth A scalar defining the depth of the one hot dimension.
-   * @param onValue A scalar defining the value to fill in output when `indices[j] = i`.
-   * @param offValue A scalar defining the value to fill in output when `indices[j] != i`.
+   * @param inputHandle 
+   * @param elementShape 
+   * @param elementDtype 
    * @param options carries optional attributes values
-   * @return a new instance of OneHot
-   * @see org.tensorflow.op.core.OneHot
+   * @return a new instance of TensorListStack
+   * @see org.tensorflow.op.core.TensorListStack
    */
-  public <U extends TType, T extends TNumber> OneHot<U> oneHot(Operand<T> indices,
-      Operand<TInt32> depth, Operand<U> onValue, Operand<U> offValue, OneHot.Options... options) {
-    return OneHot.create(scope, indices, depth, onValue, offValue, options);
+  public <T extends TType> TensorListStack<T> tensorListStack(Operand<?> inputHandle,
+      Operand<TInt32> elementShape, DataType<T> elementDtype, TensorListStack.Options... options) {
+    return TensorListStack.create(scope, inputHandle, elementShape, elementDtype, options);
+  }
+
+  /**
+   * Builds an {@link TensorScatterNdAdd} operation
+   *
+   * @param tensor Tensor to copy/update.
+   * @param indices Index tensor.
+   * @param updates Updates to scatter into output.
+   * @return a new instance of TensorScatterNdAdd
+   * @see org.tensorflow.op.core.TensorScatterNdAdd
+   */
+  public <T extends TType, U extends TNumber> TensorScatterNdAdd<T> tensorScatterNdAdd(
+      Operand<T> tensor, Operand<U> indices, Operand<T> updates) {
+    return TensorScatterNdAdd.create(scope, tensor, indices, updates);
+  }
+
+  /**
+   * Builds an {@link TensorScatterNdSub} operation
+   *
+   * @param tensor Tensor to copy/update.
+   * @param indices Index tensor.
+   * @param updates Updates to scatter into output.
+   * @return a new instance of TensorScatterNdSub
+   * @see org.tensorflow.op.core.TensorScatterNdSub
+   */
+  public <T extends TType, U extends TNumber> TensorScatterNdSub<T> tensorScatterNdSub(
+      Operand<T> tensor, Operand<U> indices, Operand<T> updates) {
+    return TensorScatterNdSub.create(scope, tensor, indices, updates);
+  }
+
+  /**
+   * Builds an {@link TensorScatterNdUpdate} operation
+   *
+   * @param tensor Tensor to copy/update.
+   * @param indices Index tensor.
+   * @param updates Updates to scatter into output.
+   * @return a new instance of TensorScatterNdUpdate
+   * @see org.tensorflow.op.core.TensorScatterNdUpdate
+   */
+  public <T extends TType, U extends TNumber> TensorScatterNdUpdate<T> tensorScatterNdUpdate(
+      Operand<T> tensor, Operand<U> indices, Operand<T> updates) {
+    return TensorScatterNdUpdate.create(scope, tensor, indices, updates);
+  }
+
+  /**
+   * Builds an {@link TensorStridedSliceUpdate} operation
+   *
+   * @param input 
+   * @param begin 
+   * @param end 
+   * @param strides 
+   * @param value 
+   * @param options carries optional attributes values
+   * @return a new instance of TensorStridedSliceUpdate
+   * @see org.tensorflow.op.core.TensorStridedSliceUpdate
+   */
+  public <T extends TType, U extends TNumber> TensorStridedSliceUpdate<T> tensorStridedSliceUpdate(
+      Operand<T> input, Operand<U> begin, Operand<U> end, Operand<U> strides, Operand<T> value,
+      TensorStridedSliceUpdate.Options... options) {
+    return TensorStridedSliceUpdate.create(scope, input, begin, end, strides, value, options);
+  }
+
+  /**
+   * Builds an {@link Tile} operation
+   *
+   * @param input 1-D or higher.
+   * @param multiples 1-D. Length must be the same as the number of dimensions in `input`
+   * @return a new instance of Tile
+   * @see org.tensorflow.op.core.Tile
+   */
+  public <T extends TType, U extends TNumber> Tile<T> tile(Operand<T> input, Operand<U> multiples) {
+    return Tile.create(scope, input, multiples);
+  }
+
+  /**
+   * Builds an {@link Timestamp} operation
+   *
+   * @return a new instance of Timestamp
+   * @see org.tensorflow.op.core.Timestamp
+   */
+  public Timestamp timestamp() {
+    return Timestamp.create(scope);
+  }
+
+  /**
+   * Builds an {@link TryRpc} operation
+   *
+   * @param address `0-D` or `1-D`.  The address (i.e. host_name:port) of the RPC server.
+   * @param method `0-D` or `1-D`.  The method address on the RPC server.
+   * @param request `0-D` or `1-D`.  Serialized proto strings: the rpc request argument.
+   * @param options carries optional attributes values
+   * @return a new instance of TryRpc
+   * @see org.tensorflow.op.core.TryRpc
+   */
+  public TryRpc tryRpc(Operand<TString> address, Operand<TString> method, Operand<TString> request,
+      TryRpc.Options... options) {
+    return TryRpc.create(scope, address, method, request, options);
+  }
+
+  /**
+   * Builds an {@link Unbatch} operation
+   *
+   * @param batchedTensor 
+   * @param batchIndex 
+   * @param id 
+   * @param timeoutMicros 
+   * @param options carries optional attributes values
+   * @return a new instance of Unbatch
+   * @see org.tensorflow.op.core.Unbatch
+   */
+  public <T extends TType> Unbatch<T> unbatch(Operand<T> batchedTensor, Operand<TInt64> batchIndex,
+      Operand<TInt64> id, Long timeoutMicros, Unbatch.Options... options) {
+    return Unbatch.create(scope, batchedTensor, batchIndex, id, timeoutMicros, options);
+  }
+
+  /**
+   * Builds an {@link UnbatchGrad} operation
+   *
+   * @param originalInput 
+   * @param batchIndex 
+   * @param grad 
+   * @param id 
+   * @param options carries optional attributes values
+   * @return a new instance of UnbatchGrad
+   * @see org.tensorflow.op.core.UnbatchGrad
+   */
+  public <T extends TType> UnbatchGrad<T> unbatchGrad(Operand<T> originalInput,
+      Operand<TInt64> batchIndex, Operand<T> grad, Operand<TInt64> id,
+      UnbatchGrad.Options... options) {
+    return UnbatchGrad.create(scope, originalInput, batchIndex, grad, id, options);
+  }
+
+  /**
+   * Builds an {@link Unique} operation
+   *
+   * @param x A `Tensor`.
+   * @param axis A `Tensor` of type `int32` (default: None). The axis of the Tensor to
+   * @return a new instance of Unique
+   * @see org.tensorflow.op.core.Unique
+   */
+  public <T extends TType, U extends TNumber> Unique<T, TInt32> unique(Operand<T> x,
+      Operand<U> axis) {
+    return Unique.create(scope, x, axis);
+  }
+
+  /**
+   * Builds an {@link Unique} operation
+   *
+   * @param x A `Tensor`.
+   * @param axis A `Tensor` of type `int32` (default: None). The axis of the Tensor to
+   * @param outIdx 
+   * @return a new instance of Unique
+   * @see org.tensorflow.op.core.Unique
+   */
+  public <T extends TType, V extends TNumber, U extends TNumber> Unique<T, V> unique(Operand<T> x,
+      Operand<U> axis, DataType<V> outIdx) {
+    return Unique.create(scope, x, axis, outIdx);
+  }
+
+  /**
+   * Builds an {@link UniqueWithCounts} operation
+   *
+   * @param x A `Tensor`.
+   * @param axis A `Tensor` of type `int32` (default: None). The axis of the Tensor to
+   * @return a new instance of UniqueWithCounts
+   * @see org.tensorflow.op.core.UniqueWithCounts
+   */
+  public <T extends TType, U extends TNumber> UniqueWithCounts<T, TInt32> uniqueWithCounts(
+      Operand<T> x, Operand<U> axis) {
+    return UniqueWithCounts.create(scope, x, axis);
+  }
+
+  /**
+   * Builds an {@link UniqueWithCounts} operation
+   *
+   * @param x A `Tensor`.
+   * @param axis A `Tensor` of type `int32` (default: None). The axis of the Tensor to
+   * @param outIdx 
+   * @return a new instance of UniqueWithCounts
+   * @see org.tensorflow.op.core.UniqueWithCounts
+   */
+  public <T extends TType, V extends TNumber, U extends TNumber> UniqueWithCounts<T, V> uniqueWithCounts(
+      Operand<T> x, Operand<U> axis, DataType<V> outIdx) {
+    return UniqueWithCounts.create(scope, x, axis, outIdx);
+  }
+
+  /**
+   * Builds an {@link UnravelIndex} operation
+   *
+   * @param indices An 0-D or 1-D `int` Tensor whose elements are indices into the
+   * @param dims An 1-D `int` Tensor. The shape of the array to use for unraveling
+   * @return a new instance of UnravelIndex
+   * @see org.tensorflow.op.core.UnravelIndex
+   */
+  public <T extends TNumber> UnravelIndex<T> unravelIndex(Operand<T> indices, Operand<T> dims) {
+    return UnravelIndex.create(scope, indices, dims);
+  }
+
+  /**
+   * Builds an {@link Unstack} operation
+   *
+   * @param value 1-D or higher, with `axis` dimension size equal to `num`.
+   * @param num 
+   * @param options carries optional attributes values
+   * @return a new instance of Unstack
+   * @see org.tensorflow.op.core.Unstack
+   */
+  public <T extends TType> Unstack<T> unstack(Operand<T> value, Long num,
+      Unstack.Options... options) {
+    return Unstack.create(scope, value, num, options);
+  }
+
+  /**
+   * Builds an {@link Unstage} operation
+   *
+   * @param dtypes 
+   * @param options carries optional attributes values
+   * @return a new instance of Unstage
+   * @see org.tensorflow.op.core.Unstage
+   */
+  public Unstage unstage(List<DataType<?>> dtypes, Unstage.Options... options) {
+    return Unstage.create(scope, dtypes, options);
+  }
+
+  /**
+   * Builds an {@link VarHandleOp} operation
+   *
+   * @param dtype the type of this variable. Must agree with the dtypes
+   * @param shape The (possibly partially specified) shape of this variable.
+   * @param options carries optional attributes values
+   * @return a new instance of VarHandleOp
+   * @see org.tensorflow.op.core.VarHandleOp
+   */
+  public <T extends TType> VarHandleOp varHandleOp(DataType<T> dtype, Shape shape,
+      VarHandleOp.Options... options) {
+    return VarHandleOp.create(scope, dtype, shape, options);
+  }
+
+  /**
+   * Builds an {@link VarIsInitializedOp} operation
+   *
+   * @param resource the input resource handle.
+   * @return a new instance of VarIsInitializedOp
+   * @see org.tensorflow.op.core.VarIsInitializedOp
+   */
+  public VarIsInitializedOp varIsInitializedOp(Operand<?> resource) {
+    return VarIsInitializedOp.create(scope, resource);
+  }
+
+  /**
+   * Builds an {@link Variable} operation
+   *
+   * @param shape The shape of the variable tensor.
+   * @param dtype The type of elements in the variable tensor.
+   * @param options carries optional attributes values
+   * @return a new instance of Variable
+   * @see org.tensorflow.op.core.Variable
+   */
+  public <T extends TType> Variable<T> variable(Shape shape, DataType<T> dtype,
+      Variable.Options... options) {
+    return Variable.create(scope, shape, dtype, options);
+  }
+
+  /**
+   * Builds an {@link VariableShape} operation
+   *
+   * @param input 
+   * @return a new instance of VariableShape
+   * @see org.tensorflow.op.core.VariableShape
+   */
+  public VariableShape<TInt32> variableShape(Operand<?> input) {
+    return VariableShape.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link VariableShape} operation
+   *
+   * @param input 
+   * @param outType 
+   * @return a new instance of VariableShape
+   * @see org.tensorflow.op.core.VariableShape
+   */
+  public <T extends TNumber> VariableShape<T> variableShape(Operand<?> input, DataType<T> outType) {
+    return VariableShape.create(scope, input, outType);
+  }
+
+  /**
+   * Builds an {@link Where} operation
+   *
+   * @param condition 
+   * @return a new instance of Where
+   * @see org.tensorflow.op.core.Where
+   */
+  public <T extends TType> Where where(Operand<T> condition) {
+    return Where.create(scope, condition);
+  }
+
+  /**
+   * Builds an {@link Zeros} operation
+   *
+   * @param dims a 1-D operand that represents the shape of the output tensor
+   * @param type the output tensor datatype
+   * @return a constant tensor initialized with zeros
+   * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with zeros.
+   * @see org.tensorflow.op.core.Zeros
+   */
+  public <T extends TType, U extends TNumber> Zeros<T> zeros(Operand<U> dims, DataType<T> type) {
+    return Zeros.create(scope, dims, type);
+  }
+
+  /**
+   * Builds an {@link ZerosLike} operation
+   *
+   * @param x a tensor of type T.
+   * @return a new instance of ZerosLike
+   * @see org.tensorflow.op.core.ZerosLike
+   */
+  public <T extends TType> ZerosLike<T> zerosLike(Operand<T> x) {
+    return ZerosLike.create(scope, x);
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/QuantizationOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/QuantizationOps.java
@@ -33,53 +33,6 @@ public final class QuantizationOps {
   }
 
   /**
-   * Builds an {@link RequantizationRange} operation
-   *
-   * @param input 
-   * @param inputMin The float value that the minimum quantized input value represents.
-   * @param inputMax The float value that the maximum quantized input value represents.
-   * @return a new instance of RequantizationRange
-   * @see org.tensorflow.op.quantization.RequantizationRange
-   */
-  public <T extends TType> RequantizationRange requantizationRange(Operand<T> input,
-      Operand<TFloat32> inputMin, Operand<TFloat32> inputMax) {
-    return RequantizationRange.create(scope, input, inputMin, inputMax);
-  }
-
-  /**
-   * Builds an {@link QuantizeAndDequantize} operation
-   *
-   * @param input 
-   * @param inputMin 
-   * @param inputMax 
-   * @param numBits 
-   * @param options carries optional attributes values
-   * @return a new instance of QuantizeAndDequantize
-   * @see org.tensorflow.op.quantization.QuantizeAndDequantize
-   */
-  public <T extends TNumber> QuantizeAndDequantize<T> quantizeAndDequantize(Operand<T> input,
-      Operand<T> inputMin, Operand<T> inputMax, Operand<TInt32> numBits,
-      QuantizeAndDequantize.Options... options) {
-    return QuantizeAndDequantize.create(scope, input, inputMin, inputMax, numBits, options);
-  }
-
-  /**
-   * Builds an {@link FakeQuantWithMinMaxVarsPerChannel} operation
-   *
-   * @param inputs 
-   * @param min 
-   * @param max 
-   * @param options carries optional attributes values
-   * @return a new instance of FakeQuantWithMinMaxVarsPerChannel
-   * @see org.tensorflow.op.quantization.FakeQuantWithMinMaxVarsPerChannel
-   */
-  public FakeQuantWithMinMaxVarsPerChannel fakeQuantWithMinMaxVarsPerChannel(
-      Operand<TFloat32> inputs, Operand<TFloat32> min, Operand<TFloat32> max,
-      FakeQuantWithMinMaxVarsPerChannel.Options... options) {
-    return FakeQuantWithMinMaxVarsPerChannel.create(scope, inputs, min, max, options);
-  }
-
-  /**
    * Builds an {@link Dequantize} operation
    *
    * @param input 
@@ -92,88 +45,6 @@ public final class QuantizationOps {
   public <T extends TType> Dequantize dequantize(Operand<T> input, Operand<TFloat32> minRange,
       Operand<TFloat32> maxRange, Dequantize.Options... options) {
     return Dequantize.create(scope, input, minRange, maxRange, options);
-  }
-
-  /**
-   * Builds an {@link QuantizedConcat} operation
-   *
-   * @param concatDim 0-D.  The dimension along which to concatenate.  Must be in the
-   * @param values The `N` Tensors to concatenate. Their ranks and types must match,
-   * @param inputMins The minimum scalar values for each of the input tensors.
-   * @param inputMaxes The maximum scalar values for each of the input tensors.
-   * @return a new instance of QuantizedConcat
-   * @see org.tensorflow.op.quantization.QuantizedConcat
-   */
-  public <T extends TType> QuantizedConcat<T> quantizedConcat(Operand<TInt32> concatDim,
-      Iterable<Operand<T>> values, Iterable<Operand<TFloat32>> inputMins,
-      Iterable<Operand<TFloat32>> inputMaxes) {
-    return QuantizedConcat.create(scope, concatDim, values, inputMins, inputMaxes);
-  }
-
-  /**
-   * Builds an {@link FakeQuantWithMinMaxArgsGradient} operation
-   *
-   * @param gradients Backpropagated gradients above the FakeQuantWithMinMaxArgs operation.
-   * @param inputs Values passed as inputs to the FakeQuantWithMinMaxArgs operation.
-   * @param options carries optional attributes values
-   * @return a new instance of FakeQuantWithMinMaxArgsGradient
-   * @see org.tensorflow.op.quantization.FakeQuantWithMinMaxArgsGradient
-   */
-  public FakeQuantWithMinMaxArgsGradient fakeQuantWithMinMaxArgsGradient(
-      Operand<TFloat32> gradients, Operand<TFloat32> inputs,
-      FakeQuantWithMinMaxArgsGradient.Options... options) {
-    return FakeQuantWithMinMaxArgsGradient.create(scope, gradients, inputs, options);
-  }
-
-  /**
-   * Builds an {@link FakeQuantWithMinMaxVarsPerChannelGradient} operation
-   *
-   * @param gradients Backpropagated gradients above the FakeQuantWithMinMaxVars operation,
-   * @param inputs Values passed as inputs to the FakeQuantWithMinMaxVars operation, shape
-   * @param min 
-   * @param max 
-   * @param options carries optional attributes values
-   * @return a new instance of FakeQuantWithMinMaxVarsPerChannelGradient
-   * @see org.tensorflow.op.quantization.FakeQuantWithMinMaxVarsPerChannelGradient
-   */
-  public FakeQuantWithMinMaxVarsPerChannelGradient fakeQuantWithMinMaxVarsPerChannelGradient(
-      Operand<TFloat32> gradients, Operand<TFloat32> inputs, Operand<TFloat32> min,
-      Operand<TFloat32> max, FakeQuantWithMinMaxVarsPerChannelGradient.Options... options) {
-    return FakeQuantWithMinMaxVarsPerChannelGradient.create(scope, gradients, inputs, min, max, options);
-  }
-
-  /**
-   * Builds an {@link QuantizeDownAndShrinkRange} operation
-   *
-   * @param input 
-   * @param inputMin The float value that the minimum quantized input value represents.
-   * @param inputMax The float value that the maximum quantized input value represents.
-   * @param outType The type of the output. Should be a lower bit depth than Tinput.
-   * @return a new instance of QuantizeDownAndShrinkRange
-   * @see org.tensorflow.op.quantization.QuantizeDownAndShrinkRange
-   */
-  public <U extends TType, T extends TType> QuantizeDownAndShrinkRange<U> quantizeDownAndShrinkRange(
-      Operand<T> input, Operand<TFloat32> inputMin, Operand<TFloat32> inputMax,
-      DataType<U> outType) {
-    return QuantizeDownAndShrinkRange.create(scope, input, inputMin, inputMax, outType);
-  }
-
-  /**
-   * Builds an {@link Requantize} operation
-   *
-   * @param input 
-   * @param inputMin The float value that the minimum quantized input value represents.
-   * @param inputMax The float value that the maximum quantized input value represents.
-   * @param requestedOutputMin The float value that the minimum quantized output value represents.
-   * @param requestedOutputMax The float value that the maximum quantized output value represents.
-   * @param outType The type of the output. Should be a lower bit depth than Tinput.
-   * @return a new instance of Requantize
-   * @see org.tensorflow.op.quantization.Requantize
-   */
-  public <U extends TType, T extends TType> Requantize<U> requantize(Operand<T> input,
-      Operand<TFloat32> inputMin, Operand<TFloat32> inputMax, Operand<TFloat32> requestedOutputMin,
-      Operand<TFloat32> requestedOutputMax, DataType<U> outType) {
-    return Requantize.create(scope, input, inputMin, inputMax, requestedOutputMin, requestedOutputMax, outType);
   }
 
   /**
@@ -190,19 +61,18 @@ public final class QuantizationOps {
   }
 
   /**
-   * Builds an {@link Quantize} operation
+   * Builds an {@link FakeQuantWithMinMaxArgsGradient} operation
    *
-   * @param input 
-   * @param minRange The minimum value of the quantization range. This value may be adjusted by the
-   * @param maxRange The maximum value of the quantization range. This value may be adjusted by the
-   * @param T 
+   * @param gradients Backpropagated gradients above the FakeQuantWithMinMaxArgs operation.
+   * @param inputs Values passed as inputs to the FakeQuantWithMinMaxArgs operation.
    * @param options carries optional attributes values
-   * @return a new instance of Quantize
-   * @see org.tensorflow.op.quantization.Quantize
+   * @return a new instance of FakeQuantWithMinMaxArgsGradient
+   * @see org.tensorflow.op.quantization.FakeQuantWithMinMaxArgsGradient
    */
-  public <T extends TType> Quantize<T> quantize(Operand<TFloat32> input, Operand<TFloat32> minRange,
-      Operand<TFloat32> maxRange, DataType<T> T, Quantize.Options... options) {
-    return Quantize.create(scope, input, minRange, maxRange, T, options);
+  public FakeQuantWithMinMaxArgsGradient fakeQuantWithMinMaxArgsGradient(
+      Operand<TFloat32> gradients, Operand<TFloat32> inputs,
+      FakeQuantWithMinMaxArgsGradient.Options... options) {
+    return FakeQuantWithMinMaxArgsGradient.create(scope, gradients, inputs, options);
   }
 
   /**
@@ -235,5 +105,135 @@ public final class QuantizationOps {
       Operand<TFloat32> gradients, Operand<TFloat32> inputs, Operand<TFloat32> min,
       Operand<TFloat32> max, FakeQuantWithMinMaxVarsGradient.Options... options) {
     return FakeQuantWithMinMaxVarsGradient.create(scope, gradients, inputs, min, max, options);
+  }
+
+  /**
+   * Builds an {@link FakeQuantWithMinMaxVarsPerChannel} operation
+   *
+   * @param inputs 
+   * @param min 
+   * @param max 
+   * @param options carries optional attributes values
+   * @return a new instance of FakeQuantWithMinMaxVarsPerChannel
+   * @see org.tensorflow.op.quantization.FakeQuantWithMinMaxVarsPerChannel
+   */
+  public FakeQuantWithMinMaxVarsPerChannel fakeQuantWithMinMaxVarsPerChannel(
+      Operand<TFloat32> inputs, Operand<TFloat32> min, Operand<TFloat32> max,
+      FakeQuantWithMinMaxVarsPerChannel.Options... options) {
+    return FakeQuantWithMinMaxVarsPerChannel.create(scope, inputs, min, max, options);
+  }
+
+  /**
+   * Builds an {@link FakeQuantWithMinMaxVarsPerChannelGradient} operation
+   *
+   * @param gradients Backpropagated gradients above the FakeQuantWithMinMaxVars operation,
+   * @param inputs Values passed as inputs to the FakeQuantWithMinMaxVars operation, shape
+   * @param min 
+   * @param max 
+   * @param options carries optional attributes values
+   * @return a new instance of FakeQuantWithMinMaxVarsPerChannelGradient
+   * @see org.tensorflow.op.quantization.FakeQuantWithMinMaxVarsPerChannelGradient
+   */
+  public FakeQuantWithMinMaxVarsPerChannelGradient fakeQuantWithMinMaxVarsPerChannelGradient(
+      Operand<TFloat32> gradients, Operand<TFloat32> inputs, Operand<TFloat32> min,
+      Operand<TFloat32> max, FakeQuantWithMinMaxVarsPerChannelGradient.Options... options) {
+    return FakeQuantWithMinMaxVarsPerChannelGradient.create(scope, gradients, inputs, min, max, options);
+  }
+
+  /**
+   * Builds an {@link Quantize} operation
+   *
+   * @param input 
+   * @param minRange The minimum value of the quantization range. This value may be adjusted by the
+   * @param maxRange The maximum value of the quantization range. This value may be adjusted by the
+   * @param T 
+   * @param options carries optional attributes values
+   * @return a new instance of Quantize
+   * @see org.tensorflow.op.quantization.Quantize
+   */
+  public <T extends TType> Quantize<T> quantize(Operand<TFloat32> input, Operand<TFloat32> minRange,
+      Operand<TFloat32> maxRange, DataType<T> T, Quantize.Options... options) {
+    return Quantize.create(scope, input, minRange, maxRange, T, options);
+  }
+
+  /**
+   * Builds an {@link QuantizeAndDequantize} operation
+   *
+   * @param input 
+   * @param inputMin 
+   * @param inputMax 
+   * @param numBits 
+   * @param options carries optional attributes values
+   * @return a new instance of QuantizeAndDequantize
+   * @see org.tensorflow.op.quantization.QuantizeAndDequantize
+   */
+  public <T extends TNumber> QuantizeAndDequantize<T> quantizeAndDequantize(Operand<T> input,
+      Operand<T> inputMin, Operand<T> inputMax, Operand<TInt32> numBits,
+      QuantizeAndDequantize.Options... options) {
+    return QuantizeAndDequantize.create(scope, input, inputMin, inputMax, numBits, options);
+  }
+
+  /**
+   * Builds an {@link QuantizeDownAndShrinkRange} operation
+   *
+   * @param input 
+   * @param inputMin The float value that the minimum quantized input value represents.
+   * @param inputMax The float value that the maximum quantized input value represents.
+   * @param outType The type of the output. Should be a lower bit depth than Tinput.
+   * @return a new instance of QuantizeDownAndShrinkRange
+   * @see org.tensorflow.op.quantization.QuantizeDownAndShrinkRange
+   */
+  public <U extends TType, T extends TType> QuantizeDownAndShrinkRange<U> quantizeDownAndShrinkRange(
+      Operand<T> input, Operand<TFloat32> inputMin, Operand<TFloat32> inputMax,
+      DataType<U> outType) {
+    return QuantizeDownAndShrinkRange.create(scope, input, inputMin, inputMax, outType);
+  }
+
+  /**
+   * Builds an {@link QuantizedConcat} operation
+   *
+   * @param concatDim 0-D.  The dimension along which to concatenate.  Must be in the
+   * @param values The `N` Tensors to concatenate. Their ranks and types must match,
+   * @param inputMins The minimum scalar values for each of the input tensors.
+   * @param inputMaxes The maximum scalar values for each of the input tensors.
+   * @return a new instance of QuantizedConcat
+   * @see org.tensorflow.op.quantization.QuantizedConcat
+   */
+  public <T extends TType> QuantizedConcat<T> quantizedConcat(Operand<TInt32> concatDim,
+      Iterable<Operand<T>> values, Iterable<Operand<TFloat32>> inputMins,
+      Iterable<Operand<TFloat32>> inputMaxes) {
+    return QuantizedConcat.create(scope, concatDim, values, inputMins, inputMaxes);
+  }
+
+  /**
+   * Builds an {@link RequantizationRange} operation
+   *
+   * @param input 
+   * @param inputMin The float value that the minimum quantized input value represents.
+   * @param inputMax The float value that the maximum quantized input value represents.
+   * @return a new instance of RequantizationRange
+   * @see org.tensorflow.op.quantization.RequantizationRange
+   */
+  public <T extends TType> RequantizationRange requantizationRange(Operand<T> input,
+      Operand<TFloat32> inputMin, Operand<TFloat32> inputMax) {
+    return RequantizationRange.create(scope, input, inputMin, inputMax);
+  }
+
+  /**
+   * Builds an {@link Requantize} operation
+   *
+   * @param input 
+   * @param inputMin The float value that the minimum quantized input value represents.
+   * @param inputMax The float value that the maximum quantized input value represents.
+   * @param requestedOutputMin The float value that the minimum quantized output value represents.
+   * @param requestedOutputMax The float value that the maximum quantized output value represents.
+   * @param outType The type of the output. Should be a lower bit depth than Tinput.
+   * @return a new instance of Requantize
+   * @see org.tensorflow.op.quantization.Requantize
+   */
+  public <U extends TType, T extends TType> Requantize<U> requantize(Operand<T> input,
+      Operand<TFloat32> inputMin, Operand<TFloat32> inputMax, Operand<TFloat32> requestedOutputMin,
+      Operand<TFloat32> requestedOutputMax, DataType<U> outType) {
+    return Requantize.create(scope, input, inputMin, inputMax, requestedOutputMin, requestedOutputMax, outType);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/RandomOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/RandomOps.java
@@ -40,24 +40,6 @@ public final class RandomOps {
   }
 
   /**
-   * Builds an {@link ParameterizedTruncatedNormal} operation
-   *
-   * @param shape The shape of the output tensor. Batches are indexed by the 0th dimension.
-   * @param means The mean parameter of each batch.
-   * @param stdevs The standard deviation parameter of each batch. Must be greater than 0.
-   * @param minvals The minimum cutoff. May be -infinity.
-   * @param maxvals The maximum cutoff. May be +infinity, and must be more than the minval
-   * @param options carries optional attributes values
-   * @return a new instance of ParameterizedTruncatedNormal
-   * @see org.tensorflow.op.random.ParameterizedTruncatedNormal
-   */
-  public <U extends TNumber, T extends TNumber> ParameterizedTruncatedNormal<U> parameterizedTruncatedNormal(
-      Operand<T> shape, Operand<U> means, Operand<U> stdevs, Operand<U> minvals, Operand<U> maxvals,
-      ParameterizedTruncatedNormal.Options... options) {
-    return ParameterizedTruncatedNormal.create(scope, shape, means, stdevs, minvals, maxvals, options);
-  }
-
-  /**
    * Builds an {@link AllCandidateSampler} operation
    *
    * @param trueClasses A batch_size * num_true matrix, in which each row contains the
@@ -71,37 +53,6 @@ public final class RandomOps {
   public AllCandidateSampler allCandidateSampler(Operand<TInt64> trueClasses, Long numTrue,
       Long numSampled, Boolean unique, AllCandidateSampler.Options... options) {
     return AllCandidateSampler.create(scope, trueClasses, numTrue, numSampled, unique, options);
-  }
-
-  /**
-   * Builds an {@link UniformCandidateSampler} operation
-   *
-   * @param trueClasses A batch_size * num_true matrix, in which each row contains the
-   * @param numTrue Number of true labels per context.
-   * @param numSampled Number of candidates to randomly sample.
-   * @param unique If unique is true, we sample with rejection, so that all sampled
-   * @param rangeMax The sampler will sample integers from the interval [0, range_max).
-   * @param options carries optional attributes values
-   * @return a new instance of UniformCandidateSampler
-   * @see org.tensorflow.op.random.UniformCandidateSampler
-   */
-  public UniformCandidateSampler uniformCandidateSampler(Operand<TInt64> trueClasses, Long numTrue,
-      Long numSampled, Boolean unique, Long rangeMax, UniformCandidateSampler.Options... options) {
-    return UniformCandidateSampler.create(scope, trueClasses, numTrue, numSampled, unique, rangeMax, options);
-  }
-
-  /**
-   * Builds an {@link TruncatedNormal} operation
-   *
-   * @param shape The shape of the output tensor.
-   * @param dtype The type of the output.
-   * @param options carries optional attributes values
-   * @return a new instance of TruncatedNormal
-   * @see org.tensorflow.op.random.TruncatedNormal
-   */
-  public <U extends TNumber, T extends TNumber> TruncatedNormal<U> truncatedNormal(Operand<T> shape,
-      DataType<U> dtype, TruncatedNormal.Options... options) {
-    return TruncatedNormal.create(scope, shape, dtype, options);
   }
 
   /**
@@ -123,31 +74,17 @@ public final class RandomOps {
   }
 
   /**
-   * Builds an {@link StatelessTruncatedNormal} operation
+   * Builds an {@link Multinomial} operation
    *
-   * @param shape The shape of the output tensor.
-   * @param seed 2 seeds (shape [2]).
-   * @param dtype The type of the output.
-   * @return a new instance of StatelessTruncatedNormal
-   * @see org.tensorflow.op.random.StatelessTruncatedNormal
+   * @param logits 2-D Tensor with shape `[batch_size, num_classes]`.  Each slice `[i, :]`
+   * @param numSamples 0-D.  Number of independent samples to draw for each row slice.
+   * @param options carries optional attributes values
+   * @return a new instance of Multinomial
+   * @see org.tensorflow.op.random.Multinomial
    */
-  public <V extends TNumber, T extends TNumber, U extends TNumber> StatelessTruncatedNormal<V> statelessTruncatedNormal(
-      Operand<T> shape, Operand<U> seed, DataType<V> dtype) {
-    return StatelessTruncatedNormal.create(scope, shape, seed, dtype);
-  }
-
-  /**
-   * Builds an {@link StatelessRandomUniform} operation
-   *
-   * @param shape The shape of the output tensor.
-   * @param seed 2 seeds (shape [2]).
-   * @param dtype The type of the output.
-   * @return a new instance of StatelessRandomUniform
-   * @see org.tensorflow.op.random.StatelessRandomUniform
-   */
-  public <V extends TNumber, T extends TNumber, U extends TNumber> StatelessRandomUniform<V> statelessRandomUniform(
-      Operand<T> shape, Operand<U> seed, DataType<V> dtype) {
-    return StatelessRandomUniform.create(scope, shape, seed, dtype);
+  public <T extends TNumber> Multinomial<TInt64> multinomial(Operand<T> logits,
+      Operand<TInt32> numSamples, Multinomial.Options... options) {
+    return Multinomial.create(scope, logits, numSamples, options);
   }
 
   /**
@@ -166,74 +103,21 @@ public final class RandomOps {
   }
 
   /**
-   * Builds an {@link StatelessRandomNormal} operation
+   * Builds an {@link ParameterizedTruncatedNormal} operation
    *
-   * @param shape The shape of the output tensor.
-   * @param seed 2 seeds (shape [2]).
-   * @return a new instance of StatelessRandomNormal
-   * @see org.tensorflow.op.random.StatelessRandomNormal
-   */
-  public <T extends TNumber, U extends TNumber> StatelessRandomNormal<TFloat32> statelessRandomNormal(
-      Operand<T> shape, Operand<U> seed) {
-    return StatelessRandomNormal.create(scope, shape, seed);
-  }
-
-  /**
-   * Builds an {@link StatefulRandomBinomial} operation
-   *
-   * @param resource 
-   * @param algorithm 
-   * @param shape 
-   * @param counts 
-   * @param probs 
-   * @param dtype 
-   * @return a new instance of StatefulRandomBinomial
-   * @see org.tensorflow.op.random.StatefulRandomBinomial
-   */
-  public <V extends TNumber, T extends TNumber, U extends TNumber> StatefulRandomBinomial<V> statefulRandomBinomial(
-      Operand<?> resource, Operand<TInt64> algorithm, Operand<T> shape, Operand<U> counts,
-      Operand<U> probs, DataType<V> dtype) {
-    return StatefulRandomBinomial.create(scope, resource, algorithm, shape, counts, probs, dtype);
-  }
-
-  /**
-   * Builds an {@link RandomShuffle} operation
-   *
-   * @param value The tensor to be shuffled.
+   * @param shape The shape of the output tensor. Batches are indexed by the 0th dimension.
+   * @param means The mean parameter of each batch.
+   * @param stdevs The standard deviation parameter of each batch. Must be greater than 0.
+   * @param minvals The minimum cutoff. May be -infinity.
+   * @param maxvals The maximum cutoff. May be +infinity, and must be more than the minval
    * @param options carries optional attributes values
-   * @return a new instance of RandomShuffle
-   * @see org.tensorflow.op.random.RandomShuffle
+   * @return a new instance of ParameterizedTruncatedNormal
+   * @see org.tensorflow.op.random.ParameterizedTruncatedNormal
    */
-  public <T extends TType> RandomShuffle<T> randomShuffle(Operand<T> value,
-      RandomShuffle.Options... options) {
-    return RandomShuffle.create(scope, value, options);
-  }
-
-  /**
-   * Builds an {@link RecordInput} operation
-   *
-   * @param filePattern Glob pattern for the data files.
-   * @param options carries optional attributes values
-   * @return a new instance of RecordInput
-   * @see org.tensorflow.op.random.RecordInput
-   */
-  public RecordInput recordInput(String filePattern, RecordInput.Options... options) {
-    return RecordInput.create(scope, filePattern, options);
-  }
-
-  /**
-   * Builds an {@link RandomUniformInt} operation
-   *
-   * @param shape The shape of the output tensor.
-   * @param minval 0-D.  Inclusive lower bound on the generated integers.
-   * @param maxval 0-D.  Exclusive upper bound on the generated integers.
-   * @param options carries optional attributes values
-   * @return a new instance of RandomUniformInt
-   * @see org.tensorflow.op.random.RandomUniformInt
-   */
-  public <U extends TNumber, T extends TNumber> RandomUniformInt<U> randomUniformInt(
-      Operand<T> shape, Operand<U> minval, Operand<U> maxval, RandomUniformInt.Options... options) {
-    return RandomUniformInt.create(scope, shape, minval, maxval, options);
+  public <U extends TNumber, T extends TNumber> ParameterizedTruncatedNormal<U> parameterizedTruncatedNormal(
+      Operand<T> shape, Operand<U> means, Operand<U> stdevs, Operand<U> minvals, Operand<U> maxvals,
+      ParameterizedTruncatedNormal.Options... options) {
+    return ParameterizedTruncatedNormal.create(scope, shape, means, stdevs, minvals, maxvals, options);
   }
 
   /**
@@ -280,132 +164,16 @@ public final class RandomOps {
   }
 
   /**
-   * Builds an {@link StatelessRandomUniform} operation
+   * Builds an {@link RandomShuffle} operation
    *
-   * @param shape The shape of the output tensor.
-   * @param seed 2 seeds (shape [2]).
-   * @return a new instance of StatelessRandomUniform
-   * @see org.tensorflow.op.random.StatelessRandomUniform
-   */
-  public <T extends TNumber, U extends TNumber> StatelessRandomUniform<TFloat32> statelessRandomUniform(
-      Operand<T> shape, Operand<U> seed) {
-    return StatelessRandomUniform.create(scope, shape, seed);
-  }
-
-  /**
-   * Builds an {@link StatelessMultinomial} operation
-   *
-   * @param logits 2-D Tensor with shape `[batch_size, num_classes]`.  Each slice `[i, :]`
-   * @param numSamples 0-D.  Number of independent samples to draw for each row slice.
-   * @param seed 2 seeds (shape [2]).
-   * @param outputDtype 
-   * @return a new instance of StatelessMultinomial
-   * @see org.tensorflow.op.random.StatelessMultinomial
-   */
-  public <V extends TNumber, T extends TNumber, U extends TNumber> StatelessMultinomial<V> statelessMultinomial(
-      Operand<T> logits, Operand<TInt32> numSamples, Operand<U> seed, DataType<V> outputDtype) {
-    return StatelessMultinomial.create(scope, logits, numSamples, seed, outputDtype);
-  }
-
-  /**
-   * Builds an {@link StatelessTruncatedNormal} operation
-   *
-   * @param shape The shape of the output tensor.
-   * @param seed 2 seeds (shape [2]).
-   * @return a new instance of StatelessTruncatedNormal
-   * @see org.tensorflow.op.random.StatelessTruncatedNormal
-   */
-  public <T extends TNumber, U extends TNumber> StatelessTruncatedNormal<TFloat32> statelessTruncatedNormal(
-      Operand<T> shape, Operand<U> seed) {
-    return StatelessTruncatedNormal.create(scope, shape, seed);
-  }
-
-  /**
-   * Builds an {@link StatefulStandardNormal} operation
-   *
-   * @param resource The handle of the resource variable that stores the state of the RNG.
-   * @param algorithm The RNG algorithm.
-   * @param shape The shape of the output tensor.
-   * @return a new instance of StatefulStandardNormal
-   * @see org.tensorflow.op.random.StatefulStandardNormal
-   */
-  public <T extends TType> StatefulStandardNormal<TFloat32> statefulStandardNormal(
-      Operand<?> resource, Operand<TInt64> algorithm, Operand<T> shape) {
-    return StatefulStandardNormal.create(scope, resource, algorithm, shape);
-  }
-
-  /**
-   * Builds an {@link StatelessMultinomial} operation
-   *
-   * @param logits 2-D Tensor with shape `[batch_size, num_classes]`.  Each slice `[i, :]`
-   * @param numSamples 0-D.  Number of independent samples to draw for each row slice.
-   * @param seed 2 seeds (shape [2]).
-   * @return a new instance of StatelessMultinomial
-   * @see org.tensorflow.op.random.StatelessMultinomial
-   */
-  public <T extends TNumber, U extends TNumber> StatelessMultinomial<TInt64> statelessMultinomial(
-      Operand<T> logits, Operand<TInt32> numSamples, Operand<U> seed) {
-    return StatelessMultinomial.create(scope, logits, numSamples, seed);
-  }
-
-  /**
-   * Builds an {@link StatefulStandardNormal} operation
-   *
-   * @param resource The handle of the resource variable that stores the state of the RNG.
-   * @param algorithm The RNG algorithm.
-   * @param shape The shape of the output tensor.
-   * @param dtype The type of the output.
-   * @return a new instance of StatefulStandardNormal
-   * @see org.tensorflow.op.random.StatefulStandardNormal
-   */
-  public <U extends TType, T extends TType> StatefulStandardNormal<U> statefulStandardNormal(
-      Operand<?> resource, Operand<TInt64> algorithm, Operand<T> shape, DataType<U> dtype) {
-    return StatefulStandardNormal.create(scope, resource, algorithm, shape, dtype);
-  }
-
-  /**
-   * Builds an {@link StatelessRandomNormal} operation
-   *
-   * @param shape The shape of the output tensor.
-   * @param seed 2 seeds (shape [2]).
-   * @param dtype The type of the output.
-   * @return a new instance of StatelessRandomNormal
-   * @see org.tensorflow.op.random.StatelessRandomNormal
-   */
-  public <V extends TNumber, T extends TNumber, U extends TNumber> StatelessRandomNormal<V> statelessRandomNormal(
-      Operand<T> shape, Operand<U> seed, DataType<V> dtype) {
-    return StatelessRandomNormal.create(scope, shape, seed, dtype);
-  }
-
-  /**
-   * Builds an {@link Multinomial} operation
-   *
-   * @param logits 2-D Tensor with shape `[batch_size, num_classes]`.  Each slice `[i, :]`
-   * @param numSamples 0-D.  Number of independent samples to draw for each row slice.
+   * @param value The tensor to be shuffled.
    * @param options carries optional attributes values
-   * @return a new instance of Multinomial
-   * @see org.tensorflow.op.random.Multinomial
+   * @return a new instance of RandomShuffle
+   * @see org.tensorflow.op.random.RandomShuffle
    */
-  public <T extends TNumber> Multinomial<TInt64> multinomial(Operand<T> logits,
-      Operand<TInt32> numSamples, Multinomial.Options... options) {
-    return Multinomial.create(scope, logits, numSamples, options);
-  }
-
-  /**
-   * Builds an {@link StatefulRandomBinomial} operation
-   *
-   * @param resource 
-   * @param algorithm 
-   * @param shape 
-   * @param counts 
-   * @param probs 
-   * @return a new instance of StatefulRandomBinomial
-   * @see org.tensorflow.op.random.StatefulRandomBinomial
-   */
-  public <T extends TNumber, U extends TNumber> StatefulRandomBinomial<TInt64> statefulRandomBinomial(
-      Operand<?> resource, Operand<TInt64> algorithm, Operand<T> shape, Operand<U> counts,
-      Operand<U> probs) {
-    return StatefulRandomBinomial.create(scope, resource, algorithm, shape, counts, probs);
+  public <T extends TType> RandomShuffle<T> randomShuffle(Operand<T> value,
+      RandomShuffle.Options... options) {
+    return RandomShuffle.create(scope, value, options);
   }
 
   /**
@@ -434,5 +202,237 @@ public final class RandomOps {
   public <U extends TNumber, T extends TNumber> RandomUniform<U> randomUniform(Operand<T> shape,
       DataType<U> dtype, RandomUniform.Options... options) {
     return RandomUniform.create(scope, shape, dtype, options);
+  }
+
+  /**
+   * Builds an {@link RandomUniformInt} operation
+   *
+   * @param shape The shape of the output tensor.
+   * @param minval 0-D.  Inclusive lower bound on the generated integers.
+   * @param maxval 0-D.  Exclusive upper bound on the generated integers.
+   * @param options carries optional attributes values
+   * @return a new instance of RandomUniformInt
+   * @see org.tensorflow.op.random.RandomUniformInt
+   */
+  public <U extends TNumber, T extends TNumber> RandomUniformInt<U> randomUniformInt(
+      Operand<T> shape, Operand<U> minval, Operand<U> maxval, RandomUniformInt.Options... options) {
+    return RandomUniformInt.create(scope, shape, minval, maxval, options);
+  }
+
+  /**
+   * Builds an {@link RecordInput} operation
+   *
+   * @param filePattern Glob pattern for the data files.
+   * @param options carries optional attributes values
+   * @return a new instance of RecordInput
+   * @see org.tensorflow.op.random.RecordInput
+   */
+  public RecordInput recordInput(String filePattern, RecordInput.Options... options) {
+    return RecordInput.create(scope, filePattern, options);
+  }
+
+  /**
+   * Builds an {@link StatefulRandomBinomial} operation
+   *
+   * @param resource 
+   * @param algorithm 
+   * @param shape 
+   * @param counts 
+   * @param probs 
+   * @return a new instance of StatefulRandomBinomial
+   * @see org.tensorflow.op.random.StatefulRandomBinomial
+   */
+  public <T extends TNumber, U extends TNumber> StatefulRandomBinomial<TInt64> statefulRandomBinomial(
+      Operand<?> resource, Operand<TInt64> algorithm, Operand<T> shape, Operand<U> counts,
+      Operand<U> probs) {
+    return StatefulRandomBinomial.create(scope, resource, algorithm, shape, counts, probs);
+  }
+
+  /**
+   * Builds an {@link StatefulRandomBinomial} operation
+   *
+   * @param resource 
+   * @param algorithm 
+   * @param shape 
+   * @param counts 
+   * @param probs 
+   * @param dtype 
+   * @return a new instance of StatefulRandomBinomial
+   * @see org.tensorflow.op.random.StatefulRandomBinomial
+   */
+  public <V extends TNumber, T extends TNumber, U extends TNumber> StatefulRandomBinomial<V> statefulRandomBinomial(
+      Operand<?> resource, Operand<TInt64> algorithm, Operand<T> shape, Operand<U> counts,
+      Operand<U> probs, DataType<V> dtype) {
+    return StatefulRandomBinomial.create(scope, resource, algorithm, shape, counts, probs, dtype);
+  }
+
+  /**
+   * Builds an {@link StatefulStandardNormal} operation
+   *
+   * @param resource The handle of the resource variable that stores the state of the RNG.
+   * @param algorithm The RNG algorithm.
+   * @param shape The shape of the output tensor.
+   * @return a new instance of StatefulStandardNormal
+   * @see org.tensorflow.op.random.StatefulStandardNormal
+   */
+  public <T extends TType> StatefulStandardNormal<TFloat32> statefulStandardNormal(
+      Operand<?> resource, Operand<TInt64> algorithm, Operand<T> shape) {
+    return StatefulStandardNormal.create(scope, resource, algorithm, shape);
+  }
+
+  /**
+   * Builds an {@link StatefulStandardNormal} operation
+   *
+   * @param resource The handle of the resource variable that stores the state of the RNG.
+   * @param algorithm The RNG algorithm.
+   * @param shape The shape of the output tensor.
+   * @param dtype The type of the output.
+   * @return a new instance of StatefulStandardNormal
+   * @see org.tensorflow.op.random.StatefulStandardNormal
+   */
+  public <U extends TType, T extends TType> StatefulStandardNormal<U> statefulStandardNormal(
+      Operand<?> resource, Operand<TInt64> algorithm, Operand<T> shape, DataType<U> dtype) {
+    return StatefulStandardNormal.create(scope, resource, algorithm, shape, dtype);
+  }
+
+  /**
+   * Builds an {@link StatelessMultinomial} operation
+   *
+   * @param logits 2-D Tensor with shape `[batch_size, num_classes]`.  Each slice `[i, :]`
+   * @param numSamples 0-D.  Number of independent samples to draw for each row slice.
+   * @param seed 2 seeds (shape [2]).
+   * @return a new instance of StatelessMultinomial
+   * @see org.tensorflow.op.random.StatelessMultinomial
+   */
+  public <T extends TNumber, U extends TNumber> StatelessMultinomial<TInt64> statelessMultinomial(
+      Operand<T> logits, Operand<TInt32> numSamples, Operand<U> seed) {
+    return StatelessMultinomial.create(scope, logits, numSamples, seed);
+  }
+
+  /**
+   * Builds an {@link StatelessMultinomial} operation
+   *
+   * @param logits 2-D Tensor with shape `[batch_size, num_classes]`.  Each slice `[i, :]`
+   * @param numSamples 0-D.  Number of independent samples to draw for each row slice.
+   * @param seed 2 seeds (shape [2]).
+   * @param outputDtype 
+   * @return a new instance of StatelessMultinomial
+   * @see org.tensorflow.op.random.StatelessMultinomial
+   */
+  public <V extends TNumber, T extends TNumber, U extends TNumber> StatelessMultinomial<V> statelessMultinomial(
+      Operand<T> logits, Operand<TInt32> numSamples, Operand<U> seed, DataType<V> outputDtype) {
+    return StatelessMultinomial.create(scope, logits, numSamples, seed, outputDtype);
+  }
+
+  /**
+   * Builds an {@link StatelessRandomNormal} operation
+   *
+   * @param shape The shape of the output tensor.
+   * @param seed 2 seeds (shape [2]).
+   * @return a new instance of StatelessRandomNormal
+   * @see org.tensorflow.op.random.StatelessRandomNormal
+   */
+  public <T extends TNumber, U extends TNumber> StatelessRandomNormal<TFloat32> statelessRandomNormal(
+      Operand<T> shape, Operand<U> seed) {
+    return StatelessRandomNormal.create(scope, shape, seed);
+  }
+
+  /**
+   * Builds an {@link StatelessRandomNormal} operation
+   *
+   * @param shape The shape of the output tensor.
+   * @param seed 2 seeds (shape [2]).
+   * @param dtype The type of the output.
+   * @return a new instance of StatelessRandomNormal
+   * @see org.tensorflow.op.random.StatelessRandomNormal
+   */
+  public <V extends TNumber, T extends TNumber, U extends TNumber> StatelessRandomNormal<V> statelessRandomNormal(
+      Operand<T> shape, Operand<U> seed, DataType<V> dtype) {
+    return StatelessRandomNormal.create(scope, shape, seed, dtype);
+  }
+
+  /**
+   * Builds an {@link StatelessRandomUniform} operation
+   *
+   * @param shape The shape of the output tensor.
+   * @param seed 2 seeds (shape [2]).
+   * @return a new instance of StatelessRandomUniform
+   * @see org.tensorflow.op.random.StatelessRandomUniform
+   */
+  public <T extends TNumber, U extends TNumber> StatelessRandomUniform<TFloat32> statelessRandomUniform(
+      Operand<T> shape, Operand<U> seed) {
+    return StatelessRandomUniform.create(scope, shape, seed);
+  }
+
+  /**
+   * Builds an {@link StatelessRandomUniform} operation
+   *
+   * @param shape The shape of the output tensor.
+   * @param seed 2 seeds (shape [2]).
+   * @param dtype The type of the output.
+   * @return a new instance of StatelessRandomUniform
+   * @see org.tensorflow.op.random.StatelessRandomUniform
+   */
+  public <V extends TNumber, T extends TNumber, U extends TNumber> StatelessRandomUniform<V> statelessRandomUniform(
+      Operand<T> shape, Operand<U> seed, DataType<V> dtype) {
+    return StatelessRandomUniform.create(scope, shape, seed, dtype);
+  }
+
+  /**
+   * Builds an {@link StatelessTruncatedNormal} operation
+   *
+   * @param shape The shape of the output tensor.
+   * @param seed 2 seeds (shape [2]).
+   * @return a new instance of StatelessTruncatedNormal
+   * @see org.tensorflow.op.random.StatelessTruncatedNormal
+   */
+  public <T extends TNumber, U extends TNumber> StatelessTruncatedNormal<TFloat32> statelessTruncatedNormal(
+      Operand<T> shape, Operand<U> seed) {
+    return StatelessTruncatedNormal.create(scope, shape, seed);
+  }
+
+  /**
+   * Builds an {@link StatelessTruncatedNormal} operation
+   *
+   * @param shape The shape of the output tensor.
+   * @param seed 2 seeds (shape [2]).
+   * @param dtype The type of the output.
+   * @return a new instance of StatelessTruncatedNormal
+   * @see org.tensorflow.op.random.StatelessTruncatedNormal
+   */
+  public <V extends TNumber, T extends TNumber, U extends TNumber> StatelessTruncatedNormal<V> statelessTruncatedNormal(
+      Operand<T> shape, Operand<U> seed, DataType<V> dtype) {
+    return StatelessTruncatedNormal.create(scope, shape, seed, dtype);
+  }
+
+  /**
+   * Builds an {@link TruncatedNormal} operation
+   *
+   * @param shape The shape of the output tensor.
+   * @param dtype The type of the output.
+   * @param options carries optional attributes values
+   * @return a new instance of TruncatedNormal
+   * @see org.tensorflow.op.random.TruncatedNormal
+   */
+  public <U extends TNumber, T extends TNumber> TruncatedNormal<U> truncatedNormal(Operand<T> shape,
+      DataType<U> dtype, TruncatedNormal.Options... options) {
+    return TruncatedNormal.create(scope, shape, dtype, options);
+  }
+
+  /**
+   * Builds an {@link UniformCandidateSampler} operation
+   *
+   * @param trueClasses A batch_size * num_true matrix, in which each row contains the
+   * @param numTrue Number of true labels per context.
+   * @param numSampled Number of candidates to randomly sample.
+   * @param unique If unique is true, we sample with rejection, so that all sampled
+   * @param rangeMax The sampler will sample integers from the interval [0, range_max).
+   * @param options carries optional attributes values
+   * @return a new instance of UniformCandidateSampler
+   * @see org.tensorflow.op.random.UniformCandidateSampler
+   */
+  public UniformCandidateSampler uniformCandidateSampler(Operand<TInt64> trueClasses, Long numTrue,
+      Long numSampled, Boolean unique, Long rangeMax, UniformCandidateSampler.Options... options) {
+    return UniformCandidateSampler.create(scope, trueClasses, numTrue, numSampled, unique, rangeMax, options);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SignalOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SignalOps.java
@@ -38,147 +38,14 @@ public final class SignalOps {
   }
 
   /**
-   * Builds an {@link Ifft3d} operation
-   *
-   * @param input A complex tensor.
-   * @return a new instance of Ifft3d
-   * @see org.tensorflow.op.signal.Ifft3d
-   */
-  public <T extends TType> Ifft3d<T> ifft3d(Operand<T> input) {
-    return Ifft3d.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Rfft3d} operation
-   *
-   * @param input A float32 tensor.
-   * @param fftLength An int32 tensor of shape [3]. The FFT length for each dimension.
-   * @param Tcomplex 
-   * @return a new instance of Rfft3d
-   * @see org.tensorflow.op.signal.Rfft3d
-   */
-  public <U extends TType, T extends TNumber> Rfft3d<U> rfft3d(Operand<T> input,
-      Operand<TInt32> fftLength, DataType<U> Tcomplex) {
-    return Rfft3d.create(scope, input, fftLength, Tcomplex);
-  }
-
-  /**
-   * Builds an {@link Rfft2d} operation
-   *
-   * @param input A float32 tensor.
-   * @param fftLength An int32 tensor of shape [2]. The FFT length for each dimension.
-   * @param Tcomplex 
-   * @return a new instance of Rfft2d
-   * @see org.tensorflow.op.signal.Rfft2d
-   */
-  public <U extends TType, T extends TNumber> Rfft2d<U> rfft2d(Operand<T> input,
-      Operand<TInt32> fftLength, DataType<U> Tcomplex) {
-    return Rfft2d.create(scope, input, fftLength, Tcomplex);
-  }
-
-  /**
-   * Builds an {@link BatchIfft} operation
+   * Builds an {@link BatchFft} operation
    *
    * @param input 
-   * @return a new instance of BatchIfft
-   * @see org.tensorflow.op.signal.BatchIfft
+   * @return a new instance of BatchFft
+   * @see org.tensorflow.op.signal.BatchFft
    */
-  public BatchIfft batchIfft(Operand<?> input) {
-    return BatchIfft.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Irfft3d} operation
-   *
-   * @param input A complex tensor.
-   * @param fftLength An int32 tensor of shape [3]. The FFT length for each dimension.
-   * @return a new instance of Irfft3d
-   * @see org.tensorflow.op.signal.Irfft3d
-   */
-  public <T extends TType> Irfft3d<TFloat32> irfft3d(Operand<T> input, Operand<TInt32> fftLength) {
-    return Irfft3d.create(scope, input, fftLength);
-  }
-
-  /**
-   * Builds an {@link Ifft2d} operation
-   *
-   * @param input A complex tensor.
-   * @return a new instance of Ifft2d
-   * @see org.tensorflow.op.signal.Ifft2d
-   */
-  public <T extends TType> Ifft2d<T> ifft2d(Operand<T> input) {
-    return Ifft2d.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Irfft3d} operation
-   *
-   * @param input A complex tensor.
-   * @param fftLength An int32 tensor of shape [3]. The FFT length for each dimension.
-   * @param Treal 
-   * @return a new instance of Irfft3d
-   * @see org.tensorflow.op.signal.Irfft3d
-   */
-  public <U extends TNumber, T extends TType> Irfft3d<U> irfft3d(Operand<T> input,
-      Operand<TInt32> fftLength, DataType<U> Treal) {
-    return Irfft3d.create(scope, input, fftLength, Treal);
-  }
-
-  /**
-   * Builds an {@link BatchIfft3d} operation
-   *
-   * @param input 
-   * @return a new instance of BatchIfft3d
-   * @see org.tensorflow.op.signal.BatchIfft3d
-   */
-  public BatchIfft3d batchIfft3d(Operand<?> input) {
-    return BatchIfft3d.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link BatchFft3d} operation
-   *
-   * @param input 
-   * @return a new instance of BatchFft3d
-   * @see org.tensorflow.op.signal.BatchFft3d
-   */
-  public BatchFft3d batchFft3d(Operand<?> input) {
-    return BatchFft3d.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Irfft2d} operation
-   *
-   * @param input A complex tensor.
-   * @param fftLength An int32 tensor of shape [2]. The FFT length for each dimension.
-   * @return a new instance of Irfft2d
-   * @see org.tensorflow.op.signal.Irfft2d
-   */
-  public <T extends TType> Irfft2d<TFloat32> irfft2d(Operand<T> input, Operand<TInt32> fftLength) {
-    return Irfft2d.create(scope, input, fftLength);
-  }
-
-  /**
-   * Builds an {@link Fft} operation
-   *
-   * @param input A complex tensor.
-   * @return a new instance of Fft
-   * @see org.tensorflow.op.signal.Fft
-   */
-  public <T extends TType> Fft<T> fft(Operand<T> input) {
-    return Fft.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link Irfft} operation
-   *
-   * @param input A complex tensor.
-   * @param fftLength An int32 tensor of shape [1]. The FFT length.
-   * @return a new instance of Irfft
-   * @see org.tensorflow.op.signal.Irfft
-   */
-  public <T extends TType> Irfft<TFloat32> irfft(Operand<T> input, Operand<TInt32> fftLength) {
-    return Irfft.create(scope, input, fftLength);
+  public BatchFft batchFft(Operand<?> input) {
+    return BatchFft.create(scope, input);
   }
 
   /**
@@ -193,17 +60,80 @@ public final class SignalOps {
   }
 
   /**
-   * Builds an {@link Rfft} operation
+   * Builds an {@link BatchFft3d} operation
    *
-   * @param input A float32 tensor.
-   * @param fftLength An int32 tensor of shape [1]. The FFT length.
-   * @param Tcomplex 
-   * @return a new instance of Rfft
-   * @see org.tensorflow.op.signal.Rfft
+   * @param input 
+   * @return a new instance of BatchFft3d
+   * @see org.tensorflow.op.signal.BatchFft3d
    */
-  public <U extends TType, T extends TNumber> Rfft<U> rfft(Operand<T> input,
-      Operand<TInt32> fftLength, DataType<U> Tcomplex) {
-    return Rfft.create(scope, input, fftLength, Tcomplex);
+  public BatchFft3d batchFft3d(Operand<?> input) {
+    return BatchFft3d.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link BatchIfft} operation
+   *
+   * @param input 
+   * @return a new instance of BatchIfft
+   * @see org.tensorflow.op.signal.BatchIfft
+   */
+  public BatchIfft batchIfft(Operand<?> input) {
+    return BatchIfft.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link BatchIfft2d} operation
+   *
+   * @param input 
+   * @return a new instance of BatchIfft2d
+   * @see org.tensorflow.op.signal.BatchIfft2d
+   */
+  public BatchIfft2d batchIfft2d(Operand<?> input) {
+    return BatchIfft2d.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link BatchIfft3d} operation
+   *
+   * @param input 
+   * @return a new instance of BatchIfft3d
+   * @see org.tensorflow.op.signal.BatchIfft3d
+   */
+  public BatchIfft3d batchIfft3d(Operand<?> input) {
+    return BatchIfft3d.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Fft} operation
+   *
+   * @param input A complex tensor.
+   * @return a new instance of Fft
+   * @see org.tensorflow.op.signal.Fft
+   */
+  public <T extends TType> Fft<T> fft(Operand<T> input) {
+    return Fft.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Fft2d} operation
+   *
+   * @param input A complex tensor.
+   * @return a new instance of Fft2d
+   * @see org.tensorflow.op.signal.Fft2d
+   */
+  public <T extends TType> Fft2d<T> fft2d(Operand<T> input) {
+    return Fft2d.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Fft3d} operation
+   *
+   * @param input A complex tensor.
+   * @return a new instance of Fft3d
+   * @see org.tensorflow.op.signal.Fft3d
+   */
+  public <T extends TType> Fft3d<T> fft3d(Operand<T> input) {
+    return Fft3d.create(scope, input);
   }
 
   /**
@@ -218,28 +148,37 @@ public final class SignalOps {
   }
 
   /**
-   * Builds an {@link Irfft2d} operation
+   * Builds an {@link Ifft2d} operation
    *
    * @param input A complex tensor.
-   * @param fftLength An int32 tensor of shape [2]. The FFT length for each dimension.
-   * @param Treal 
-   * @return a new instance of Irfft2d
-   * @see org.tensorflow.op.signal.Irfft2d
+   * @return a new instance of Ifft2d
+   * @see org.tensorflow.op.signal.Ifft2d
    */
-  public <U extends TNumber, T extends TType> Irfft2d<U> irfft2d(Operand<T> input,
-      Operand<TInt32> fftLength, DataType<U> Treal) {
-    return Irfft2d.create(scope, input, fftLength, Treal);
+  public <T extends TType> Ifft2d<T> ifft2d(Operand<T> input) {
+    return Ifft2d.create(scope, input);
   }
 
   /**
-   * Builds an {@link Fft3d} operation
+   * Builds an {@link Ifft3d} operation
    *
    * @param input A complex tensor.
-   * @return a new instance of Fft3d
-   * @see org.tensorflow.op.signal.Fft3d
+   * @return a new instance of Ifft3d
+   * @see org.tensorflow.op.signal.Ifft3d
    */
-  public <T extends TType> Fft3d<T> fft3d(Operand<T> input) {
-    return Fft3d.create(scope, input);
+  public <T extends TType> Ifft3d<T> ifft3d(Operand<T> input) {
+    return Ifft3d.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Irfft} operation
+   *
+   * @param input A complex tensor.
+   * @param fftLength An int32 tensor of shape [1]. The FFT length.
+   * @return a new instance of Irfft
+   * @see org.tensorflow.op.signal.Irfft
+   */
+  public <T extends TType> Irfft<TFloat32> irfft(Operand<T> input, Operand<TInt32> fftLength) {
+    return Irfft.create(scope, input, fftLength);
   }
 
   /**
@@ -257,35 +196,96 @@ public final class SignalOps {
   }
 
   /**
-   * Builds an {@link Fft2d} operation
+   * Builds an {@link Irfft2d} operation
    *
    * @param input A complex tensor.
-   * @return a new instance of Fft2d
-   * @see org.tensorflow.op.signal.Fft2d
+   * @param fftLength An int32 tensor of shape [2]. The FFT length for each dimension.
+   * @return a new instance of Irfft2d
+   * @see org.tensorflow.op.signal.Irfft2d
    */
-  public <T extends TType> Fft2d<T> fft2d(Operand<T> input) {
-    return Fft2d.create(scope, input);
+  public <T extends TType> Irfft2d<TFloat32> irfft2d(Operand<T> input, Operand<TInt32> fftLength) {
+    return Irfft2d.create(scope, input, fftLength);
   }
 
   /**
-   * Builds an {@link BatchFft} operation
+   * Builds an {@link Irfft2d} operation
    *
-   * @param input 
-   * @return a new instance of BatchFft
-   * @see org.tensorflow.op.signal.BatchFft
+   * @param input A complex tensor.
+   * @param fftLength An int32 tensor of shape [2]. The FFT length for each dimension.
+   * @param Treal 
+   * @return a new instance of Irfft2d
+   * @see org.tensorflow.op.signal.Irfft2d
    */
-  public BatchFft batchFft(Operand<?> input) {
-    return BatchFft.create(scope, input);
+  public <U extends TNumber, T extends TType> Irfft2d<U> irfft2d(Operand<T> input,
+      Operand<TInt32> fftLength, DataType<U> Treal) {
+    return Irfft2d.create(scope, input, fftLength, Treal);
   }
 
   /**
-   * Builds an {@link BatchIfft2d} operation
+   * Builds an {@link Irfft3d} operation
    *
-   * @param input 
-   * @return a new instance of BatchIfft2d
-   * @see org.tensorflow.op.signal.BatchIfft2d
+   * @param input A complex tensor.
+   * @param fftLength An int32 tensor of shape [3]. The FFT length for each dimension.
+   * @return a new instance of Irfft3d
+   * @see org.tensorflow.op.signal.Irfft3d
    */
-  public BatchIfft2d batchIfft2d(Operand<?> input) {
-    return BatchIfft2d.create(scope, input);
+  public <T extends TType> Irfft3d<TFloat32> irfft3d(Operand<T> input, Operand<TInt32> fftLength) {
+    return Irfft3d.create(scope, input, fftLength);
+  }
+
+  /**
+   * Builds an {@link Irfft3d} operation
+   *
+   * @param input A complex tensor.
+   * @param fftLength An int32 tensor of shape [3]. The FFT length for each dimension.
+   * @param Treal 
+   * @return a new instance of Irfft3d
+   * @see org.tensorflow.op.signal.Irfft3d
+   */
+  public <U extends TNumber, T extends TType> Irfft3d<U> irfft3d(Operand<T> input,
+      Operand<TInt32> fftLength, DataType<U> Treal) {
+    return Irfft3d.create(scope, input, fftLength, Treal);
+  }
+
+  /**
+   * Builds an {@link Rfft} operation
+   *
+   * @param input A float32 tensor.
+   * @param fftLength An int32 tensor of shape [1]. The FFT length.
+   * @param Tcomplex 
+   * @return a new instance of Rfft
+   * @see org.tensorflow.op.signal.Rfft
+   */
+  public <U extends TType, T extends TNumber> Rfft<U> rfft(Operand<T> input,
+      Operand<TInt32> fftLength, DataType<U> Tcomplex) {
+    return Rfft.create(scope, input, fftLength, Tcomplex);
+  }
+
+  /**
+   * Builds an {@link Rfft2d} operation
+   *
+   * @param input A float32 tensor.
+   * @param fftLength An int32 tensor of shape [2]. The FFT length for each dimension.
+   * @param Tcomplex 
+   * @return a new instance of Rfft2d
+   * @see org.tensorflow.op.signal.Rfft2d
+   */
+  public <U extends TType, T extends TNumber> Rfft2d<U> rfft2d(Operand<T> input,
+      Operand<TInt32> fftLength, DataType<U> Tcomplex) {
+    return Rfft2d.create(scope, input, fftLength, Tcomplex);
+  }
+
+  /**
+   * Builds an {@link Rfft3d} operation
+   *
+   * @param input A float32 tensor.
+   * @param fftLength An int32 tensor of shape [3]. The FFT length for each dimension.
+   * @param Tcomplex 
+   * @return a new instance of Rfft3d
+   * @see org.tensorflow.op.signal.Rfft3d
+   */
+  public <U extends TType, T extends TNumber> Rfft3d<U> rfft3d(Operand<T> input,
+      Operand<TInt32> fftLength, DataType<U> Tcomplex) {
+    return Rfft3d.create(scope, input, fftLength, Tcomplex);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SparseOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SparseOps.java
@@ -65,152 +65,81 @@ public final class SparseOps {
   }
 
   /**
-   * Builds an {@link SparseDenseCwiseMul} operation
+   * Builds an {@link AddManySparseToTensorsMap} operation
    *
-   * @param spIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param spValues 1-D.  `N` non-empty values corresponding to `sp_indices`.
-   * @param spShape 1-D.  Shape of the input SparseTensor.
-   * @param dense `R`-D.  The dense Tensor operand.
-   * @return a new instance of SparseDenseCwiseMul
-   * @see org.tensorflow.op.sparse.SparseDenseCwiseMul
-   */
-  public <T extends TType> SparseDenseCwiseMul<T> sparseDenseCwiseMul(Operand<TInt64> spIndices,
-      Operand<T> spValues, Operand<TInt64> spShape, Operand<T> dense) {
-    return SparseDenseCwiseMul.create(scope, spIndices, spValues, spShape, dense);
-  }
-
-  /**
-   * Builds an {@link SparseSliceGrad} operation
-   *
-   * @param backpropValGrad 1-D. The gradient with respect to
-   * @param inputIndices 2-D.  The `indices` of the input `SparseTensor`.
-   * @param inputStart 1-D. tensor represents the start of the slice.
-   * @param outputIndices 2-D.  The `indices` of the sliced `SparseTensor`.
-   * @return a new instance of SparseSliceGrad
-   * @see org.tensorflow.op.sparse.SparseSliceGrad
-   */
-  public <T extends TType> SparseSliceGrad<T> sparseSliceGrad(Operand<T> backpropValGrad,
-      Operand<TInt64> inputIndices, Operand<TInt64> inputStart, Operand<TInt64> outputIndices) {
-    return SparseSliceGrad.create(scope, backpropValGrad, inputIndices, inputStart, outputIndices);
-  }
-
-  /**
-   * Builds an {@link SparseToDense} operation
-   *
-   * @param sparseIndices 0-D, 1-D, or 2-D.  `sparse_indices[i]` contains the complete
-   * @param outputShape 1-D.  Shape of the dense output tensor.
-   * @param sparseValues 1-D.  Values corresponding to each row of `sparse_indices`,
-   * @param defaultValue Scalar value to set for indices not specified in
+   * @param sparseIndices 2-D.  The `indices` of the minibatch `SparseTensor`.
+   * @param sparseValues 1-D.  The `values` of the minibatch `SparseTensor`.
+   * @param sparseShape 1-D.  The `shape` of the minibatch `SparseTensor`.
    * @param options carries optional attributes values
-   * @return a new instance of SparseToDense
-   * @see org.tensorflow.op.sparse.SparseToDense
+   * @return a new instance of AddManySparseToTensorsMap
+   * @see org.tensorflow.op.sparse.AddManySparseToTensorsMap
    */
-  public <U extends TType, T extends TNumber> SparseToDense<U> sparseToDense(
-      Operand<T> sparseIndices, Operand<T> outputShape, Operand<U> sparseValues,
-      Operand<U> defaultValue, SparseToDense.Options... options) {
-    return SparseToDense.create(scope, sparseIndices, outputShape, sparseValues, defaultValue, options);
+  public <T extends TType> AddManySparseToTensorsMap addManySparseToTensorsMap(
+      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape,
+      AddManySparseToTensorsMap.Options... options) {
+    return AddManySparseToTensorsMap.create(scope, sparseIndices, sparseValues, sparseShape, options);
   }
 
   /**
-   * Builds an {@link SparseSegmentMean} operation
+   * Builds an {@link AddSparseToTensorsMap} operation
    *
-   * @param data 
-   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
-   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
-   * @return a new instance of SparseSegmentMean
-   * @see org.tensorflow.op.sparse.SparseSegmentMean
+   * @param sparseIndices 2-D.  The `indices` of the `SparseTensor`.
+   * @param sparseValues 1-D.  The `values` of the `SparseTensor`.
+   * @param sparseShape 1-D.  The `shape` of the `SparseTensor`.
+   * @param options carries optional attributes values
+   * @return a new instance of AddSparseToTensorsMap
+   * @see org.tensorflow.op.sparse.AddSparseToTensorsMap
    */
-  public <T extends TNumber, U extends TNumber> SparseSegmentMean<T> sparseSegmentMean(
-      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds) {
-    return SparseSegmentMean.create(scope, data, indices, segmentIds);
+  public <T extends TType> AddSparseToTensorsMap addSparseToTensorsMap(
+      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape,
+      AddSparseToTensorsMap.Options... options) {
+    return AddSparseToTensorsMap.create(scope, sparseIndices, sparseValues, sparseShape, options);
   }
 
   /**
-   * Builds an {@link SparseFillEmptyRows} operation
+   * Builds an {@link DenseToDenseSetOperation} operation
    *
-   * @param indices 2-D. the indices of the sparse tensor.
-   * @param values 1-D. the values of the sparse tensor.
-   * @param denseShape 1-D. the shape of the sparse tensor.
-   * @param defaultValue 0-D. default value to insert into location `[row, 0, ..., 0]`
-   * @return a new instance of SparseFillEmptyRows
-   * @see org.tensorflow.op.sparse.SparseFillEmptyRows
+   * @param set1 `Tensor` with rank `n`. 1st `n-1` dimensions must be the same as `set2`.
+   * @param set2 `Tensor` with rank `n`. 1st `n-1` dimensions must be the same as `set1`.
+   * @param setOperation 
+   * @param options carries optional attributes values
+   * @return a new instance of DenseToDenseSetOperation
+   * @see org.tensorflow.op.sparse.DenseToDenseSetOperation
    */
-  public <T extends TType> SparseFillEmptyRows<T> sparseFillEmptyRows(Operand<TInt64> indices,
-      Operand<T> values, Operand<TInt64> denseShape, Operand<T> defaultValue) {
-    return SparseFillEmptyRows.create(scope, indices, values, denseShape, defaultValue);
+  public <T extends TType> DenseToDenseSetOperation<T> denseToDenseSetOperation(Operand<T> set1,
+      Operand<T> set2, String setOperation, DenseToDenseSetOperation.Options... options) {
+    return DenseToDenseSetOperation.create(scope, set1, set2, setOperation, options);
   }
 
   /**
-   * Builds an {@link SparseSegmentMeanGrad} operation
+   * Builds an {@link DenseToSparseSetOperation} operation
    *
-   * @param grad gradient propagated to the SparseSegmentMean op.
-   * @param indices indices passed to the corresponding SparseSegmentMean op.
-   * @param segmentIds segment_ids passed to the corresponding SparseSegmentMean op.
-   * @param outputDim0 dimension 0 of "data" passed to SparseSegmentMean op.
-   * @return a new instance of SparseSegmentMeanGrad
-   * @see org.tensorflow.op.sparse.SparseSegmentMeanGrad
+   * @param set1 `Tensor` with rank `n`. 1st `n-1` dimensions must be the same as `set2`.
+   * @param set2Indices 2D `Tensor`, indices of a `SparseTensor`. Must be in row-major
+   * @param set2Values 1D `Tensor`, values of a `SparseTensor`. Must be in row-major
+   * @param set2Shape 1D `Tensor`, shape of a `SparseTensor`. `set2_shape[0...n-1]` must
+   * @param setOperation 
+   * @param options carries optional attributes values
+   * @return a new instance of DenseToSparseSetOperation
+   * @see org.tensorflow.op.sparse.DenseToSparseSetOperation
    */
-  public <T extends TNumber, U extends TNumber> SparseSegmentMeanGrad<T> sparseSegmentMeanGrad(
-      Operand<T> grad, Operand<U> indices, Operand<TInt32> segmentIds, Operand<TInt32> outputDim0) {
-    return SparseSegmentMeanGrad.create(scope, grad, indices, segmentIds, outputDim0);
+  public <T extends TType> DenseToSparseSetOperation<T> denseToSparseSetOperation(Operand<T> set1,
+      Operand<TInt64> set2Indices, Operand<T> set2Values, Operand<TInt64> set2Shape,
+      String setOperation, DenseToSparseSetOperation.Options... options) {
+    return DenseToSparseSetOperation.create(scope, set1, set2Indices, set2Values, set2Shape, setOperation, options);
   }
 
   /**
-   * Builds an {@link SparseSoftmax} operation
+   * Builds an {@link DeserializeSparse} operation
    *
-   * @param spIndices 2-D.  `NNZ x R` matrix with the indices of non-empty values in a
-   * @param spValues 1-D.  `NNZ` non-empty values corresponding to `sp_indices`.
-   * @param spShape 1-D.  Shape of the input SparseTensor.
-   * @return a new instance of SparseSoftmax
-   * @see org.tensorflow.op.sparse.SparseSoftmax
+   * @param serializedSparse The serialized `SparseTensor` objects. The last dimension
+   * @param dtype The `dtype` of the serialized `SparseTensor` objects.
+   * @return a new instance of DeserializeSparse
+   * @see org.tensorflow.op.sparse.DeserializeSparse
    */
-  public <T extends TNumber> SparseSoftmax<T> sparseSoftmax(Operand<TInt64> spIndices,
-      Operand<T> spValues, Operand<TInt64> spShape) {
-    return SparseSoftmax.create(scope, spIndices, spValues, spShape);
-  }
-
-  /**
-   * Builds an {@link SparseDenseCwiseAdd} operation
-   *
-   * @param spIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param spValues 1-D.  `N` non-empty values corresponding to `sp_indices`.
-   * @param spShape 1-D.  Shape of the input SparseTensor.
-   * @param dense `R`-D.  The dense Tensor operand.
-   * @return a new instance of SparseDenseCwiseAdd
-   * @see org.tensorflow.op.sparse.SparseDenseCwiseAdd
-   */
-  public <T extends TType> SparseDenseCwiseAdd<T> sparseDenseCwiseAdd(Operand<TInt64> spIndices,
-      Operand<T> spValues, Operand<TInt64> spShape, Operand<T> dense) {
-    return SparseDenseCwiseAdd.create(scope, spIndices, spValues, spShape, dense);
-  }
-
-  /**
-   * Builds an {@link SparseSegmentMeanWithNumSegments} operation
-   *
-   * @param data 
-   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
-   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
-   * @param numSegments Should equal the number of distinct segment IDs.
-   * @return a new instance of SparseSegmentMeanWithNumSegments
-   * @see org.tensorflow.op.sparse.SparseSegmentMeanWithNumSegments
-   */
-  public <T extends TNumber, U extends TNumber, V extends TNumber> SparseSegmentMeanWithNumSegments<T> sparseSegmentMeanWithNumSegments(
-      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds, Operand<V> numSegments) {
-    return SparseSegmentMeanWithNumSegments.create(scope, data, indices, segmentIds, numSegments);
-  }
-
-  /**
-   * Builds an {@link SparseReshape} operation
-   *
-   * @param inputIndices 2-D.  `N x R_in` matrix with the indices of non-empty values in a
-   * @param inputShape 1-D.  `R_in` vector with the input SparseTensor's dense shape.
-   * @param newShape 1-D.  `R_out` vector with the requested new dense shape.
-   * @return a new instance of SparseReshape
-   * @see org.tensorflow.op.sparse.SparseReshape
-   */
-  public SparseReshape sparseReshape(Operand<TInt64> inputIndices, Operand<TInt64> inputShape,
-      Operand<TInt64> newShape) {
-    return SparseReshape.create(scope, inputIndices, inputShape, newShape);
+  public <U extends TType, T extends TType> DeserializeSparse<U> deserializeSparse(
+      Operand<T> serializedSparse, DataType<U> dtype) {
+    return DeserializeSparse.create(scope, serializedSparse, dtype);
   }
 
   /**
@@ -232,96 +161,36 @@ public final class SparseOps {
   }
 
   /**
-   * Builds an {@link AddSparseToTensorsMap} operation
+   * Builds an {@link SparseAccumulatorTakeGradient} operation
    *
-   * @param sparseIndices 2-D.  The `indices` of the `SparseTensor`.
-   * @param sparseValues 1-D.  The `values` of the `SparseTensor`.
-   * @param sparseShape 1-D.  The `shape` of the `SparseTensor`.
-   * @param options carries optional attributes values
-   * @return a new instance of AddSparseToTensorsMap
-   * @see org.tensorflow.op.sparse.AddSparseToTensorsMap
+   * @param handle The handle to a SparseConditionalAccumulator.
+   * @param numRequired Number of gradients required before we return an aggregate.
+   * @param dtype The data type of accumulated gradients. Needs to correspond to the type
+   * @return a new instance of SparseAccumulatorTakeGradient
+   * @see org.tensorflow.op.sparse.SparseAccumulatorTakeGradient
    */
-  public <T extends TType> AddSparseToTensorsMap addSparseToTensorsMap(
-      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape,
-      AddSparseToTensorsMap.Options... options) {
-    return AddSparseToTensorsMap.create(scope, sparseIndices, sparseValues, sparseShape, options);
+  public <T extends TType> SparseAccumulatorTakeGradient<T> sparseAccumulatorTakeGradient(
+      Operand<TString> handle, Operand<TInt32> numRequired, DataType<T> dtype) {
+    return SparseAccumulatorTakeGradient.create(scope, handle, numRequired, dtype);
   }
 
   /**
-   * Builds an {@link SparseDenseCwiseDiv} operation
+   * Builds an {@link SparseAdd} operation
    *
-   * @param spIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param spValues 1-D.  `N` non-empty values corresponding to `sp_indices`.
-   * @param spShape 1-D.  Shape of the input SparseTensor.
-   * @param dense `R`-D.  The dense Tensor operand.
-   * @return a new instance of SparseDenseCwiseDiv
-   * @see org.tensorflow.op.sparse.SparseDenseCwiseDiv
+   * @param aIndices 2-D.  The `indices` of the first `SparseTensor`, size `[nnz, ndims]` Matrix.
+   * @param aValues 1-D.  The `values` of the first `SparseTensor`, size `[nnz]` Vector.
+   * @param aShape 1-D.  The `shape` of the first `SparseTensor`, size `[ndims]` Vector.
+   * @param bIndices 2-D.  The `indices` of the second `SparseTensor`, size `[nnz, ndims]` Matrix.
+   * @param bValues 1-D.  The `values` of the second `SparseTensor`, size `[nnz]` Vector.
+   * @param bShape 1-D.  The `shape` of the second `SparseTensor`, size `[ndims]` Vector.
+   * @param thresh 0-D.  The magnitude threshold that determines if an output value/index
+   * @return a new instance of SparseAdd
+   * @see org.tensorflow.op.sparse.SparseAdd
    */
-  public <T extends TType> SparseDenseCwiseDiv<T> sparseDenseCwiseDiv(Operand<TInt64> spIndices,
-      Operand<T> spValues, Operand<TInt64> spShape, Operand<T> dense) {
-    return SparseDenseCwiseDiv.create(scope, spIndices, spValues, spShape, dense);
-  }
-
-  /**
-   * Builds an {@link SparseConditionalAccumulator} operation
-   *
-   * @param dtype The type of the value being accumulated.
-   * @param shape The shape of the values.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseConditionalAccumulator
-   * @see org.tensorflow.op.sparse.SparseConditionalAccumulator
-   */
-  public <T extends TType> SparseConditionalAccumulator sparseConditionalAccumulator(
-      DataType<T> dtype, Shape shape, SparseConditionalAccumulator.Options... options) {
-    return SparseConditionalAccumulator.create(scope, dtype, shape, options);
-  }
-
-  /**
-   * Builds an {@link SparseSegmentSqrtNGrad} operation
-   *
-   * @param grad gradient propagated to the SparseSegmentSqrtN op.
-   * @param indices indices passed to the corresponding SparseSegmentSqrtN op.
-   * @param segmentIds segment_ids passed to the corresponding SparseSegmentSqrtN op.
-   * @param outputDim0 dimension 0 of "data" passed to SparseSegmentSqrtN op.
-   * @return a new instance of SparseSegmentSqrtNGrad
-   * @see org.tensorflow.op.sparse.SparseSegmentSqrtNGrad
-   */
-  public <T extends TNumber, U extends TNumber> SparseSegmentSqrtNGrad<T> sparseSegmentSqrtNGrad(
-      Operand<T> grad, Operand<U> indices, Operand<TInt32> segmentIds, Operand<TInt32> outputDim0) {
-    return SparseSegmentSqrtNGrad.create(scope, grad, indices, segmentIds, outputDim0);
-  }
-
-  /**
-   * Builds an {@link SparseReduceSumSparse} operation
-   *
-   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
-   * @param inputShape 1-D.  Shape of the input SparseTensor.
-   * @param reductionAxes 1-D.  Length-`K` vector containing the reduction axes.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseReduceSumSparse
-   * @see org.tensorflow.op.sparse.SparseReduceSumSparse
-   */
-  public <T extends TType> SparseReduceSumSparse<T> sparseReduceSumSparse(
-      Operand<TInt64> inputIndices, Operand<T> inputValues, Operand<TInt64> inputShape,
-      Operand<TInt32> reductionAxes, SparseReduceSumSparse.Options... options) {
-    return SparseReduceSumSparse.create(scope, inputIndices, inputValues, inputShape, reductionAxes, options);
-  }
-
-  /**
-   * Builds an {@link SparseSplit} operation
-   *
-   * @param splitDim 0-D.  The dimension along which to split.  Must be in the range
-   * @param indices 2-D tensor represents the indices of the sparse tensor.
-   * @param values 1-D tensor represents the values of the sparse tensor.
-   * @param shape 1-D. tensor represents the shape of the sparse tensor.
-   * @param numSplit The number of ways to split.
-   * @return a new instance of SparseSplit
-   * @see org.tensorflow.op.sparse.SparseSplit
-   */
-  public <T extends TType> SparseSplit<T> sparseSplit(Operand<TInt64> splitDim,
-      Operand<TInt64> indices, Operand<T> values, Operand<TInt64> shape, Long numSplit) {
-    return SparseSplit.create(scope, splitDim, indices, values, shape, numSplit);
+  public <T extends TType, U extends TNumber> SparseAdd<T> sparseAdd(Operand<TInt64> aIndices,
+      Operand<T> aValues, Operand<TInt64> aShape, Operand<TInt64> bIndices, Operand<T> bValues,
+      Operand<TInt64> bShape, Operand<U> thresh) {
+    return SparseAdd.create(scope, aIndices, aValues, aShape, bIndices, bValues, bShape, thresh);
   }
 
   /**
@@ -355,281 +224,17 @@ public final class SparseOps {
   }
 
   /**
-   * Builds an {@link SparseSlice} operation
+   * Builds an {@link SparseConditionalAccumulator} operation
    *
-   * @param indices 2-D tensor represents the indices of the sparse tensor.
-   * @param values 1-D tensor represents the values of the sparse tensor.
-   * @param shape 1-D. tensor represents the shape of the sparse tensor.
-   * @param start 1-D. tensor represents the start of the slice.
-   * @param size 1-D. tensor represents the size of the slice.
-   * @return a new instance of SparseSlice
-   * @see org.tensorflow.op.sparse.SparseSlice
-   */
-  public <T extends TType> SparseSlice<T> sparseSlice(Operand<TInt64> indices, Operand<T> values,
-      Operand<TInt64> shape, Operand<TInt64> start, Operand<TInt64> size) {
-    return SparseSlice.create(scope, indices, values, shape, start, size);
-  }
-
-  /**
-   * Builds an {@link SparseToSparseSetOperation} operation
-   *
-   * @param set1Indices 2D `Tensor`, indices of a `SparseTensor`. Must be in row-major
-   * @param set1Values 1D `Tensor`, values of a `SparseTensor`. Must be in row-major
-   * @param set1Shape 1D `Tensor`, shape of a `SparseTensor`. `set1_shape[0...n-1]` must
-   * @param set2Indices 2D `Tensor`, indices of a `SparseTensor`. Must be in row-major
-   * @param set2Values 1D `Tensor`, values of a `SparseTensor`. Must be in row-major
-   * @param set2Shape 1D `Tensor`, shape of a `SparseTensor`. `set2_shape[0...n-1]` must
-   * @param setOperation 
+   * @param dtype The type of the value being accumulated.
+   * @param shape The shape of the values.
    * @param options carries optional attributes values
-   * @return a new instance of SparseToSparseSetOperation
-   * @see org.tensorflow.op.sparse.SparseToSparseSetOperation
+   * @return a new instance of SparseConditionalAccumulator
+   * @see org.tensorflow.op.sparse.SparseConditionalAccumulator
    */
-  public <T extends TType> SparseToSparseSetOperation<T> sparseToSparseSetOperation(
-      Operand<TInt64> set1Indices, Operand<T> set1Values, Operand<TInt64> set1Shape,
-      Operand<TInt64> set2Indices, Operand<T> set2Values, Operand<TInt64> set2Shape,
-      String setOperation, SparseToSparseSetOperation.Options... options) {
-    return SparseToSparseSetOperation.create(scope, set1Indices, set1Values, set1Shape, set2Indices, set2Values, set2Shape, setOperation, options);
-  }
-
-  /**
-   * Builds an {@link SparseReduceSum} operation
-   *
-   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
-   * @param inputShape 1-D.  Shape of the input SparseTensor.
-   * @param reductionAxes 1-D.  Length-`K` vector containing the reduction axes.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseReduceSum
-   * @see org.tensorflow.op.sparse.SparseReduceSum
-   */
-  public <T extends TType> SparseReduceSum<T> sparseReduceSum(Operand<TInt64> inputIndices,
-      Operand<T> inputValues, Operand<TInt64> inputShape, Operand<TInt32> reductionAxes,
-      SparseReduceSum.Options... options) {
-    return SparseReduceSum.create(scope, inputIndices, inputValues, inputShape, reductionAxes, options);
-  }
-
-  /**
-   * Builds an {@link SparseReorder} operation
-   *
-   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
-   * @param inputShape 1-D.  Shape of the input SparseTensor.
-   * @return a new instance of SparseReorder
-   * @see org.tensorflow.op.sparse.SparseReorder
-   */
-  public <T extends TType> SparseReorder<T> sparseReorder(Operand<TInt64> inputIndices,
-      Operand<T> inputValues, Operand<TInt64> inputShape) {
-    return SparseReorder.create(scope, inputIndices, inputValues, inputShape);
-  }
-
-  /**
-   * Builds an {@link AddManySparseToTensorsMap} operation
-   *
-   * @param sparseIndices 2-D.  The `indices` of the minibatch `SparseTensor`.
-   * @param sparseValues 1-D.  The `values` of the minibatch `SparseTensor`.
-   * @param sparseShape 1-D.  The `shape` of the minibatch `SparseTensor`.
-   * @param options carries optional attributes values
-   * @return a new instance of AddManySparseToTensorsMap
-   * @see org.tensorflow.op.sparse.AddManySparseToTensorsMap
-   */
-  public <T extends TType> AddManySparseToTensorsMap addManySparseToTensorsMap(
-      Operand<TInt64> sparseIndices, Operand<T> sparseValues, Operand<TInt64> sparseShape,
-      AddManySparseToTensorsMap.Options... options) {
-    return AddManySparseToTensorsMap.create(scope, sparseIndices, sparseValues, sparseShape, options);
-  }
-
-  /**
-   * Builds an {@link SparseAdd} operation
-   *
-   * @param aIndices 2-D.  The `indices` of the first `SparseTensor`, size `[nnz, ndims]` Matrix.
-   * @param aValues 1-D.  The `values` of the first `SparseTensor`, size `[nnz]` Vector.
-   * @param aShape 1-D.  The `shape` of the first `SparseTensor`, size `[ndims]` Vector.
-   * @param bIndices 2-D.  The `indices` of the second `SparseTensor`, size `[nnz, ndims]` Matrix.
-   * @param bValues 1-D.  The `values` of the second `SparseTensor`, size `[nnz]` Vector.
-   * @param bShape 1-D.  The `shape` of the second `SparseTensor`, size `[ndims]` Vector.
-   * @param thresh 0-D.  The magnitude threshold that determines if an output value/index
-   * @return a new instance of SparseAdd
-   * @see org.tensorflow.op.sparse.SparseAdd
-   */
-  public <T extends TType, U extends TNumber> SparseAdd<T> sparseAdd(Operand<TInt64> aIndices,
-      Operand<T> aValues, Operand<TInt64> aShape, Operand<TInt64> bIndices, Operand<T> bValues,
-      Operand<TInt64> bShape, Operand<U> thresh) {
-    return SparseAdd.create(scope, aIndices, aValues, aShape, bIndices, bValues, bShape, thresh);
-  }
-
-  /**
-   * Builds an {@link SparseSegmentSum} operation
-   *
-   * @param data 
-   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
-   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
-   * @return a new instance of SparseSegmentSum
-   * @see org.tensorflow.op.sparse.SparseSegmentSum
-   */
-  public <T extends TNumber, U extends TNumber> SparseSegmentSum<T> sparseSegmentSum(
-      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds) {
-    return SparseSegmentSum.create(scope, data, indices, segmentIds);
-  }
-
-  /**
-   * Builds an {@link DenseToSparseSetOperation} operation
-   *
-   * @param set1 `Tensor` with rank `n`. 1st `n-1` dimensions must be the same as `set2`.
-   * @param set2Indices 2D `Tensor`, indices of a `SparseTensor`. Must be in row-major
-   * @param set2Values 1D `Tensor`, values of a `SparseTensor`. Must be in row-major
-   * @param set2Shape 1D `Tensor`, shape of a `SparseTensor`. `set2_shape[0...n-1]` must
-   * @param setOperation 
-   * @param options carries optional attributes values
-   * @return a new instance of DenseToSparseSetOperation
-   * @see org.tensorflow.op.sparse.DenseToSparseSetOperation
-   */
-  public <T extends TType> DenseToSparseSetOperation<T> denseToSparseSetOperation(Operand<T> set1,
-      Operand<TInt64> set2Indices, Operand<T> set2Values, Operand<TInt64> set2Shape,
-      String setOperation, DenseToSparseSetOperation.Options... options) {
-    return DenseToSparseSetOperation.create(scope, set1, set2Indices, set2Values, set2Shape, setOperation, options);
-  }
-
-  /**
-   * Builds an {@link SparseFillEmptyRowsGrad} operation
-   *
-   * @param reverseIndexMap 1-D.  The reverse index map from SparseFillEmptyRows.
-   * @param gradValues 1-D.  The gradients from backprop.
-   * @return a new instance of SparseFillEmptyRowsGrad
-   * @see org.tensorflow.op.sparse.SparseFillEmptyRowsGrad
-   */
-  public <T extends TType> SparseFillEmptyRowsGrad<T> sparseFillEmptyRowsGrad(
-      Operand<TInt64> reverseIndexMap, Operand<T> gradValues) {
-    return SparseFillEmptyRowsGrad.create(scope, reverseIndexMap, gradValues);
-  }
-
-  /**
-   * Builds an {@link SparseReduceMax} operation
-   *
-   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
-   * @param inputShape 1-D.  Shape of the input SparseTensor.
-   * @param reductionAxes 1-D.  Length-`K` vector containing the reduction axes.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseReduceMax
-   * @see org.tensorflow.op.sparse.SparseReduceMax
-   */
-  public <T extends TNumber> SparseReduceMax<T> sparseReduceMax(Operand<TInt64> inputIndices,
-      Operand<T> inputValues, Operand<TInt64> inputShape, Operand<TInt32> reductionAxes,
-      SparseReduceMax.Options... options) {
-    return SparseReduceMax.create(scope, inputIndices, inputValues, inputShape, reductionAxes, options);
-  }
-
-  /**
-   * Builds an {@link SparseSparseMaximum} operation
-   *
-   * @param aIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param aValues 1-D.  `N` non-empty values corresponding to `a_indices`.
-   * @param aShape 1-D.  Shape of the input SparseTensor.
-   * @param bIndices counterpart to `a_indices` for the other operand.
-   * @param bValues counterpart to `a_values` for the other operand; must be of the same dtype.
-   * @param bShape counterpart to `a_shape` for the other operand; the two shapes must be equal.
-   * @return a new instance of SparseSparseMaximum
-   * @see org.tensorflow.op.sparse.SparseSparseMaximum
-   */
-  public <T extends TNumber> SparseSparseMaximum<T> sparseSparseMaximum(Operand<TInt64> aIndices,
-      Operand<T> aValues, Operand<TInt64> aShape, Operand<TInt64> bIndices, Operand<T> bValues,
-      Operand<TInt64> bShape) {
-    return SparseSparseMaximum.create(scope, aIndices, aValues, aShape, bIndices, bValues, bShape);
-  }
-
-  /**
-   * Builds an {@link DeserializeSparse} operation
-   *
-   * @param serializedSparse The serialized `SparseTensor` objects. The last dimension
-   * @param dtype The `dtype` of the serialized `SparseTensor` objects.
-   * @return a new instance of DeserializeSparse
-   * @see org.tensorflow.op.sparse.DeserializeSparse
-   */
-  public <U extends TType, T extends TType> DeserializeSparse<U> deserializeSparse(
-      Operand<T> serializedSparse, DataType<U> dtype) {
-    return DeserializeSparse.create(scope, serializedSparse, dtype);
-  }
-
-  /**
-   * Builds an {@link TakeManySparseFromTensorsMap} operation
-   *
-   * @param sparseHandles 1-D, The `N` serialized `SparseTensor` objects.
-   * @param dtype The `dtype` of the `SparseTensor` objects stored in the
-   * @param options carries optional attributes values
-   * @return a new instance of TakeManySparseFromTensorsMap
-   * @see org.tensorflow.op.sparse.TakeManySparseFromTensorsMap
-   */
-  public <T extends TType> TakeManySparseFromTensorsMap<T> takeManySparseFromTensorsMap(
-      Operand<TInt64> sparseHandles, DataType<T> dtype,
-      TakeManySparseFromTensorsMap.Options... options) {
-    return TakeManySparseFromTensorsMap.create(scope, sparseHandles, dtype, options);
-  }
-
-  /**
-   * Builds an {@link SparseSegmentSumWithNumSegments} operation
-   *
-   * @param data 
-   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
-   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
-   * @param numSegments Should equal the number of distinct segment IDs.
-   * @return a new instance of SparseSegmentSumWithNumSegments
-   * @see org.tensorflow.op.sparse.SparseSegmentSumWithNumSegments
-   */
-  public <T extends TNumber, U extends TNumber, V extends TNumber> SparseSegmentSumWithNumSegments<T> sparseSegmentSumWithNumSegments(
-      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds, Operand<V> numSegments) {
-    return SparseSegmentSumWithNumSegments.create(scope, data, indices, segmentIds, numSegments);
-  }
-
-  /**
-   * Builds an {@link SparseReduceMaxSparse} operation
-   *
-   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
-   * @param inputShape 1-D.  Shape of the input SparseTensor.
-   * @param reductionAxes 1-D.  Length-`K` vector containing the reduction axes.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseReduceMaxSparse
-   * @see org.tensorflow.op.sparse.SparseReduceMaxSparse
-   */
-  public <T extends TNumber> SparseReduceMaxSparse<T> sparseReduceMaxSparse(
-      Operand<TInt64> inputIndices, Operand<T> inputValues, Operand<TInt64> inputShape,
-      Operand<TInt32> reductionAxes, SparseReduceMaxSparse.Options... options) {
-    return SparseReduceMaxSparse.create(scope, inputIndices, inputValues, inputShape, reductionAxes, options);
-  }
-
-  /**
-   * Builds an {@link SparseTensorDenseMatMul} operation
-   *
-   * @param aIndices 2-D.  The `indices` of the `SparseTensor`, size `[nnz, 2]` Matrix.
-   * @param aValues 1-D.  The `values` of the `SparseTensor`, size `[nnz]` Vector.
-   * @param aShape 1-D.  The `shape` of the `SparseTensor`, size `[2]` Vector.
-   * @param b 2-D.  A dense Matrix.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseTensorDenseMatMul
-   * @see org.tensorflow.op.sparse.SparseTensorDenseMatMul
-   */
-  public <U extends TType, T extends TNumber> SparseTensorDenseMatMul<U> sparseTensorDenseMatMul(
-      Operand<T> aIndices, Operand<U> aValues, Operand<TInt64> aShape, Operand<U> b,
-      SparseTensorDenseMatMul.Options... options) {
-    return SparseTensorDenseMatMul.create(scope, aIndices, aValues, aShape, b, options);
-  }
-
-  /**
-   * Builds an {@link SparseSparseMinimum} operation
-   *
-   * @param aIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
-   * @param aValues 1-D.  `N` non-empty values corresponding to `a_indices`.
-   * @param aShape 1-D.  Shape of the input SparseTensor.
-   * @param bIndices counterpart to `a_indices` for the other operand.
-   * @param bValues counterpart to `a_values` for the other operand; must be of the same dtype.
-   * @param bShape counterpart to `a_shape` for the other operand; the two shapes must be equal.
-   * @return a new instance of SparseSparseMinimum
-   * @see org.tensorflow.op.sparse.SparseSparseMinimum
-   */
-  public <T extends TType> SparseSparseMinimum<T> sparseSparseMinimum(Operand<TInt64> aIndices,
-      Operand<T> aValues, Operand<TInt64> aShape, Operand<TInt64> bIndices, Operand<T> bValues,
-      Operand<TInt64> bShape) {
-    return SparseSparseMinimum.create(scope, aIndices, aValues, aShape, bIndices, bValues, bShape);
+  public <T extends TType> SparseConditionalAccumulator sparseConditionalAccumulator(
+      DataType<T> dtype, Shape shape, SparseConditionalAccumulator.Options... options) {
+    return SparseConditionalAccumulator.create(scope, dtype, shape, options);
   }
 
   /**
@@ -655,32 +260,76 @@ public final class SparseOps {
   }
 
   /**
-   * Builds an {@link SparseSegmentSqrtNWithNumSegments} operation
+   * Builds an {@link SparseDenseCwiseAdd} operation
    *
-   * @param data 
-   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
-   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
-   * @param numSegments Should equal the number of distinct segment IDs.
-   * @return a new instance of SparseSegmentSqrtNWithNumSegments
-   * @see org.tensorflow.op.sparse.SparseSegmentSqrtNWithNumSegments
+   * @param spIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param spValues 1-D.  `N` non-empty values corresponding to `sp_indices`.
+   * @param spShape 1-D.  Shape of the input SparseTensor.
+   * @param dense `R`-D.  The dense Tensor operand.
+   * @return a new instance of SparseDenseCwiseAdd
+   * @see org.tensorflow.op.sparse.SparseDenseCwiseAdd
    */
-  public <T extends TNumber, U extends TNumber, V extends TNumber> SparseSegmentSqrtNWithNumSegments<T> sparseSegmentSqrtNWithNumSegments(
-      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds, Operand<V> numSegments) {
-    return SparseSegmentSqrtNWithNumSegments.create(scope, data, indices, segmentIds, numSegments);
+  public <T extends TType> SparseDenseCwiseAdd<T> sparseDenseCwiseAdd(Operand<TInt64> spIndices,
+      Operand<T> spValues, Operand<TInt64> spShape, Operand<T> dense) {
+    return SparseDenseCwiseAdd.create(scope, spIndices, spValues, spShape, dense);
   }
 
   /**
-   * Builds an {@link SparseAccumulatorTakeGradient} operation
+   * Builds an {@link SparseDenseCwiseDiv} operation
    *
-   * @param handle The handle to a SparseConditionalAccumulator.
-   * @param numRequired Number of gradients required before we return an aggregate.
-   * @param dtype The data type of accumulated gradients. Needs to correspond to the type
-   * @return a new instance of SparseAccumulatorTakeGradient
-   * @see org.tensorflow.op.sparse.SparseAccumulatorTakeGradient
+   * @param spIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param spValues 1-D.  `N` non-empty values corresponding to `sp_indices`.
+   * @param spShape 1-D.  Shape of the input SparseTensor.
+   * @param dense `R`-D.  The dense Tensor operand.
+   * @return a new instance of SparseDenseCwiseDiv
+   * @see org.tensorflow.op.sparse.SparseDenseCwiseDiv
    */
-  public <T extends TType> SparseAccumulatorTakeGradient<T> sparseAccumulatorTakeGradient(
-      Operand<TString> handle, Operand<TInt32> numRequired, DataType<T> dtype) {
-    return SparseAccumulatorTakeGradient.create(scope, handle, numRequired, dtype);
+  public <T extends TType> SparseDenseCwiseDiv<T> sparseDenseCwiseDiv(Operand<TInt64> spIndices,
+      Operand<T> spValues, Operand<TInt64> spShape, Operand<T> dense) {
+    return SparseDenseCwiseDiv.create(scope, spIndices, spValues, spShape, dense);
+  }
+
+  /**
+   * Builds an {@link SparseDenseCwiseMul} operation
+   *
+   * @param spIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param spValues 1-D.  `N` non-empty values corresponding to `sp_indices`.
+   * @param spShape 1-D.  Shape of the input SparseTensor.
+   * @param dense `R`-D.  The dense Tensor operand.
+   * @return a new instance of SparseDenseCwiseMul
+   * @see org.tensorflow.op.sparse.SparseDenseCwiseMul
+   */
+  public <T extends TType> SparseDenseCwiseMul<T> sparseDenseCwiseMul(Operand<TInt64> spIndices,
+      Operand<T> spValues, Operand<TInt64> spShape, Operand<T> dense) {
+    return SparseDenseCwiseMul.create(scope, spIndices, spValues, spShape, dense);
+  }
+
+  /**
+   * Builds an {@link SparseFillEmptyRows} operation
+   *
+   * @param indices 2-D. the indices of the sparse tensor.
+   * @param values 1-D. the values of the sparse tensor.
+   * @param denseShape 1-D. the shape of the sparse tensor.
+   * @param defaultValue 0-D. default value to insert into location `[row, 0, ..., 0]`
+   * @return a new instance of SparseFillEmptyRows
+   * @see org.tensorflow.op.sparse.SparseFillEmptyRows
+   */
+  public <T extends TType> SparseFillEmptyRows<T> sparseFillEmptyRows(Operand<TInt64> indices,
+      Operand<T> values, Operand<TInt64> denseShape, Operand<T> defaultValue) {
+    return SparseFillEmptyRows.create(scope, indices, values, denseShape, defaultValue);
+  }
+
+  /**
+   * Builds an {@link SparseFillEmptyRowsGrad} operation
+   *
+   * @param reverseIndexMap 1-D.  The reverse index map from SparseFillEmptyRows.
+   * @param gradValues 1-D.  The gradients from backprop.
+   * @return a new instance of SparseFillEmptyRowsGrad
+   * @see org.tensorflow.op.sparse.SparseFillEmptyRowsGrad
+   */
+  public <T extends TType> SparseFillEmptyRowsGrad<T> sparseFillEmptyRowsGrad(
+      Operand<TInt64> reverseIndexMap, Operand<T> gradValues) {
+    return SparseFillEmptyRowsGrad.create(scope, reverseIndexMap, gradValues);
   }
 
   /**
@@ -698,18 +347,143 @@ public final class SparseOps {
   }
 
   /**
-   * Builds an {@link DenseToDenseSetOperation} operation
+   * Builds an {@link SparseReduceMax} operation
    *
-   * @param set1 `Tensor` with rank `n`. 1st `n-1` dimensions must be the same as `set2`.
-   * @param set2 `Tensor` with rank `n`. 1st `n-1` dimensions must be the same as `set1`.
-   * @param setOperation 
+   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
+   * @param inputShape 1-D.  Shape of the input SparseTensor.
+   * @param reductionAxes 1-D.  Length-`K` vector containing the reduction axes.
    * @param options carries optional attributes values
-   * @return a new instance of DenseToDenseSetOperation
-   * @see org.tensorflow.op.sparse.DenseToDenseSetOperation
+   * @return a new instance of SparseReduceMax
+   * @see org.tensorflow.op.sparse.SparseReduceMax
    */
-  public <T extends TType> DenseToDenseSetOperation<T> denseToDenseSetOperation(Operand<T> set1,
-      Operand<T> set2, String setOperation, DenseToDenseSetOperation.Options... options) {
-    return DenseToDenseSetOperation.create(scope, set1, set2, setOperation, options);
+  public <T extends TNumber> SparseReduceMax<T> sparseReduceMax(Operand<TInt64> inputIndices,
+      Operand<T> inputValues, Operand<TInt64> inputShape, Operand<TInt32> reductionAxes,
+      SparseReduceMax.Options... options) {
+    return SparseReduceMax.create(scope, inputIndices, inputValues, inputShape, reductionAxes, options);
+  }
+
+  /**
+   * Builds an {@link SparseReduceMaxSparse} operation
+   *
+   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
+   * @param inputShape 1-D.  Shape of the input SparseTensor.
+   * @param reductionAxes 1-D.  Length-`K` vector containing the reduction axes.
+   * @param options carries optional attributes values
+   * @return a new instance of SparseReduceMaxSparse
+   * @see org.tensorflow.op.sparse.SparseReduceMaxSparse
+   */
+  public <T extends TNumber> SparseReduceMaxSparse<T> sparseReduceMaxSparse(
+      Operand<TInt64> inputIndices, Operand<T> inputValues, Operand<TInt64> inputShape,
+      Operand<TInt32> reductionAxes, SparseReduceMaxSparse.Options... options) {
+    return SparseReduceMaxSparse.create(scope, inputIndices, inputValues, inputShape, reductionAxes, options);
+  }
+
+  /**
+   * Builds an {@link SparseReduceSum} operation
+   *
+   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
+   * @param inputShape 1-D.  Shape of the input SparseTensor.
+   * @param reductionAxes 1-D.  Length-`K` vector containing the reduction axes.
+   * @param options carries optional attributes values
+   * @return a new instance of SparseReduceSum
+   * @see org.tensorflow.op.sparse.SparseReduceSum
+   */
+  public <T extends TType> SparseReduceSum<T> sparseReduceSum(Operand<TInt64> inputIndices,
+      Operand<T> inputValues, Operand<TInt64> inputShape, Operand<TInt32> reductionAxes,
+      SparseReduceSum.Options... options) {
+    return SparseReduceSum.create(scope, inputIndices, inputValues, inputShape, reductionAxes, options);
+  }
+
+  /**
+   * Builds an {@link SparseReduceSumSparse} operation
+   *
+   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
+   * @param inputShape 1-D.  Shape of the input SparseTensor.
+   * @param reductionAxes 1-D.  Length-`K` vector containing the reduction axes.
+   * @param options carries optional attributes values
+   * @return a new instance of SparseReduceSumSparse
+   * @see org.tensorflow.op.sparse.SparseReduceSumSparse
+   */
+  public <T extends TType> SparseReduceSumSparse<T> sparseReduceSumSparse(
+      Operand<TInt64> inputIndices, Operand<T> inputValues, Operand<TInt64> inputShape,
+      Operand<TInt32> reductionAxes, SparseReduceSumSparse.Options... options) {
+    return SparseReduceSumSparse.create(scope, inputIndices, inputValues, inputShape, reductionAxes, options);
+  }
+
+  /**
+   * Builds an {@link SparseReorder} operation
+   *
+   * @param inputIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param inputValues 1-D.  `N` non-empty values corresponding to `input_indices`.
+   * @param inputShape 1-D.  Shape of the input SparseTensor.
+   * @return a new instance of SparseReorder
+   * @see org.tensorflow.op.sparse.SparseReorder
+   */
+  public <T extends TType> SparseReorder<T> sparseReorder(Operand<TInt64> inputIndices,
+      Operand<T> inputValues, Operand<TInt64> inputShape) {
+    return SparseReorder.create(scope, inputIndices, inputValues, inputShape);
+  }
+
+  /**
+   * Builds an {@link SparseReshape} operation
+   *
+   * @param inputIndices 2-D.  `N x R_in` matrix with the indices of non-empty values in a
+   * @param inputShape 1-D.  `R_in` vector with the input SparseTensor's dense shape.
+   * @param newShape 1-D.  `R_out` vector with the requested new dense shape.
+   * @return a new instance of SparseReshape
+   * @see org.tensorflow.op.sparse.SparseReshape
+   */
+  public SparseReshape sparseReshape(Operand<TInt64> inputIndices, Operand<TInt64> inputShape,
+      Operand<TInt64> newShape) {
+    return SparseReshape.create(scope, inputIndices, inputShape, newShape);
+  }
+
+  /**
+   * Builds an {@link SparseSegmentMean} operation
+   *
+   * @param data 
+   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
+   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
+   * @return a new instance of SparseSegmentMean
+   * @see org.tensorflow.op.sparse.SparseSegmentMean
+   */
+  public <T extends TNumber, U extends TNumber> SparseSegmentMean<T> sparseSegmentMean(
+      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds) {
+    return SparseSegmentMean.create(scope, data, indices, segmentIds);
+  }
+
+  /**
+   * Builds an {@link SparseSegmentMeanGrad} operation
+   *
+   * @param grad gradient propagated to the SparseSegmentMean op.
+   * @param indices indices passed to the corresponding SparseSegmentMean op.
+   * @param segmentIds segment_ids passed to the corresponding SparseSegmentMean op.
+   * @param outputDim0 dimension 0 of "data" passed to SparseSegmentMean op.
+   * @return a new instance of SparseSegmentMeanGrad
+   * @see org.tensorflow.op.sparse.SparseSegmentMeanGrad
+   */
+  public <T extends TNumber, U extends TNumber> SparseSegmentMeanGrad<T> sparseSegmentMeanGrad(
+      Operand<T> grad, Operand<U> indices, Operand<TInt32> segmentIds, Operand<TInt32> outputDim0) {
+    return SparseSegmentMeanGrad.create(scope, grad, indices, segmentIds, outputDim0);
+  }
+
+  /**
+   * Builds an {@link SparseSegmentMeanWithNumSegments} operation
+   *
+   * @param data 
+   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
+   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
+   * @param numSegments Should equal the number of distinct segment IDs.
+   * @return a new instance of SparseSegmentMeanWithNumSegments
+   * @see org.tensorflow.op.sparse.SparseSegmentMeanWithNumSegments
+   */
+  public <T extends TNumber, U extends TNumber, V extends TNumber> SparseSegmentMeanWithNumSegments<T> sparseSegmentMeanWithNumSegments(
+      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds, Operand<V> numSegments) {
+    return SparseSegmentMeanWithNumSegments.create(scope, data, indices, segmentIds, numSegments);
   }
 
   /**
@@ -727,6 +501,162 @@ public final class SparseOps {
   }
 
   /**
+   * Builds an {@link SparseSegmentSqrtNGrad} operation
+   *
+   * @param grad gradient propagated to the SparseSegmentSqrtN op.
+   * @param indices indices passed to the corresponding SparseSegmentSqrtN op.
+   * @param segmentIds segment_ids passed to the corresponding SparseSegmentSqrtN op.
+   * @param outputDim0 dimension 0 of "data" passed to SparseSegmentSqrtN op.
+   * @return a new instance of SparseSegmentSqrtNGrad
+   * @see org.tensorflow.op.sparse.SparseSegmentSqrtNGrad
+   */
+  public <T extends TNumber, U extends TNumber> SparseSegmentSqrtNGrad<T> sparseSegmentSqrtNGrad(
+      Operand<T> grad, Operand<U> indices, Operand<TInt32> segmentIds, Operand<TInt32> outputDim0) {
+    return SparseSegmentSqrtNGrad.create(scope, grad, indices, segmentIds, outputDim0);
+  }
+
+  /**
+   * Builds an {@link SparseSegmentSqrtNWithNumSegments} operation
+   *
+   * @param data 
+   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
+   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
+   * @param numSegments Should equal the number of distinct segment IDs.
+   * @return a new instance of SparseSegmentSqrtNWithNumSegments
+   * @see org.tensorflow.op.sparse.SparseSegmentSqrtNWithNumSegments
+   */
+  public <T extends TNumber, U extends TNumber, V extends TNumber> SparseSegmentSqrtNWithNumSegments<T> sparseSegmentSqrtNWithNumSegments(
+      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds, Operand<V> numSegments) {
+    return SparseSegmentSqrtNWithNumSegments.create(scope, data, indices, segmentIds, numSegments);
+  }
+
+  /**
+   * Builds an {@link SparseSegmentSum} operation
+   *
+   * @param data 
+   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
+   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
+   * @return a new instance of SparseSegmentSum
+   * @see org.tensorflow.op.sparse.SparseSegmentSum
+   */
+  public <T extends TNumber, U extends TNumber> SparseSegmentSum<T> sparseSegmentSum(
+      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds) {
+    return SparseSegmentSum.create(scope, data, indices, segmentIds);
+  }
+
+  /**
+   * Builds an {@link SparseSegmentSumWithNumSegments} operation
+   *
+   * @param data 
+   * @param indices A 1-D tensor. Has same rank as `segment_ids`.
+   * @param segmentIds A 1-D tensor. Values should be sorted and can be repeated.
+   * @param numSegments Should equal the number of distinct segment IDs.
+   * @return a new instance of SparseSegmentSumWithNumSegments
+   * @see org.tensorflow.op.sparse.SparseSegmentSumWithNumSegments
+   */
+  public <T extends TNumber, U extends TNumber, V extends TNumber> SparseSegmentSumWithNumSegments<T> sparseSegmentSumWithNumSegments(
+      Operand<T> data, Operand<U> indices, Operand<TInt32> segmentIds, Operand<V> numSegments) {
+    return SparseSegmentSumWithNumSegments.create(scope, data, indices, segmentIds, numSegments);
+  }
+
+  /**
+   * Builds an {@link SparseSlice} operation
+   *
+   * @param indices 2-D tensor represents the indices of the sparse tensor.
+   * @param values 1-D tensor represents the values of the sparse tensor.
+   * @param shape 1-D. tensor represents the shape of the sparse tensor.
+   * @param start 1-D. tensor represents the start of the slice.
+   * @param size 1-D. tensor represents the size of the slice.
+   * @return a new instance of SparseSlice
+   * @see org.tensorflow.op.sparse.SparseSlice
+   */
+  public <T extends TType> SparseSlice<T> sparseSlice(Operand<TInt64> indices, Operand<T> values,
+      Operand<TInt64> shape, Operand<TInt64> start, Operand<TInt64> size) {
+    return SparseSlice.create(scope, indices, values, shape, start, size);
+  }
+
+  /**
+   * Builds an {@link SparseSliceGrad} operation
+   *
+   * @param backpropValGrad 1-D. The gradient with respect to
+   * @param inputIndices 2-D.  The `indices` of the input `SparseTensor`.
+   * @param inputStart 1-D. tensor represents the start of the slice.
+   * @param outputIndices 2-D.  The `indices` of the sliced `SparseTensor`.
+   * @return a new instance of SparseSliceGrad
+   * @see org.tensorflow.op.sparse.SparseSliceGrad
+   */
+  public <T extends TType> SparseSliceGrad<T> sparseSliceGrad(Operand<T> backpropValGrad,
+      Operand<TInt64> inputIndices, Operand<TInt64> inputStart, Operand<TInt64> outputIndices) {
+    return SparseSliceGrad.create(scope, backpropValGrad, inputIndices, inputStart, outputIndices);
+  }
+
+  /**
+   * Builds an {@link SparseSoftmax} operation
+   *
+   * @param spIndices 2-D.  `NNZ x R` matrix with the indices of non-empty values in a
+   * @param spValues 1-D.  `NNZ` non-empty values corresponding to `sp_indices`.
+   * @param spShape 1-D.  Shape of the input SparseTensor.
+   * @return a new instance of SparseSoftmax
+   * @see org.tensorflow.op.sparse.SparseSoftmax
+   */
+  public <T extends TNumber> SparseSoftmax<T> sparseSoftmax(Operand<TInt64> spIndices,
+      Operand<T> spValues, Operand<TInt64> spShape) {
+    return SparseSoftmax.create(scope, spIndices, spValues, spShape);
+  }
+
+  /**
+   * Builds an {@link SparseSparseMaximum} operation
+   *
+   * @param aIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param aValues 1-D.  `N` non-empty values corresponding to `a_indices`.
+   * @param aShape 1-D.  Shape of the input SparseTensor.
+   * @param bIndices counterpart to `a_indices` for the other operand.
+   * @param bValues counterpart to `a_values` for the other operand; must be of the same dtype.
+   * @param bShape counterpart to `a_shape` for the other operand; the two shapes must be equal.
+   * @return a new instance of SparseSparseMaximum
+   * @see org.tensorflow.op.sparse.SparseSparseMaximum
+   */
+  public <T extends TNumber> SparseSparseMaximum<T> sparseSparseMaximum(Operand<TInt64> aIndices,
+      Operand<T> aValues, Operand<TInt64> aShape, Operand<TInt64> bIndices, Operand<T> bValues,
+      Operand<TInt64> bShape) {
+    return SparseSparseMaximum.create(scope, aIndices, aValues, aShape, bIndices, bValues, bShape);
+  }
+
+  /**
+   * Builds an {@link SparseSparseMinimum} operation
+   *
+   * @param aIndices 2-D.  `N x R` matrix with the indices of non-empty values in a
+   * @param aValues 1-D.  `N` non-empty values corresponding to `a_indices`.
+   * @param aShape 1-D.  Shape of the input SparseTensor.
+   * @param bIndices counterpart to `a_indices` for the other operand.
+   * @param bValues counterpart to `a_values` for the other operand; must be of the same dtype.
+   * @param bShape counterpart to `a_shape` for the other operand; the two shapes must be equal.
+   * @return a new instance of SparseSparseMinimum
+   * @see org.tensorflow.op.sparse.SparseSparseMinimum
+   */
+  public <T extends TType> SparseSparseMinimum<T> sparseSparseMinimum(Operand<TInt64> aIndices,
+      Operand<T> aValues, Operand<TInt64> aShape, Operand<TInt64> bIndices, Operand<T> bValues,
+      Operand<TInt64> bShape) {
+    return SparseSparseMinimum.create(scope, aIndices, aValues, aShape, bIndices, bValues, bShape);
+  }
+
+  /**
+   * Builds an {@link SparseSplit} operation
+   *
+   * @param splitDim 0-D.  The dimension along which to split.  Must be in the range
+   * @param indices 2-D tensor represents the indices of the sparse tensor.
+   * @param values 1-D tensor represents the values of the sparse tensor.
+   * @param shape 1-D. tensor represents the shape of the sparse tensor.
+   * @param numSplit The number of ways to split.
+   * @return a new instance of SparseSplit
+   * @see org.tensorflow.op.sparse.SparseSplit
+   */
+  public <T extends TType> SparseSplit<T> sparseSplit(Operand<TInt64> splitDim,
+      Operand<TInt64> indices, Operand<T> values, Operand<TInt64> shape, Long numSplit) {
+    return SparseSplit.create(scope, splitDim, indices, values, shape, numSplit);
+  }
+
+  /**
    * Builds an {@link SparseTensorDenseAdd} operation
    *
    * @param aIndices 2-D.  The `indices` of the `SparseTensor`, with shape `[nnz, ndims]`.
@@ -739,5 +669,75 @@ public final class SparseOps {
   public <U extends TType, T extends TNumber> SparseTensorDenseAdd<U> sparseTensorDenseAdd(
       Operand<T> aIndices, Operand<U> aValues, Operand<T> aShape, Operand<U> b) {
     return SparseTensorDenseAdd.create(scope, aIndices, aValues, aShape, b);
+  }
+
+  /**
+   * Builds an {@link SparseTensorDenseMatMul} operation
+   *
+   * @param aIndices 2-D.  The `indices` of the `SparseTensor`, size `[nnz, 2]` Matrix.
+   * @param aValues 1-D.  The `values` of the `SparseTensor`, size `[nnz]` Vector.
+   * @param aShape 1-D.  The `shape` of the `SparseTensor`, size `[2]` Vector.
+   * @param b 2-D.  A dense Matrix.
+   * @param options carries optional attributes values
+   * @return a new instance of SparseTensorDenseMatMul
+   * @see org.tensorflow.op.sparse.SparseTensorDenseMatMul
+   */
+  public <U extends TType, T extends TNumber> SparseTensorDenseMatMul<U> sparseTensorDenseMatMul(
+      Operand<T> aIndices, Operand<U> aValues, Operand<TInt64> aShape, Operand<U> b,
+      SparseTensorDenseMatMul.Options... options) {
+    return SparseTensorDenseMatMul.create(scope, aIndices, aValues, aShape, b, options);
+  }
+
+  /**
+   * Builds an {@link SparseToDense} operation
+   *
+   * @param sparseIndices 0-D, 1-D, or 2-D.  `sparse_indices[i]` contains the complete
+   * @param outputShape 1-D.  Shape of the dense output tensor.
+   * @param sparseValues 1-D.  Values corresponding to each row of `sparse_indices`,
+   * @param defaultValue Scalar value to set for indices not specified in
+   * @param options carries optional attributes values
+   * @return a new instance of SparseToDense
+   * @see org.tensorflow.op.sparse.SparseToDense
+   */
+  public <U extends TType, T extends TNumber> SparseToDense<U> sparseToDense(
+      Operand<T> sparseIndices, Operand<T> outputShape, Operand<U> sparseValues,
+      Operand<U> defaultValue, SparseToDense.Options... options) {
+    return SparseToDense.create(scope, sparseIndices, outputShape, sparseValues, defaultValue, options);
+  }
+
+  /**
+   * Builds an {@link SparseToSparseSetOperation} operation
+   *
+   * @param set1Indices 2D `Tensor`, indices of a `SparseTensor`. Must be in row-major
+   * @param set1Values 1D `Tensor`, values of a `SparseTensor`. Must be in row-major
+   * @param set1Shape 1D `Tensor`, shape of a `SparseTensor`. `set1_shape[0...n-1]` must
+   * @param set2Indices 2D `Tensor`, indices of a `SparseTensor`. Must be in row-major
+   * @param set2Values 1D `Tensor`, values of a `SparseTensor`. Must be in row-major
+   * @param set2Shape 1D `Tensor`, shape of a `SparseTensor`. `set2_shape[0...n-1]` must
+   * @param setOperation 
+   * @param options carries optional attributes values
+   * @return a new instance of SparseToSparseSetOperation
+   * @see org.tensorflow.op.sparse.SparseToSparseSetOperation
+   */
+  public <T extends TType> SparseToSparseSetOperation<T> sparseToSparseSetOperation(
+      Operand<TInt64> set1Indices, Operand<T> set1Values, Operand<TInt64> set1Shape,
+      Operand<TInt64> set2Indices, Operand<T> set2Values, Operand<TInt64> set2Shape,
+      String setOperation, SparseToSparseSetOperation.Options... options) {
+    return SparseToSparseSetOperation.create(scope, set1Indices, set1Values, set1Shape, set2Indices, set2Values, set2Shape, setOperation, options);
+  }
+
+  /**
+   * Builds an {@link TakeManySparseFromTensorsMap} operation
+   *
+   * @param sparseHandles 1-D, The `N` serialized `SparseTensor` objects.
+   * @param dtype The `dtype` of the `SparseTensor` objects stored in the
+   * @param options carries optional attributes values
+   * @return a new instance of TakeManySparseFromTensorsMap
+   * @see org.tensorflow.op.sparse.TakeManySparseFromTensorsMap
+   */
+  public <T extends TType> TakeManySparseFromTensorsMap<T> takeManySparseFromTensorsMap(
+      Operand<TInt64> sparseHandles, DataType<T> dtype,
+      TakeManySparseFromTensorsMap.Options... options) {
+    return TakeManySparseFromTensorsMap.create(scope, sparseHandles, dtype, options);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/StringsOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/StringsOps.java
@@ -40,21 +40,6 @@ public final class StringsOps {
   }
 
   /**
-   * Builds an {@link Substr} operation
-   *
-   * @param input Tensor of strings
-   * @param pos Scalar defining the position of first character in each substring
-   * @param len Scalar defining the number of characters to include in each substring
-   * @param options carries optional attributes values
-   * @return a new instance of Substr
-   * @see org.tensorflow.op.strings.Substr
-   */
-  public <T extends TNumber> Substr substr(Operand<TString> input, Operand<T> pos, Operand<T> len,
-      Substr.Options... options) {
-    return Substr.create(scope, input, pos, len, options);
-  }
-
-  /**
    * Builds an {@link Join} operation
    *
    * @param inputs A list of string tensors.  The tensors must all have the same shape,
@@ -67,54 +52,29 @@ public final class StringsOps {
   }
 
   /**
-   * Builds an {@link StringFormat} operation
+   * Builds an {@link Lower} operation
    *
-   * @param inputs The list of tensors to format into the placeholder string.
+   * @param input 
    * @param options carries optional attributes values
-   * @return a new instance of StringFormat
-   * @see org.tensorflow.op.strings.StringFormat
+   * @return a new instance of Lower
+   * @see org.tensorflow.op.strings.Lower
    */
-  public StringFormat stringFormat(Iterable<Operand<?>> inputs, StringFormat.Options... options) {
-    return StringFormat.create(scope, inputs, options);
+  public Lower lower(Operand<TString> input, Lower.Options... options) {
+    return Lower.create(scope, input, options);
   }
 
   /**
-   * Builds an {@link ToHashBucketFast} operation
+   * Builds an {@link ReduceJoin} operation
    *
-   * @param input The strings to assign a hash bucket.
-   * @param numBuckets The number of buckets.
-   * @return a new instance of ToHashBucketFast
-   * @see org.tensorflow.op.strings.ToHashBucketFast
-   */
-  public ToHashBucketFast toHashBucketFast(Operand<TString> input, Long numBuckets) {
-    return ToHashBucketFast.create(scope, input, numBuckets);
-  }
-
-  /**
-   * Builds an {@link Strip} operation
-   *
-   * @param input A string `Tensor` of any shape.
-   * @return a new instance of Strip
-   * @see org.tensorflow.op.strings.Strip
-   */
-  public Strip strip(Operand<TString> input) {
-    return Strip.create(scope, input);
-  }
-
-  /**
-   * Builds an {@link UnsortedSegmentJoin} operation
-   *
-   * @param inputs The input to be joined.
-   * @param segmentIds A tensor whose shape is a prefix of data.shape.  Negative segment ids are not
-   * @param numSegments A scalar.
+   * @param inputs The input to be joined.  All reduced indices must have non-zero size.
+   * @param reductionIndices The dimensions to reduce over.  Dimensions are reduced in the
    * @param options carries optional attributes values
-   * @return a new instance of UnsortedSegmentJoin
-   * @see org.tensorflow.op.strings.UnsortedSegmentJoin
+   * @return a new instance of ReduceJoin
+   * @see org.tensorflow.op.strings.ReduceJoin
    */
-  public <T extends TNumber, U extends TNumber> UnsortedSegmentJoin unsortedSegmentJoin(
-      Operand<TString> inputs, Operand<T> segmentIds, Operand<U> numSegments,
-      UnsortedSegmentJoin.Options... options) {
-    return UnsortedSegmentJoin.create(scope, inputs, segmentIds, numSegments, options);
+  public ReduceJoin reduceJoin(Operand<TString> inputs, Operand<TInt32> reductionIndices,
+      ReduceJoin.Options... options) {
+    return ReduceJoin.create(scope, inputs, reductionIndices, options);
   }
 
   /**
@@ -130,18 +90,42 @@ public final class StringsOps {
   }
 
   /**
-   * Builds an {@link UnicodeTranscode} operation
+   * Builds an {@link RegexReplace} operation
    *
-   * @param input The text to be processed. Can have any shape.
-   * @param inputEncoding Text encoding of the input strings. This is any of the encodings supported
-   * @param outputEncoding The unicode encoding to use in the output. Must be one of
+   * @param input The text to be processed.
+   * @param pattern The regular expression to be matched in the `input` strings.
+   * @param rewrite The rewrite string to be substituted for the `pattern` expression where it is
    * @param options carries optional attributes values
-   * @return a new instance of UnicodeTranscode
-   * @see org.tensorflow.op.strings.UnicodeTranscode
+   * @return a new instance of RegexReplace
+   * @see org.tensorflow.op.strings.RegexReplace
    */
-  public UnicodeTranscode unicodeTranscode(Operand<TString> input, String inputEncoding,
-      String outputEncoding, UnicodeTranscode.Options... options) {
-    return UnicodeTranscode.create(scope, input, inputEncoding, outputEncoding, options);
+  public RegexReplace regexReplace(Operand<TString> input, Operand<TString> pattern,
+      Operand<TString> rewrite, RegexReplace.Options... options) {
+    return RegexReplace.create(scope, input, pattern, rewrite, options);
+  }
+
+  /**
+   * Builds an {@link StringFormat} operation
+   *
+   * @param inputs The list of tensors to format into the placeholder string.
+   * @param options carries optional attributes values
+   * @return a new instance of StringFormat
+   * @see org.tensorflow.op.strings.StringFormat
+   */
+  public StringFormat stringFormat(Iterable<Operand<?>> inputs, StringFormat.Options... options) {
+    return StringFormat.create(scope, inputs, options);
+  }
+
+  /**
+   * Builds an {@link StringLength} operation
+   *
+   * @param input The string for which to compute the length.
+   * @param options carries optional attributes values
+   * @return a new instance of StringLength
+   * @see org.tensorflow.op.strings.StringLength
+   */
+  public StringLength stringLength(Operand<TString> input, StringLength.Options... options) {
+    return StringLength.create(scope, input, options);
   }
 
   /**
@@ -165,18 +149,43 @@ public final class StringsOps {
   }
 
   /**
-   * Builds an {@link RegexReplace} operation
+   * Builds an {@link StringSplit} operation
    *
-   * @param input The text to be processed.
-   * @param pattern The regular expression to be matched in the `input` strings.
-   * @param rewrite The rewrite string to be substituted for the `pattern` expression where it is
+   * @param input `1-D` string `Tensor`, the strings to split.
+   * @param sep `0-D` string `Tensor`, the delimiter character.
    * @param options carries optional attributes values
-   * @return a new instance of RegexReplace
-   * @see org.tensorflow.op.strings.RegexReplace
+   * @return a new instance of StringSplit
+   * @see org.tensorflow.op.strings.StringSplit
    */
-  public RegexReplace regexReplace(Operand<TString> input, Operand<TString> pattern,
-      Operand<TString> rewrite, RegexReplace.Options... options) {
-    return RegexReplace.create(scope, input, pattern, rewrite, options);
+  public StringSplit stringSplit(Operand<TString> input, Operand<TString> sep,
+      StringSplit.Options... options) {
+    return StringSplit.create(scope, input, sep, options);
+  }
+
+  /**
+   * Builds an {@link Strip} operation
+   *
+   * @param input A string `Tensor` of any shape.
+   * @return a new instance of Strip
+   * @see org.tensorflow.op.strings.Strip
+   */
+  public Strip strip(Operand<TString> input) {
+    return Strip.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link Substr} operation
+   *
+   * @param input Tensor of strings
+   * @param pos Scalar defining the position of first character in each substring
+   * @param len Scalar defining the number of characters to include in each substring
+   * @param options carries optional attributes values
+   * @return a new instance of Substr
+   * @see org.tensorflow.op.strings.Substr
+   */
+  public <T extends TNumber> Substr substr(Operand<TString> input, Operand<T> pos, Operand<T> len,
+      Substr.Options... options) {
+    return Substr.create(scope, input, pos, len, options);
   }
 
   /**
@@ -192,51 +201,15 @@ public final class StringsOps {
   }
 
   /**
-   * Builds an {@link StringSplit} operation
+   * Builds an {@link ToHashBucketFast} operation
    *
-   * @param input `1-D` string `Tensor`, the strings to split.
-   * @param sep `0-D` string `Tensor`, the delimiter character.
-   * @param options carries optional attributes values
-   * @return a new instance of StringSplit
-   * @see org.tensorflow.op.strings.StringSplit
+   * @param input The strings to assign a hash bucket.
+   * @param numBuckets The number of buckets.
+   * @return a new instance of ToHashBucketFast
+   * @see org.tensorflow.op.strings.ToHashBucketFast
    */
-  public StringSplit stringSplit(Operand<TString> input, Operand<TString> sep,
-      StringSplit.Options... options) {
-    return StringSplit.create(scope, input, sep, options);
-  }
-
-  /**
-   * Builds an {@link Lower} operation
-   *
-   * @param input 
-   * @param options carries optional attributes values
-   * @return a new instance of Lower
-   * @see org.tensorflow.op.strings.Lower
-   */
-  public Lower lower(Operand<TString> input, Lower.Options... options) {
-    return Lower.create(scope, input, options);
-  }
-
-  /**
-   * Builds an {@link ToNumber} operation
-   *
-   * @param stringTensor 
-   * @return a new instance of ToNumber
-   * @see org.tensorflow.op.strings.ToNumber
-   */
-  public ToNumber<TFloat32> toNumber(Operand<TString> stringTensor) {
-    return ToNumber.create(scope, stringTensor);
-  }
-
-  /**
-   * Builds an {@link UnicodeScript} operation
-   *
-   * @param input A Tensor of int32 Unicode code points.
-   * @return a new instance of UnicodeScript
-   * @see org.tensorflow.op.strings.UnicodeScript
-   */
-  public UnicodeScript unicodeScript(Operand<TInt32> input) {
-    return UnicodeScript.create(scope, input);
+  public ToHashBucketFast toHashBucketFast(Operand<TString> input, Long numBuckets) {
+    return ToHashBucketFast.create(scope, input, numBuckets);
   }
 
   /**
@@ -257,6 +230,17 @@ public final class StringsOps {
    * Builds an {@link ToNumber} operation
    *
    * @param stringTensor 
+   * @return a new instance of ToNumber
+   * @see org.tensorflow.op.strings.ToNumber
+   */
+  public ToNumber<TFloat32> toNumber(Operand<TString> stringTensor) {
+    return ToNumber.create(scope, stringTensor);
+  }
+
+  /**
+   * Builds an {@link ToNumber} operation
+   *
+   * @param stringTensor 
    * @param outType The numeric type to interpret each string in `string_tensor` as.
    * @return a new instance of ToNumber
    * @see org.tensorflow.op.strings.ToNumber
@@ -267,17 +251,45 @@ public final class StringsOps {
   }
 
   /**
-   * Builds an {@link ReduceJoin} operation
+   * Builds an {@link UnicodeScript} operation
    *
-   * @param inputs The input to be joined.  All reduced indices must have non-zero size.
-   * @param reductionIndices The dimensions to reduce over.  Dimensions are reduced in the
-   * @param options carries optional attributes values
-   * @return a new instance of ReduceJoin
-   * @see org.tensorflow.op.strings.ReduceJoin
+   * @param input A Tensor of int32 Unicode code points.
+   * @return a new instance of UnicodeScript
+   * @see org.tensorflow.op.strings.UnicodeScript
    */
-  public ReduceJoin reduceJoin(Operand<TString> inputs, Operand<TInt32> reductionIndices,
-      ReduceJoin.Options... options) {
-    return ReduceJoin.create(scope, inputs, reductionIndices, options);
+  public UnicodeScript unicodeScript(Operand<TInt32> input) {
+    return UnicodeScript.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link UnicodeTranscode} operation
+   *
+   * @param input The text to be processed. Can have any shape.
+   * @param inputEncoding Text encoding of the input strings. This is any of the encodings supported
+   * @param outputEncoding The unicode encoding to use in the output. Must be one of
+   * @param options carries optional attributes values
+   * @return a new instance of UnicodeTranscode
+   * @see org.tensorflow.op.strings.UnicodeTranscode
+   */
+  public UnicodeTranscode unicodeTranscode(Operand<TString> input, String inputEncoding,
+      String outputEncoding, UnicodeTranscode.Options... options) {
+    return UnicodeTranscode.create(scope, input, inputEncoding, outputEncoding, options);
+  }
+
+  /**
+   * Builds an {@link UnsortedSegmentJoin} operation
+   *
+   * @param inputs The input to be joined.
+   * @param segmentIds A tensor whose shape is a prefix of data.shape.  Negative segment ids are not
+   * @param numSegments A scalar.
+   * @param options carries optional attributes values
+   * @return a new instance of UnsortedSegmentJoin
+   * @see org.tensorflow.op.strings.UnsortedSegmentJoin
+   */
+  public <T extends TNumber, U extends TNumber> UnsortedSegmentJoin unsortedSegmentJoin(
+      Operand<TString> inputs, Operand<T> segmentIds, Operand<U> numSegments,
+      UnsortedSegmentJoin.Options... options) {
+    return UnsortedSegmentJoin.create(scope, inputs, segmentIds, numSegments, options);
   }
 
   /**
@@ -290,17 +302,5 @@ public final class StringsOps {
    */
   public Upper upper(Operand<TString> input, Upper.Options... options) {
     return Upper.create(scope, input, options);
-  }
-
-  /**
-   * Builds an {@link StringLength} operation
-   *
-   * @param input The string for which to compute the length.
-   * @param options carries optional attributes values
-   * @return a new instance of StringLength
-   * @see org.tensorflow.op.strings.StringLength
-   */
-  public StringLength stringLength(Operand<TString> input, StringLength.Options... options) {
-    return StringLength.create(scope, input, options);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SummaryOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SummaryOps.java
@@ -25,17 +25,31 @@ public final class SummaryOps {
   }
 
   /**
-   * Builds an {@link TensorSummary} operation
+   * Builds an {@link AudioSummary} operation
    *
-   * @param tag A string attached to this summary. Used for organization in TensorBoard.
-   * @param tensor A tensor to serialize.
-   * @param serializedSummaryMetadata A serialized SummaryMetadata proto. Contains plugin
-   * @return a new instance of TensorSummary
-   * @see org.tensorflow.op.summary.TensorSummary
+   * @param tag Scalar. Used to build the `tag` attribute of the summary values.
+   * @param tensor 2-D of shape `[batch_size, frames]`.
+   * @param sampleRate The sample rate of the signal in hertz.
+   * @param options carries optional attributes values
+   * @return a new instance of AudioSummary
+   * @see org.tensorflow.op.summary.AudioSummary
    */
-  public <T extends TType> TensorSummary tensorSummary(Operand<TString> tag, Operand<T> tensor,
-      Operand<TString> serializedSummaryMetadata) {
-    return TensorSummary.create(scope, tag, tensor, serializedSummaryMetadata);
+  public AudioSummary audioSummary(Operand<TString> tag, Operand<TFloat32> tensor,
+      Operand<TFloat32> sampleRate, AudioSummary.Options... options) {
+    return AudioSummary.create(scope, tag, tensor, sampleRate, options);
+  }
+
+  /**
+   * Builds an {@link HistogramSummary} operation
+   *
+   * @param tag Scalar.  Tag to use for the `Summary.Value`.
+   * @param values Any shape. Values to use to build the histogram.
+   * @return a new instance of HistogramSummary
+   * @see org.tensorflow.op.summary.HistogramSummary
+   */
+  public <T extends TNumber> HistogramSummary histogramSummary(Operand<TString> tag,
+      Operand<T> values) {
+    return HistogramSummary.create(scope, tag, values);
   }
 
   /**
@@ -53,31 +67,14 @@ public final class SummaryOps {
   }
 
   /**
-   * Builds an {@link HistogramSummary} operation
+   * Builds an {@link MergeSummary} operation
    *
-   * @param tag Scalar.  Tag to use for the `Summary.Value`.
-   * @param values Any shape. Values to use to build the histogram.
-   * @return a new instance of HistogramSummary
-   * @see org.tensorflow.op.summary.HistogramSummary
+   * @param inputs Can be of any shape.  Each must contain serialized `Summary` protocol
+   * @return a new instance of MergeSummary
+   * @see org.tensorflow.op.summary.MergeSummary
    */
-  public <T extends TNumber> HistogramSummary histogramSummary(Operand<TString> tag,
-      Operand<T> values) {
-    return HistogramSummary.create(scope, tag, values);
-  }
-
-  /**
-   * Builds an {@link AudioSummary} operation
-   *
-   * @param tag Scalar. Used to build the `tag` attribute of the summary values.
-   * @param tensor 2-D of shape `[batch_size, frames]`.
-   * @param sampleRate The sample rate of the signal in hertz.
-   * @param options carries optional attributes values
-   * @return a new instance of AudioSummary
-   * @see org.tensorflow.op.summary.AudioSummary
-   */
-  public AudioSummary audioSummary(Operand<TString> tag, Operand<TFloat32> tensor,
-      Operand<TFloat32> sampleRate, AudioSummary.Options... options) {
-    return AudioSummary.create(scope, tag, tensor, sampleRate, options);
+  public MergeSummary mergeSummary(Iterable<Operand<TString>> inputs) {
+    return MergeSummary.create(scope, inputs);
   }
 
   /**
@@ -93,13 +90,16 @@ public final class SummaryOps {
   }
 
   /**
-   * Builds an {@link MergeSummary} operation
+   * Builds an {@link TensorSummary} operation
    *
-   * @param inputs Can be of any shape.  Each must contain serialized `Summary` protocol
-   * @return a new instance of MergeSummary
-   * @see org.tensorflow.op.summary.MergeSummary
+   * @param tag A string attached to this summary. Used for organization in TensorBoard.
+   * @param tensor A tensor to serialize.
+   * @param serializedSummaryMetadata A serialized SummaryMetadata proto. Contains plugin
+   * @return a new instance of TensorSummary
+   * @see org.tensorflow.op.summary.TensorSummary
    */
-  public MergeSummary mergeSummary(Iterable<Operand<TString>> inputs) {
-    return MergeSummary.create(scope, inputs);
+  public <T extends TType> TensorSummary tensorSummary(Operand<TString> tag, Operand<T> tensor,
+      Operand<TString> serializedSummaryMetadata) {
+    return TensorSummary.create(scope, tag, tensor, serializedSummaryMetadata);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/TrainOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/TrainOps.java
@@ -86,27 +86,467 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link SparseApplyFtrl} operation
+   * Builds an {@link AccumulatorApplyGradient} operation
+   *
+   * @param handle The handle to a accumulator.
+   * @param localStep The local_step value at which the gradient was computed.
+   * @param gradient A tensor of the gradient to be accumulated.
+   * @return a new instance of AccumulatorApplyGradient
+   * @see org.tensorflow.op.train.AccumulatorApplyGradient
+   */
+  public <T extends TType> AccumulatorApplyGradient accumulatorApplyGradient(
+      Operand<TString> handle, Operand<TInt64> localStep, Operand<T> gradient) {
+    return AccumulatorApplyGradient.create(scope, handle, localStep, gradient);
+  }
+
+  /**
+   * Builds an {@link AccumulatorNumAccumulated} operation
+   *
+   * @param handle The handle to an accumulator.
+   * @return a new instance of AccumulatorNumAccumulated
+   * @see org.tensorflow.op.train.AccumulatorNumAccumulated
+   */
+  public AccumulatorNumAccumulated accumulatorNumAccumulated(Operand<TString> handle) {
+    return AccumulatorNumAccumulated.create(scope, handle);
+  }
+
+  /**
+   * Builds an {@link AccumulatorSetGlobalStep} operation
+   *
+   * @param handle The handle to an accumulator.
+   * @param newGlobalStep The new global_step value to set.
+   * @return a new instance of AccumulatorSetGlobalStep
+   * @see org.tensorflow.op.train.AccumulatorSetGlobalStep
+   */
+  public AccumulatorSetGlobalStep accumulatorSetGlobalStep(Operand<TString> handle,
+      Operand<TInt64> newGlobalStep) {
+    return AccumulatorSetGlobalStep.create(scope, handle, newGlobalStep);
+  }
+
+  /**
+   * Builds an {@link AccumulatorTakeGradient} operation
+   *
+   * @param handle The handle to an accumulator.
+   * @param numRequired Number of gradients required before we return an aggregate.
+   * @param dtype The data type of accumulated gradients. Needs to correspond to the type
+   * @return a new instance of AccumulatorTakeGradient
+   * @see org.tensorflow.op.train.AccumulatorTakeGradient
+   */
+  public <T extends TType> AccumulatorTakeGradient<T> accumulatorTakeGradient(
+      Operand<TString> handle, Operand<TInt32> numRequired, DataType<T> dtype) {
+    return AccumulatorTakeGradient.create(scope, handle, numRequired, dtype);
+  }
+
+  /**
+   * Builds an {@link ApplyAdadelta} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param accumUpdate Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param rho Decay factor. Must be a scalar.
+   * @param epsilon Constant factor. Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyAdadelta
+   * @see org.tensorflow.op.train.ApplyAdadelta
+   */
+  public <T extends TType> ApplyAdadelta<T> applyAdadelta(Operand<T> var, Operand<T> accum,
+      Operand<T> accumUpdate, Operand<T> lr, Operand<T> rho, Operand<T> epsilon, Operand<T> grad,
+      ApplyAdadelta.Options... options) {
+    return ApplyAdadelta.create(scope, var, accum, accumUpdate, lr, rho, epsilon, grad, options);
+  }
+
+  /**
+   * Builds an {@link ApplyAdagrad} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyAdagrad
+   * @see org.tensorflow.op.train.ApplyAdagrad
+   */
+  public <T extends TType> ApplyAdagrad<T> applyAdagrad(Operand<T> var, Operand<T> accum,
+      Operand<T> lr, Operand<T> grad, ApplyAdagrad.Options... options) {
+    return ApplyAdagrad.create(scope, var, accum, lr, grad, options);
+  }
+
+  /**
+   * Builds an {@link ApplyAdagradDa} operation
+   *
+   * @param var Should be from a Variable().
+   * @param gradientAccumulator Should be from a Variable().
+   * @param gradientSquaredAccumulator Should be from a Variable().
+   * @param grad The gradient.
+   * @param lr Scaling factor. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 regularization. Must be a scalar.
+   * @param globalStep Training step number. Must be a scalar.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyAdagradDa
+   * @see org.tensorflow.op.train.ApplyAdagradDa
+   */
+  public <T extends TType> ApplyAdagradDa<T> applyAdagradDa(Operand<T> var,
+      Operand<T> gradientAccumulator, Operand<T> gradientSquaredAccumulator, Operand<T> grad,
+      Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<TInt64> globalStep,
+      ApplyAdagradDa.Options... options) {
+    return ApplyAdagradDa.create(scope, var, gradientAccumulator, gradientSquaredAccumulator, grad, lr, l1, l2, globalStep, options);
+  }
+
+  /**
+   * Builds an {@link ApplyAdam} operation
+   *
+   * @param var Should be from a Variable().
+   * @param m Should be from a Variable().
+   * @param v Should be from a Variable().
+   * @param beta1Power Must be a scalar.
+   * @param beta2Power Must be a scalar.
+   * @param lr Scaling factor. Must be a scalar.
+   * @param beta1 Momentum factor. Must be a scalar.
+   * @param beta2 Momentum factor. Must be a scalar.
+   * @param epsilon Ridge term. Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyAdam
+   * @see org.tensorflow.op.train.ApplyAdam
+   */
+  public <T extends TType> ApplyAdam<T> applyAdam(Operand<T> var, Operand<T> m, Operand<T> v,
+      Operand<T> beta1Power, Operand<T> beta2Power, Operand<T> lr, Operand<T> beta1,
+      Operand<T> beta2, Operand<T> epsilon, Operand<T> grad, ApplyAdam.Options... options) {
+    return ApplyAdam.create(scope, var, m, v, beta1Power, beta2Power, lr, beta1, beta2, epsilon, grad, options);
+  }
+
+  /**
+   * Builds an {@link ApplyAddSign} operation
+   *
+   * @param var Should be from a Variable().
+   * @param m Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param alpha Must be a scalar.
+   * @param signDecay Must be a scalar.
+   * @param beta Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyAddSign
+   * @see org.tensorflow.op.train.ApplyAddSign
+   */
+  public <T extends TType> ApplyAddSign<T> applyAddSign(Operand<T> var, Operand<T> m, Operand<T> lr,
+      Operand<T> alpha, Operand<T> signDecay, Operand<T> beta, Operand<T> grad,
+      ApplyAddSign.Options... options) {
+    return ApplyAddSign.create(scope, var, m, lr, alpha, signDecay, beta, grad, options);
+  }
+
+  /**
+   * Builds an {@link ApplyCenteredRmsProp} operation
+   *
+   * @param var Should be from a Variable().
+   * @param mg Should be from a Variable().
+   * @param ms Should be from a Variable().
+   * @param mom Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param rho Decay rate. Must be a scalar.
+   * @param momentum 
+   * @param epsilon Ridge term. Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyCenteredRmsProp
+   * @see org.tensorflow.op.train.ApplyCenteredRmsProp
+   */
+  public <T extends TType> ApplyCenteredRmsProp<T> applyCenteredRmsProp(Operand<T> var,
+      Operand<T> mg, Operand<T> ms, Operand<T> mom, Operand<T> lr, Operand<T> rho,
+      Operand<T> momentum, Operand<T> epsilon, Operand<T> grad,
+      ApplyCenteredRmsProp.Options... options) {
+    return ApplyCenteredRmsProp.create(scope, var, mg, ms, mom, lr, rho, momentum, epsilon, grad, options);
+  }
+
+  /**
+   * Builds an {@link ApplyFtrl} operation
    *
    * @param var Should be from a Variable().
    * @param accum Should be from a Variable().
    * @param linear Should be from a Variable().
    * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
    * @param lr Scaling factor. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
+   * @param l1 L1 regulariation. Must be a scalar.
    * @param l2 L2 shrinkage regulariation. Must be a scalar.
    * @param l2Shrinkage 
    * @param lrPower Scaling factor. Must be a scalar.
    * @param options carries optional attributes values
-   * @return a new instance of SparseApplyFtrl
-   * @see org.tensorflow.op.train.SparseApplyFtrl
+   * @return a new instance of ApplyFtrl
+   * @see org.tensorflow.op.train.ApplyFtrl
    */
-  public <T extends TType, U extends TNumber> SparseApplyFtrl<T> sparseApplyFtrl(Operand<T> var,
-      Operand<T> accum, Operand<T> linear, Operand<T> grad, Operand<U> indices, Operand<T> lr,
-      Operand<T> l1, Operand<T> l2, Operand<T> l2Shrinkage, Operand<T> lrPower,
-      SparseApplyFtrl.Options... options) {
-    return SparseApplyFtrl.create(scope, var, accum, linear, grad, indices, lr, l1, l2, l2Shrinkage, lrPower, options);
+  public <T extends TType> ApplyFtrl<T> applyFtrl(Operand<T> var, Operand<T> accum,
+      Operand<T> linear, Operand<T> grad, Operand<T> lr, Operand<T> l1, Operand<T> l2,
+      Operand<T> l2Shrinkage, Operand<T> lrPower, ApplyFtrl.Options... options) {
+    return ApplyFtrl.create(scope, var, accum, linear, grad, lr, l1, l2, l2Shrinkage, lrPower, options);
+  }
+
+  /**
+   * Builds an {@link ApplyGradientDescent} operation
+   *
+   * @param var Should be from a Variable().
+   * @param alpha Scaling factor. Must be a scalar.
+   * @param delta The change.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyGradientDescent
+   * @see org.tensorflow.op.train.ApplyGradientDescent
+   */
+  public <T extends TType> ApplyGradientDescent<T> applyGradientDescent(Operand<T> var,
+      Operand<T> alpha, Operand<T> delta, ApplyGradientDescent.Options... options) {
+    return ApplyGradientDescent.create(scope, var, alpha, delta, options);
+  }
+
+  /**
+   * Builds an {@link ApplyMomentum} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param grad The gradient.
+   * @param momentum Momentum. Must be a scalar.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyMomentum
+   * @see org.tensorflow.op.train.ApplyMomentum
+   */
+  public <T extends TType> ApplyMomentum<T> applyMomentum(Operand<T> var, Operand<T> accum,
+      Operand<T> lr, Operand<T> grad, Operand<T> momentum, ApplyMomentum.Options... options) {
+    return ApplyMomentum.create(scope, var, accum, lr, grad, momentum, options);
+  }
+
+  /**
+   * Builds an {@link ApplyPowerSign} operation
+   *
+   * @param var Should be from a Variable().
+   * @param m Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param logbase Must be a scalar.
+   * @param signDecay Must be a scalar.
+   * @param beta Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyPowerSign
+   * @see org.tensorflow.op.train.ApplyPowerSign
+   */
+  public <T extends TType> ApplyPowerSign<T> applyPowerSign(Operand<T> var, Operand<T> m,
+      Operand<T> lr, Operand<T> logbase, Operand<T> signDecay, Operand<T> beta, Operand<T> grad,
+      ApplyPowerSign.Options... options) {
+    return ApplyPowerSign.create(scope, var, m, lr, logbase, signDecay, beta, grad, options);
+  }
+
+  /**
+   * Builds an {@link ApplyProximalAdagrad} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 regularization. Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyProximalAdagrad
+   * @see org.tensorflow.op.train.ApplyProximalAdagrad
+   */
+  public <T extends TType> ApplyProximalAdagrad<T> applyProximalAdagrad(Operand<T> var,
+      Operand<T> accum, Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<T> grad,
+      ApplyProximalAdagrad.Options... options) {
+    return ApplyProximalAdagrad.create(scope, var, accum, lr, l1, l2, grad, options);
+  }
+
+  /**
+   * Builds an {@link ApplyProximalGradientDescent} operation
+   *
+   * @param var Should be from a Variable().
+   * @param alpha Scaling factor. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 regularization. Must be a scalar.
+   * @param delta The change.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyProximalGradientDescent
+   * @see org.tensorflow.op.train.ApplyProximalGradientDescent
+   */
+  public <T extends TType> ApplyProximalGradientDescent<T> applyProximalGradientDescent(
+      Operand<T> var, Operand<T> alpha, Operand<T> l1, Operand<T> l2, Operand<T> delta,
+      ApplyProximalGradientDescent.Options... options) {
+    return ApplyProximalGradientDescent.create(scope, var, alpha, l1, l2, delta, options);
+  }
+
+  /**
+   * Builds an {@link ApplyRmsProp} operation
+   *
+   * @param var Should be from a Variable().
+   * @param ms Should be from a Variable().
+   * @param mom Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param rho Decay rate. Must be a scalar.
+   * @param momentum 
+   * @param epsilon Ridge term. Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ApplyRmsProp
+   * @see org.tensorflow.op.train.ApplyRmsProp
+   */
+  public <T extends TType> ApplyRmsProp<T> applyRmsProp(Operand<T> var, Operand<T> ms,
+      Operand<T> mom, Operand<T> lr, Operand<T> rho, Operand<T> momentum, Operand<T> epsilon,
+      Operand<T> grad, ApplyRmsProp.Options... options) {
+    return ApplyRmsProp.create(scope, var, ms, mom, lr, rho, momentum, epsilon, grad, options);
+  }
+
+  /**
+   * Builds an {@link BatchMatMul} operation
+   *
+   * @param x 2-D or higher with shape `[..., r_x, c_x]`.
+   * @param y 2-D or higher with shape `[..., r_y, c_y]`.
+   * @param options carries optional attributes values
+   * @return a new instance of BatchMatMul
+   * @see org.tensorflow.op.train.BatchMatMul
+   */
+  public <T extends TType> BatchMatMul<T> batchMatMul(Operand<T> x, Operand<T> y,
+      BatchMatMul.Options... options) {
+    return BatchMatMul.create(scope, x, y, options);
+  }
+
+  /**
+   * Builds an {@link ConditionalAccumulator} operation
+   *
+   * @param dtype The type of the value being accumulated.
+   * @param shape The shape of the values, can be [], in which case shape is unknown.
+   * @param options carries optional attributes values
+   * @return a new instance of ConditionalAccumulator
+   * @see org.tensorflow.op.train.ConditionalAccumulator
+   */
+  public <T extends TType> ConditionalAccumulator conditionalAccumulator(DataType<T> dtype,
+      Shape shape, ConditionalAccumulator.Options... options) {
+    return ConditionalAccumulator.create(scope, dtype, shape, options);
+  }
+
+  /**
+   * Builds an {@link GenerateVocabRemapping} operation
+   *
+   * @param newVocabFile Path to the new vocab file.
+   * @param oldVocabFile Path to the old vocab file.
+   * @param newVocabOffset How many entries into the new vocab file to start reading.
+   * @param numNewVocab Number of entries in the new vocab file to remap.
+   * @param options carries optional attributes values
+   * @return a new instance of GenerateVocabRemapping
+   * @see org.tensorflow.op.train.GenerateVocabRemapping
+   */
+  public GenerateVocabRemapping generateVocabRemapping(Operand<TString> newVocabFile,
+      Operand<TString> oldVocabFile, Long newVocabOffset, Long numNewVocab,
+      GenerateVocabRemapping.Options... options) {
+    return GenerateVocabRemapping.create(scope, newVocabFile, oldVocabFile, newVocabOffset, numNewVocab, options);
+  }
+
+  /**
+   * Builds an {@link MergeV2Checkpoints} operation
+   *
+   * @param checkpointPrefixes prefixes of V2 checkpoints to merge.
+   * @param destinationPrefix scalar.  The desired final prefix.  Allowed to be the same
+   * @param options carries optional attributes values
+   * @return a new instance of MergeV2Checkpoints
+   * @see org.tensorflow.op.train.MergeV2Checkpoints
+   */
+  public MergeV2Checkpoints mergeV2Checkpoints(Operand<TString> checkpointPrefixes,
+      Operand<TString> destinationPrefix, MergeV2Checkpoints.Options... options) {
+    return MergeV2Checkpoints.create(scope, checkpointPrefixes, destinationPrefix, options);
+  }
+
+  /**
+   * Builds an {@link NegTrain} operation
+   *
+   * @param wIn input word embedding.
+   * @param wOut output word embedding.
+   * @param examples A vector of word ids.
+   * @param labels A vector of word ids.
+   * @param lr 
+   * @param vocabCount Count of words in the vocabulary.
+   * @param numNegativeSamples Number of negative samples per example.
+   * @return a new instance of NegTrain
+   * @see org.tensorflow.op.train.NegTrain
+   */
+  public NegTrain negTrain(Operand<TFloat32> wIn, Operand<TFloat32> wOut, Operand<TInt32> examples,
+      Operand<TInt32> labels, Operand<TFloat32> lr, List<Long> vocabCount,
+      Long numNegativeSamples) {
+    return NegTrain.create(scope, wIn, wOut, examples, labels, lr, vocabCount, numNegativeSamples);
+  }
+
+  /**
+   * Builds an {@link PreventGradient} operation
+   *
+   * @param input any tensor.
+   * @param options carries optional attributes values
+   * @return a new instance of PreventGradient
+   * @see org.tensorflow.op.train.PreventGradient
+   */
+  public <T extends TType> PreventGradient<T> preventGradient(Operand<T> input,
+      PreventGradient.Options... options) {
+    return PreventGradient.create(scope, input, options);
+  }
+
+  /**
+   * Builds an {@link ResourceApplyAdadelta} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param accumUpdate Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param rho Decay factor. Must be a scalar.
+   * @param epsilon Constant factor. Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceApplyAdadelta
+   * @see org.tensorflow.op.train.ResourceApplyAdadelta
+   */
+  public <T extends TType> ResourceApplyAdadelta resourceApplyAdadelta(Operand<?> var,
+      Operand<?> accum, Operand<?> accumUpdate, Operand<T> lr, Operand<T> rho, Operand<T> epsilon,
+      Operand<T> grad, ResourceApplyAdadelta.Options... options) {
+    return ResourceApplyAdadelta.create(scope, var, accum, accumUpdate, lr, rho, epsilon, grad, options);
+  }
+
+  /**
+   * Builds an {@link ResourceApplyAdagradDa} operation
+   *
+   * @param var Should be from a Variable().
+   * @param gradientAccumulator Should be from a Variable().
+   * @param gradientSquaredAccumulator Should be from a Variable().
+   * @param grad The gradient.
+   * @param lr Scaling factor. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 regularization. Must be a scalar.
+   * @param globalStep Training step number. Must be a scalar.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceApplyAdagradDa
+   * @see org.tensorflow.op.train.ResourceApplyAdagradDa
+   */
+  public <T extends TType> ResourceApplyAdagradDa resourceApplyAdagradDa(Operand<?> var,
+      Operand<?> gradientAccumulator, Operand<?> gradientSquaredAccumulator, Operand<T> grad,
+      Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<TInt64> globalStep,
+      ResourceApplyAdagradDa.Options... options) {
+    return ResourceApplyAdagradDa.create(scope, var, gradientAccumulator, gradientSquaredAccumulator, grad, lr, l1, l2, globalStep, options);
+  }
+
+  /**
+   * Builds an {@link ResourceApplyAdam} operation
+   *
+   * @param var Should be from a Variable().
+   * @param m Should be from a Variable().
+   * @param v Should be from a Variable().
+   * @param beta1Power Must be a scalar.
+   * @param beta2Power Must be a scalar.
+   * @param lr Scaling factor. Must be a scalar.
+   * @param beta1 Momentum factor. Must be a scalar.
+   * @param beta2 Momentum factor. Must be a scalar.
+   * @param epsilon Ridge term. Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceApplyAdam
+   * @see org.tensorflow.op.train.ResourceApplyAdam
+   */
+  public <T extends TType> ResourceApplyAdam resourceApplyAdam(Operand<?> var, Operand<?> m,
+      Operand<?> v, Operand<T> beta1Power, Operand<T> beta2Power, Operand<T> lr, Operand<T> beta1,
+      Operand<T> beta2, Operand<T> epsilon, Operand<T> grad, ResourceApplyAdam.Options... options) {
+    return ResourceApplyAdam.create(scope, var, m, v, beta1Power, beta2Power, lr, beta1, beta2, epsilon, grad, options);
   }
 
   /**
@@ -135,108 +575,23 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link ApplyPowerSign} operation
+   * Builds an {@link ResourceApplyAddSign} operation
    *
    * @param var Should be from a Variable().
    * @param m Should be from a Variable().
    * @param lr Scaling factor. Must be a scalar.
-   * @param logbase Must be a scalar.
+   * @param alpha Must be a scalar.
    * @param signDecay Must be a scalar.
    * @param beta Must be a scalar.
    * @param grad The gradient.
    * @param options carries optional attributes values
-   * @return a new instance of ApplyPowerSign
-   * @see org.tensorflow.op.train.ApplyPowerSign
+   * @return a new instance of ResourceApplyAddSign
+   * @see org.tensorflow.op.train.ResourceApplyAddSign
    */
-  public <T extends TType> ApplyPowerSign<T> applyPowerSign(Operand<T> var, Operand<T> m,
-      Operand<T> lr, Operand<T> logbase, Operand<T> signDecay, Operand<T> beta, Operand<T> grad,
-      ApplyPowerSign.Options... options) {
-    return ApplyPowerSign.create(scope, var, m, lr, logbase, signDecay, beta, grad, options);
-  }
-
-  /**
-   * Builds an {@link ResourceSparseApplyAdagrad} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Learning rate. Must be a scalar.
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceSparseApplyAdagrad
-   * @see org.tensorflow.op.train.ResourceSparseApplyAdagrad
-   */
-  public <T extends TType, U extends TNumber> ResourceSparseApplyAdagrad resourceSparseApplyAdagrad(
-      Operand<?> var, Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<U> indices,
-      ResourceSparseApplyAdagrad.Options... options) {
-    return ResourceSparseApplyAdagrad.create(scope, var, accum, lr, grad, indices, options);
-  }
-
-  /**
-   * Builds an {@link ApplyCenteredRmsProp} operation
-   *
-   * @param var Should be from a Variable().
-   * @param mg Should be from a Variable().
-   * @param ms Should be from a Variable().
-   * @param mom Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param rho Decay rate. Must be a scalar.
-   * @param momentum 
-   * @param epsilon Ridge term. Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ApplyCenteredRmsProp
-   * @see org.tensorflow.op.train.ApplyCenteredRmsProp
-   */
-  public <T extends TType> ApplyCenteredRmsProp<T> applyCenteredRmsProp(Operand<T> var,
-      Operand<T> mg, Operand<T> ms, Operand<T> mom, Operand<T> lr, Operand<T> rho,
-      Operand<T> momentum, Operand<T> epsilon, Operand<T> grad,
-      ApplyCenteredRmsProp.Options... options) {
-    return ApplyCenteredRmsProp.create(scope, var, mg, ms, mom, lr, rho, momentum, epsilon, grad, options);
-  }
-
-  /**
-   * Builds an {@link ResourceApplyPowerSign} operation
-   *
-   * @param var Should be from a Variable().
-   * @param m Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param logbase Must be a scalar.
-   * @param signDecay Must be a scalar.
-   * @param beta Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceApplyPowerSign
-   * @see org.tensorflow.op.train.ResourceApplyPowerSign
-   */
-  public <T extends TType> ResourceApplyPowerSign resourceApplyPowerSign(Operand<?> var,
-      Operand<?> m, Operand<T> lr, Operand<T> logbase, Operand<T> signDecay, Operand<T> beta,
-      Operand<T> grad, ResourceApplyPowerSign.Options... options) {
-    return ResourceApplyPowerSign.create(scope, var, m, lr, logbase, signDecay, beta, grad, options);
-  }
-
-  /**
-   * Builds an {@link ResourceSparseApplyFtrl} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param linear Should be from a Variable().
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
-   * @param lr Scaling factor. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 shrinkage regulariation. Must be a scalar.
-   * @param l2Shrinkage 
-   * @param lrPower Scaling factor. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceSparseApplyFtrl
-   * @see org.tensorflow.op.train.ResourceSparseApplyFtrl
-   */
-  public <T extends TType, U extends TNumber> ResourceSparseApplyFtrl resourceSparseApplyFtrl(
-      Operand<?> var, Operand<?> accum, Operand<?> linear, Operand<T> grad, Operand<U> indices,
-      Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<T> l2Shrinkage, Operand<T> lrPower,
-      ResourceSparseApplyFtrl.Options... options) {
-    return ResourceSparseApplyFtrl.create(scope, var, accum, linear, grad, indices, lr, l1, l2, l2Shrinkage, lrPower, options);
+  public <T extends TType> ResourceApplyAddSign resourceApplyAddSign(Operand<?> var, Operand<?> m,
+      Operand<T> lr, Operand<T> alpha, Operand<T> signDecay, Operand<T> beta, Operand<T> grad,
+      ResourceApplyAddSign.Options... options) {
+    return ResourceApplyAddSign.create(scope, var, m, lr, alpha, signDecay, beta, grad, options);
   }
 
   /**
@@ -263,65 +618,6 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link ApplyFtrl} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param linear Should be from a Variable().
-   * @param grad The gradient.
-   * @param lr Scaling factor. Must be a scalar.
-   * @param l1 L1 regulariation. Must be a scalar.
-   * @param l2 L2 shrinkage regulariation. Must be a scalar.
-   * @param l2Shrinkage 
-   * @param lrPower Scaling factor. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of ApplyFtrl
-   * @see org.tensorflow.op.train.ApplyFtrl
-   */
-  public <T extends TType> ApplyFtrl<T> applyFtrl(Operand<T> var, Operand<T> accum,
-      Operand<T> linear, Operand<T> grad, Operand<T> lr, Operand<T> l1, Operand<T> l2,
-      Operand<T> l2Shrinkage, Operand<T> lrPower, ApplyFtrl.Options... options) {
-    return ApplyFtrl.create(scope, var, accum, linear, grad, lr, l1, l2, l2Shrinkage, lrPower, options);
-  }
-
-  /**
-   * Builds an {@link AccumulatorApplyGradient} operation
-   *
-   * @param handle The handle to a accumulator.
-   * @param localStep The local_step value at which the gradient was computed.
-   * @param gradient A tensor of the gradient to be accumulated.
-   * @return a new instance of AccumulatorApplyGradient
-   * @see org.tensorflow.op.train.AccumulatorApplyGradient
-   */
-  public <T extends TType> AccumulatorApplyGradient accumulatorApplyGradient(
-      Operand<TString> handle, Operand<TInt64> localStep, Operand<T> gradient) {
-    return AccumulatorApplyGradient.create(scope, handle, localStep, gradient);
-  }
-
-  /**
-   * Builds an {@link SparseApplyRmsProp} operation
-   *
-   * @param var Should be from a Variable().
-   * @param ms Should be from a Variable().
-   * @param mom Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param rho Decay rate. Must be a scalar.
-   * @param momentum 
-   * @param epsilon Ridge term. Must be a scalar.
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var, ms and mom.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseApplyRmsProp
-   * @see org.tensorflow.op.train.SparseApplyRmsProp
-   */
-  public <T extends TType, U extends TNumber> SparseApplyRmsProp<T> sparseApplyRmsProp(
-      Operand<T> var, Operand<T> ms, Operand<T> mom, Operand<T> lr, Operand<T> rho,
-      Operand<T> momentum, Operand<T> epsilon, Operand<T> grad, Operand<U> indices,
-      SparseApplyRmsProp.Options... options) {
-    return SparseApplyRmsProp.create(scope, var, ms, mom, lr, rho, momentum, epsilon, grad, indices, options);
-  }
-
-  /**
    * Builds an {@link ResourceApplyFtrl} operation
    *
    * @param var Should be from a Variable().
@@ -344,57 +640,6 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link ApplyRmsProp} operation
-   *
-   * @param var Should be from a Variable().
-   * @param ms Should be from a Variable().
-   * @param mom Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param rho Decay rate. Must be a scalar.
-   * @param momentum 
-   * @param epsilon Ridge term. Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ApplyRmsProp
-   * @see org.tensorflow.op.train.ApplyRmsProp
-   */
-  public <T extends TType> ApplyRmsProp<T> applyRmsProp(Operand<T> var, Operand<T> ms,
-      Operand<T> mom, Operand<T> lr, Operand<T> rho, Operand<T> momentum, Operand<T> epsilon,
-      Operand<T> grad, ApplyRmsProp.Options... options) {
-    return ApplyRmsProp.create(scope, var, ms, mom, lr, rho, momentum, epsilon, grad, options);
-  }
-
-  /**
-   * Builds an {@link RestoreSlice} operation
-   *
-   * @param filePattern Must have a single element. The pattern of the files from
-   * @param tensorName Must have a single element. The name of the tensor to be
-   * @param shapeAndSlice Scalar. The shapes and slice specifications to use when
-   * @param dt The type of the tensor to be restored.
-   * @param options carries optional attributes values
-   * @return a new instance of RestoreSlice
-   * @see org.tensorflow.op.train.RestoreSlice
-   */
-  public <T extends TType> RestoreSlice<T> restoreSlice(Operand<TString> filePattern,
-      Operand<TString> tensorName, Operand<TString> shapeAndSlice, DataType<T> dt,
-      RestoreSlice.Options... options) {
-    return RestoreSlice.create(scope, filePattern, tensorName, shapeAndSlice, dt, options);
-  }
-
-  /**
-   * Builds an {@link SdcaShrinkL1} operation
-   *
-   * @param weights a list of vectors where each value is the weight associated with a
-   * @param l1 Symmetric l1 regularization strength.
-   * @param l2 Symmetric l2 regularization strength. Should be a positive float.
-   * @return a new instance of SdcaShrinkL1
-   * @see org.tensorflow.op.train.SdcaShrinkL1
-   */
-  public SdcaShrinkL1 sdcaShrinkL1(Iterable<Operand<TFloat32>> weights, Float l1, Float l2) {
-    return SdcaShrinkL1.create(scope, weights, l1, l2);
-  }
-
-  /**
    * Builds an {@link ResourceApplyGradientDescent} operation
    *
    * @param var Should be from a Variable().
@@ -410,151 +655,78 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link ResourceSparseApplyKerasMomentum} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Learning rate. Must be a scalar.
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
-   * @param momentum Momentum. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceSparseApplyKerasMomentum
-   * @see org.tensorflow.op.train.ResourceSparseApplyKerasMomentum
-   */
-  public <T extends TType, U extends TNumber> ResourceSparseApplyKerasMomentum resourceSparseApplyKerasMomentum(
-      Operand<?> var, Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<U> indices,
-      Operand<T> momentum, ResourceSparseApplyKerasMomentum.Options... options) {
-    return ResourceSparseApplyKerasMomentum.create(scope, var, accum, lr, grad, indices, momentum, options);
-  }
-
-  /**
-   * Builds an {@link SparseApplyAdagradDa} operation
-   *
-   * @param var Should be from a Variable().
-   * @param gradientAccumulator Should be from a Variable().
-   * @param gradientSquaredAccumulator Should be from a Variable().
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
-   * @param lr Learning rate. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 regularization. Must be a scalar.
-   * @param globalStep Training step number. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseApplyAdagradDa
-   * @see org.tensorflow.op.train.SparseApplyAdagradDa
-   */
-  public <T extends TType, U extends TNumber> SparseApplyAdagradDa<T> sparseApplyAdagradDa(
-      Operand<T> var, Operand<T> gradientAccumulator, Operand<T> gradientSquaredAccumulator,
-      Operand<T> grad, Operand<U> indices, Operand<T> lr, Operand<T> l1, Operand<T> l2,
-      Operand<TInt64> globalStep, SparseApplyAdagradDa.Options... options) {
-    return SparseApplyAdagradDa.create(scope, var, gradientAccumulator, gradientSquaredAccumulator, grad, indices, lr, l1, l2, globalStep, options);
-  }
-
-  /**
-   * Builds an {@link ApplyAdagrad} operation
+   * Builds an {@link ResourceApplyKerasMomentum} operation
    *
    * @param var Should be from a Variable().
    * @param accum Should be from a Variable().
    * @param lr Scaling factor. Must be a scalar.
    * @param grad The gradient.
+   * @param momentum Momentum. Must be a scalar.
    * @param options carries optional attributes values
-   * @return a new instance of ApplyAdagrad
-   * @see org.tensorflow.op.train.ApplyAdagrad
+   * @return a new instance of ResourceApplyKerasMomentum
+   * @see org.tensorflow.op.train.ResourceApplyKerasMomentum
    */
-  public <T extends TType> ApplyAdagrad<T> applyAdagrad(Operand<T> var, Operand<T> accum,
-      Operand<T> lr, Operand<T> grad, ApplyAdagrad.Options... options) {
-    return ApplyAdagrad.create(scope, var, accum, lr, grad, options);
+  public <T extends TType> ResourceApplyKerasMomentum resourceApplyKerasMomentum(Operand<?> var,
+      Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<T> momentum,
+      ResourceApplyKerasMomentum.Options... options) {
+    return ResourceApplyKerasMomentum.create(scope, var, accum, lr, grad, momentum, options);
   }
 
   /**
-   * Builds an {@link SparseApplyProximalGradientDescent} operation
+   * Builds an {@link ResourceApplyMomentum} operation
    *
    * @param var Should be from a Variable().
-   * @param alpha Scaling factor. Must be a scalar.
+   * @param accum Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param grad The gradient.
+   * @param momentum Momentum. Must be a scalar.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceApplyMomentum
+   * @see org.tensorflow.op.train.ResourceApplyMomentum
+   */
+  public <T extends TType> ResourceApplyMomentum resourceApplyMomentum(Operand<?> var,
+      Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<T> momentum,
+      ResourceApplyMomentum.Options... options) {
+    return ResourceApplyMomentum.create(scope, var, accum, lr, grad, momentum, options);
+  }
+
+  /**
+   * Builds an {@link ResourceApplyPowerSign} operation
+   *
+   * @param var Should be from a Variable().
+   * @param m Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param logbase Must be a scalar.
+   * @param signDecay Must be a scalar.
+   * @param beta Must be a scalar.
+   * @param grad The gradient.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceApplyPowerSign
+   * @see org.tensorflow.op.train.ResourceApplyPowerSign
+   */
+  public <T extends TType> ResourceApplyPowerSign resourceApplyPowerSign(Operand<?> var,
+      Operand<?> m, Operand<T> lr, Operand<T> logbase, Operand<T> signDecay, Operand<T> beta,
+      Operand<T> grad, ResourceApplyPowerSign.Options... options) {
+    return ResourceApplyPowerSign.create(scope, var, m, lr, logbase, signDecay, beta, grad, options);
+  }
+
+  /**
+   * Builds an {@link ResourceApplyProximalAdagrad} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
    * @param l1 L1 regularization. Must be a scalar.
    * @param l2 L2 regularization. Must be a scalar.
    * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
    * @param options carries optional attributes values
-   * @return a new instance of SparseApplyProximalGradientDescent
-   * @see org.tensorflow.op.train.SparseApplyProximalGradientDescent
+   * @return a new instance of ResourceApplyProximalAdagrad
+   * @see org.tensorflow.op.train.ResourceApplyProximalAdagrad
    */
-  public <T extends TType, U extends TNumber> SparseApplyProximalGradientDescent<T> sparseApplyProximalGradientDescent(
-      Operand<T> var, Operand<T> alpha, Operand<T> l1, Operand<T> l2, Operand<T> grad,
-      Operand<U> indices, SparseApplyProximalGradientDescent.Options... options) {
-    return SparseApplyProximalGradientDescent.create(scope, var, alpha, l1, l2, grad, indices, options);
-  }
-
-  /**
-   * Builds an {@link PreventGradient} operation
-   *
-   * @param input any tensor.
-   * @param options carries optional attributes values
-   * @return a new instance of PreventGradient
-   * @see org.tensorflow.op.train.PreventGradient
-   */
-  public <T extends TType> PreventGradient<T> preventGradient(Operand<T> input,
-      PreventGradient.Options... options) {
-    return PreventGradient.create(scope, input, options);
-  }
-
-  /**
-   * Builds an {@link ResourceSparseApplyAdagradDa} operation
-   *
-   * @param var Should be from a Variable().
-   * @param gradientAccumulator Should be from a Variable().
-   * @param gradientSquaredAccumulator Should be from a Variable().
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
-   * @param lr Learning rate. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 regularization. Must be a scalar.
-   * @param globalStep Training step number. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceSparseApplyAdagradDa
-   * @see org.tensorflow.op.train.ResourceSparseApplyAdagradDa
-   */
-  public <T extends TType, U extends TNumber> ResourceSparseApplyAdagradDa resourceSparseApplyAdagradDa(
-      Operand<?> var, Operand<?> gradientAccumulator, Operand<?> gradientSquaredAccumulator,
-      Operand<T> grad, Operand<U> indices, Operand<T> lr, Operand<T> l1, Operand<T> l2,
-      Operand<TInt64> globalStep, ResourceSparseApplyAdagradDa.Options... options) {
-    return ResourceSparseApplyAdagradDa.create(scope, var, gradientAccumulator, gradientSquaredAccumulator, grad, indices, lr, l1, l2, globalStep, options);
-  }
-
-  /**
-   * Builds an {@link ApplyProximalGradientDescent} operation
-   *
-   * @param var Should be from a Variable().
-   * @param alpha Scaling factor. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 regularization. Must be a scalar.
-   * @param delta The change.
-   * @param options carries optional attributes values
-   * @return a new instance of ApplyProximalGradientDescent
-   * @see org.tensorflow.op.train.ApplyProximalGradientDescent
-   */
-  public <T extends TType> ApplyProximalGradientDescent<T> applyProximalGradientDescent(
-      Operand<T> var, Operand<T> alpha, Operand<T> l1, Operand<T> l2, Operand<T> delta,
-      ApplyProximalGradientDescent.Options... options) {
-    return ApplyProximalGradientDescent.create(scope, var, alpha, l1, l2, delta, options);
-  }
-
-  /**
-   * Builds an {@link GenerateVocabRemapping} operation
-   *
-   * @param newVocabFile Path to the new vocab file.
-   * @param oldVocabFile Path to the old vocab file.
-   * @param newVocabOffset How many entries into the new vocab file to start reading.
-   * @param numNewVocab Number of entries in the new vocab file to remap.
-   * @param options carries optional attributes values
-   * @return a new instance of GenerateVocabRemapping
-   * @see org.tensorflow.op.train.GenerateVocabRemapping
-   */
-  public GenerateVocabRemapping generateVocabRemapping(Operand<TString> newVocabFile,
-      Operand<TString> oldVocabFile, Long newVocabOffset, Long numNewVocab,
-      GenerateVocabRemapping.Options... options) {
-    return GenerateVocabRemapping.create(scope, newVocabFile, oldVocabFile, newVocabOffset, numNewVocab, options);
+  public <T extends TType> ResourceApplyProximalAdagrad resourceApplyProximalAdagrad(Operand<?> var,
+      Operand<?> accum, Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<T> grad,
+      ResourceApplyProximalAdagrad.Options... options) {
+    return ResourceApplyProximalAdagrad.create(scope, var, accum, lr, l1, l2, grad, options);
   }
 
   /**
@@ -573,123 +745,6 @@ public final class TrainOps {
       Operand<?> var, Operand<T> alpha, Operand<T> l1, Operand<T> l2, Operand<T> delta,
       ResourceApplyProximalGradientDescent.Options... options) {
     return ResourceApplyProximalGradientDescent.create(scope, var, alpha, l1, l2, delta, options);
-  }
-
-  /**
-   * Builds an {@link Save} operation
-   *
-   * @param prefix Must have a single element. The prefix of the V2 checkpoint to which we
-   * @param tensorNames shape {N}. The names of the tensors to be saved.
-   * @param shapeAndSlices shape {N}.  The slice specs of the tensors to be saved.
-   * @param tensors `N` tensors to save.
-   * @return a new instance of Save
-   * @see org.tensorflow.op.train.Save
-   */
-  public Save save(Operand<TString> prefix, Operand<TString> tensorNames,
-      Operand<TString> shapeAndSlices, Iterable<Operand<?>> tensors) {
-    return Save.create(scope, prefix, tensorNames, shapeAndSlices, tensors);
-  }
-
-  /**
-   * Builds an {@link ResourceApplyAddSign} operation
-   *
-   * @param var Should be from a Variable().
-   * @param m Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param alpha Must be a scalar.
-   * @param signDecay Must be a scalar.
-   * @param beta Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceApplyAddSign
-   * @see org.tensorflow.op.train.ResourceApplyAddSign
-   */
-  public <T extends TType> ResourceApplyAddSign resourceApplyAddSign(Operand<?> var, Operand<?> m,
-      Operand<T> lr, Operand<T> alpha, Operand<T> signDecay, Operand<T> beta, Operand<T> grad,
-      ResourceApplyAddSign.Options... options) {
-    return ResourceApplyAddSign.create(scope, var, m, lr, alpha, signDecay, beta, grad, options);
-  }
-
-  /**
-   * Builds an {@link SaveSlices} operation
-   *
-   * @param filename Must have a single element. The name of the file to which we write the
-   * @param tensorNames Shape `[N]`. The names of the tensors to be saved.
-   * @param shapesAndSlices Shape `[N]`.  The shapes and slice specifications to use when
-   * @param data `N` tensors to save.
-   * @return a new instance of SaveSlices
-   * @see org.tensorflow.op.train.SaveSlices
-   */
-  public SaveSlices saveSlices(Operand<TString> filename, Operand<TString> tensorNames,
-      Operand<TString> shapesAndSlices, Iterable<Operand<?>> data) {
-    return SaveSlices.create(scope, filename, tensorNames, shapesAndSlices, data);
-  }
-
-  /**
-   * Builds an {@link BatchMatMul} operation
-   *
-   * @param x 2-D or higher with shape `[..., r_x, c_x]`.
-   * @param y 2-D or higher with shape `[..., r_y, c_y]`.
-   * @param options carries optional attributes values
-   * @return a new instance of BatchMatMul
-   * @see org.tensorflow.op.train.BatchMatMul
-   */
-  public <T extends TType> BatchMatMul<T> batchMatMul(Operand<T> x, Operand<T> y,
-      BatchMatMul.Options... options) {
-    return BatchMatMul.create(scope, x, y, options);
-  }
-
-  /**
-   * Builds an {@link Restore} operation
-   *
-   * @param prefix Must have a single element.  The prefix of a V2 checkpoint.
-   * @param tensorNames shape {N}.  The names of the tensors to be restored.
-   * @param shapeAndSlices shape {N}.  The slice specs of the tensors to be restored.
-   * @param dtypes shape {N}.  The list of expected dtype for the tensors.  Must match
-   * @return a new instance of Restore
-   * @see org.tensorflow.op.train.Restore
-   */
-  public Restore restore(Operand<TString> prefix, Operand<TString> tensorNames,
-      Operand<TString> shapeAndSlices, List<DataType<?>> dtypes) {
-    return Restore.create(scope, prefix, tensorNames, shapeAndSlices, dtypes);
-  }
-
-  /**
-   * Builds an {@link AccumulatorSetGlobalStep} operation
-   *
-   * @param handle The handle to an accumulator.
-   * @param newGlobalStep The new global_step value to set.
-   * @return a new instance of AccumulatorSetGlobalStep
-   * @see org.tensorflow.op.train.AccumulatorSetGlobalStep
-   */
-  public AccumulatorSetGlobalStep accumulatorSetGlobalStep(Operand<TString> handle,
-      Operand<TInt64> newGlobalStep) {
-    return AccumulatorSetGlobalStep.create(scope, handle, newGlobalStep);
-  }
-
-  /**
-   * Builds an {@link MergeV2Checkpoints} operation
-   *
-   * @param checkpointPrefixes prefixes of V2 checkpoints to merge.
-   * @param destinationPrefix scalar.  The desired final prefix.  Allowed to be the same
-   * @param options carries optional attributes values
-   * @return a new instance of MergeV2Checkpoints
-   * @see org.tensorflow.op.train.MergeV2Checkpoints
-   */
-  public MergeV2Checkpoints mergeV2Checkpoints(Operand<TString> checkpointPrefixes,
-      Operand<TString> destinationPrefix, MergeV2Checkpoints.Options... options) {
-    return MergeV2Checkpoints.create(scope, checkpointPrefixes, destinationPrefix, options);
-  }
-
-  /**
-   * Builds an {@link AccumulatorNumAccumulated} operation
-   *
-   * @param handle The handle to an accumulator.
-   * @return a new instance of AccumulatorNumAccumulated
-   * @see org.tensorflow.op.train.AccumulatorNumAccumulated
-   */
-  public AccumulatorNumAccumulated accumulatorNumAccumulated(Operand<TString> handle) {
-    return AccumulatorNumAccumulated.create(scope, handle);
   }
 
   /**
@@ -714,7 +769,7 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link SparseApplyAdadelta} operation
+   * Builds an {@link ResourceSparseApplyAdadelta} operation
    *
    * @param var 
    * @param accum Should be from a Variable().
@@ -725,343 +780,55 @@ public final class TrainOps {
    * @param grad The gradient.
    * @param indices A vector of indices into the first dimension of var and accum.
    * @param options carries optional attributes values
-   * @return a new instance of SparseApplyAdadelta
-   * @see org.tensorflow.op.train.SparseApplyAdadelta
+   * @return a new instance of ResourceSparseApplyAdadelta
+   * @see org.tensorflow.op.train.ResourceSparseApplyAdadelta
    */
-  public <T extends TType, U extends TNumber> SparseApplyAdadelta<T> sparseApplyAdadelta(
-      Operand<T> var, Operand<T> accum, Operand<T> accumUpdate, Operand<T> lr, Operand<T> rho,
+  public <T extends TType, U extends TNumber> ResourceSparseApplyAdadelta resourceSparseApplyAdadelta(
+      Operand<?> var, Operand<?> accum, Operand<?> accumUpdate, Operand<T> lr, Operand<T> rho,
       Operand<T> epsilon, Operand<T> grad, Operand<U> indices,
-      SparseApplyAdadelta.Options... options) {
-    return SparseApplyAdadelta.create(scope, var, accum, accumUpdate, lr, rho, epsilon, grad, indices, options);
+      ResourceSparseApplyAdadelta.Options... options) {
+    return ResourceSparseApplyAdadelta.create(scope, var, accum, accumUpdate, lr, rho, epsilon, grad, indices, options);
   }
 
   /**
-   * Builds an {@link SparseApplyCenteredRmsProp} operation
-   *
-   * @param var Should be from a Variable().
-   * @param mg Should be from a Variable().
-   * @param ms Should be from a Variable().
-   * @param mom Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param rho Decay rate. Must be a scalar.
-   * @param momentum 
-   * @param epsilon Ridge term. Must be a scalar.
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var, ms and mom.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseApplyCenteredRmsProp
-   * @see org.tensorflow.op.train.SparseApplyCenteredRmsProp
-   */
-  public <T extends TType, U extends TNumber> SparseApplyCenteredRmsProp<T> sparseApplyCenteredRmsProp(
-      Operand<T> var, Operand<T> mg, Operand<T> ms, Operand<T> mom, Operand<T> lr, Operand<T> rho,
-      Operand<T> momentum, Operand<T> epsilon, Operand<T> grad, Operand<U> indices,
-      SparseApplyCenteredRmsProp.Options... options) {
-    return SparseApplyCenteredRmsProp.create(scope, var, mg, ms, mom, lr, rho, momentum, epsilon, grad, indices, options);
-  }
-
-  /**
-   * Builds an {@link ApplyAdadelta} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param accumUpdate Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param rho Decay factor. Must be a scalar.
-   * @param epsilon Constant factor. Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ApplyAdadelta
-   * @see org.tensorflow.op.train.ApplyAdadelta
-   */
-  public <T extends TType> ApplyAdadelta<T> applyAdadelta(Operand<T> var, Operand<T> accum,
-      Operand<T> accumUpdate, Operand<T> lr, Operand<T> rho, Operand<T> epsilon, Operand<T> grad,
-      ApplyAdadelta.Options... options) {
-    return ApplyAdadelta.create(scope, var, accum, accumUpdate, lr, rho, epsilon, grad, options);
-  }
-
-  /**
-   * Builds an {@link TileGrad} operation
-   *
-   * @param input 
-   * @param multiples 
-   * @return a new instance of TileGrad
-   * @see org.tensorflow.op.train.TileGrad
-   */
-  public <T extends TType> TileGrad<T> tileGrad(Operand<T> input, Operand<TInt32> multiples) {
-    return TileGrad.create(scope, input, multiples);
-  }
-
-  /**
-   * Builds an {@link ResourceSparseApplyProximalAdagrad} operation
+   * Builds an {@link ResourceSparseApplyAdagrad} operation
    *
    * @param var Should be from a Variable().
    * @param accum Should be from a Variable().
    * @param lr Learning rate. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 regularization. Must be a scalar.
    * @param grad The gradient.
    * @param indices A vector of indices into the first dimension of var and accum.
    * @param options carries optional attributes values
-   * @return a new instance of ResourceSparseApplyProximalAdagrad
-   * @see org.tensorflow.op.train.ResourceSparseApplyProximalAdagrad
+   * @return a new instance of ResourceSparseApplyAdagrad
+   * @see org.tensorflow.op.train.ResourceSparseApplyAdagrad
    */
-  public <T extends TType, U extends TNumber> ResourceSparseApplyProximalAdagrad resourceSparseApplyProximalAdagrad(
-      Operand<?> var, Operand<?> accum, Operand<T> lr, Operand<T> l1, Operand<T> l2,
-      Operand<T> grad, Operand<U> indices, ResourceSparseApplyProximalAdagrad.Options... options) {
-    return ResourceSparseApplyProximalAdagrad.create(scope, var, accum, lr, l1, l2, grad, indices, options);
+  public <T extends TType, U extends TNumber> ResourceSparseApplyAdagrad resourceSparseApplyAdagrad(
+      Operand<?> var, Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<U> indices,
+      ResourceSparseApplyAdagrad.Options... options) {
+    return ResourceSparseApplyAdagrad.create(scope, var, accum, lr, grad, indices, options);
   }
 
   /**
-   * Builds an {@link ApplyAdagradDa} operation
+   * Builds an {@link ResourceSparseApplyAdagradDa} operation
    *
    * @param var Should be from a Variable().
    * @param gradientAccumulator Should be from a Variable().
    * @param gradientSquaredAccumulator Should be from a Variable().
    * @param grad The gradient.
-   * @param lr Scaling factor. Must be a scalar.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param lr Learning rate. Must be a scalar.
    * @param l1 L1 regularization. Must be a scalar.
    * @param l2 L2 regularization. Must be a scalar.
    * @param globalStep Training step number. Must be a scalar.
    * @param options carries optional attributes values
-   * @return a new instance of ApplyAdagradDa
-   * @see org.tensorflow.op.train.ApplyAdagradDa
+   * @return a new instance of ResourceSparseApplyAdagradDa
+   * @see org.tensorflow.op.train.ResourceSparseApplyAdagradDa
    */
-  public <T extends TType> ApplyAdagradDa<T> applyAdagradDa(Operand<T> var,
-      Operand<T> gradientAccumulator, Operand<T> gradientSquaredAccumulator, Operand<T> grad,
-      Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<TInt64> globalStep,
-      ApplyAdagradDa.Options... options) {
-    return ApplyAdagradDa.create(scope, var, gradientAccumulator, gradientSquaredAccumulator, grad, lr, l1, l2, globalStep, options);
-  }
-
-  /**
-   * Builds an {@link ResourceSparseApplyMomentum} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Learning rate. Must be a scalar.
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
-   * @param momentum Momentum. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceSparseApplyMomentum
-   * @see org.tensorflow.op.train.ResourceSparseApplyMomentum
-   */
-  public <T extends TType, U extends TNumber> ResourceSparseApplyMomentum resourceSparseApplyMomentum(
-      Operand<?> var, Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<U> indices,
-      Operand<T> momentum, ResourceSparseApplyMomentum.Options... options) {
-    return ResourceSparseApplyMomentum.create(scope, var, accum, lr, grad, indices, momentum, options);
-  }
-
-  /**
-   * Builds an {@link ResourceApplyProximalAdagrad} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 regularization. Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceApplyProximalAdagrad
-   * @see org.tensorflow.op.train.ResourceApplyProximalAdagrad
-   */
-  public <T extends TType> ResourceApplyProximalAdagrad resourceApplyProximalAdagrad(Operand<?> var,
-      Operand<?> accum, Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<T> grad,
-      ResourceApplyProximalAdagrad.Options... options) {
-    return ResourceApplyProximalAdagrad.create(scope, var, accum, lr, l1, l2, grad, options);
-  }
-
-  /**
-   * Builds an {@link ConditionalAccumulator} operation
-   *
-   * @param dtype The type of the value being accumulated.
-   * @param shape The shape of the values, can be [], in which case shape is unknown.
-   * @param options carries optional attributes values
-   * @return a new instance of ConditionalAccumulator
-   * @see org.tensorflow.op.train.ConditionalAccumulator
-   */
-  public <T extends TType> ConditionalAccumulator conditionalAccumulator(DataType<T> dtype,
-      Shape shape, ConditionalAccumulator.Options... options) {
-    return ConditionalAccumulator.create(scope, dtype, shape, options);
-  }
-
-  /**
-   * Builds an {@link SparseApplyProximalAdagrad} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Learning rate. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 regularization. Must be a scalar.
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
-   * @param options carries optional attributes values
-   * @return a new instance of SparseApplyProximalAdagrad
-   * @see org.tensorflow.op.train.SparseApplyProximalAdagrad
-   */
-  public <T extends TType, U extends TNumber> SparseApplyProximalAdagrad<T> sparseApplyProximalAdagrad(
-      Operand<T> var, Operand<T> accum, Operand<T> lr, Operand<T> l1, Operand<T> l2,
-      Operand<T> grad, Operand<U> indices, SparseApplyProximalAdagrad.Options... options) {
-    return SparseApplyProximalAdagrad.create(scope, var, accum, lr, l1, l2, grad, indices, options);
-  }
-
-  /**
-   * Builds an {@link ApplyAdam} operation
-   *
-   * @param var Should be from a Variable().
-   * @param m Should be from a Variable().
-   * @param v Should be from a Variable().
-   * @param beta1Power Must be a scalar.
-   * @param beta2Power Must be a scalar.
-   * @param lr Scaling factor. Must be a scalar.
-   * @param beta1 Momentum factor. Must be a scalar.
-   * @param beta2 Momentum factor. Must be a scalar.
-   * @param epsilon Ridge term. Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ApplyAdam
-   * @see org.tensorflow.op.train.ApplyAdam
-   */
-  public <T extends TType> ApplyAdam<T> applyAdam(Operand<T> var, Operand<T> m, Operand<T> v,
-      Operand<T> beta1Power, Operand<T> beta2Power, Operand<T> lr, Operand<T> beta1,
-      Operand<T> beta2, Operand<T> epsilon, Operand<T> grad, ApplyAdam.Options... options) {
-    return ApplyAdam.create(scope, var, m, v, beta1Power, beta2Power, lr, beta1, beta2, epsilon, grad, options);
-  }
-
-  /**
-   * Builds an {@link ApplyProximalAdagrad} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 regularization. Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ApplyProximalAdagrad
-   * @see org.tensorflow.op.train.ApplyProximalAdagrad
-   */
-  public <T extends TType> ApplyProximalAdagrad<T> applyProximalAdagrad(Operand<T> var,
-      Operand<T> accum, Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<T> grad,
-      ApplyProximalAdagrad.Options... options) {
-    return ApplyProximalAdagrad.create(scope, var, accum, lr, l1, l2, grad, options);
-  }
-
-  /**
-   * Builds an {@link ResourceApplyAdam} operation
-   *
-   * @param var Should be from a Variable().
-   * @param m Should be from a Variable().
-   * @param v Should be from a Variable().
-   * @param beta1Power Must be a scalar.
-   * @param beta2Power Must be a scalar.
-   * @param lr Scaling factor. Must be a scalar.
-   * @param beta1 Momentum factor. Must be a scalar.
-   * @param beta2 Momentum factor. Must be a scalar.
-   * @param epsilon Ridge term. Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceApplyAdam
-   * @see org.tensorflow.op.train.ResourceApplyAdam
-   */
-  public <T extends TType> ResourceApplyAdam resourceApplyAdam(Operand<?> var, Operand<?> m,
-      Operand<?> v, Operand<T> beta1Power, Operand<T> beta2Power, Operand<T> lr, Operand<T> beta1,
-      Operand<T> beta2, Operand<T> epsilon, Operand<T> grad, ResourceApplyAdam.Options... options) {
-    return ResourceApplyAdam.create(scope, var, m, v, beta1Power, beta2Power, lr, beta1, beta2, epsilon, grad, options);
-  }
-
-  /**
-   * Builds an {@link ResourceSparseApplyProximalGradientDescent} operation
-   *
-   * @param var Should be from a Variable().
-   * @param alpha Scaling factor. Must be a scalar.
-   * @param l1 L1 regularization. Must be a scalar.
-   * @param l2 L2 regularization. Must be a scalar.
-   * @param grad The gradient.
-   * @param indices A vector of indices into the first dimension of var and accum.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceSparseApplyProximalGradientDescent
-   * @see org.tensorflow.op.train.ResourceSparseApplyProximalGradientDescent
-   */
-  public <T extends TType, U extends TNumber> ResourceSparseApplyProximalGradientDescent resourceSparseApplyProximalGradientDescent(
-      Operand<?> var, Operand<T> alpha, Operand<T> l1, Operand<T> l2, Operand<T> grad,
-      Operand<U> indices, ResourceSparseApplyProximalGradientDescent.Options... options) {
-    return ResourceSparseApplyProximalGradientDescent.create(scope, var, alpha, l1, l2, grad, indices, options);
-  }
-
-  /**
-   * Builds an {@link ResourceApplyAdadelta} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param accumUpdate Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param rho Decay factor. Must be a scalar.
-   * @param epsilon Constant factor. Must be a scalar.
-   * @param grad The gradient.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceApplyAdadelta
-   * @see org.tensorflow.op.train.ResourceApplyAdadelta
-   */
-  public <T extends TType> ResourceApplyAdadelta resourceApplyAdadelta(Operand<?> var,
-      Operand<?> accum, Operand<?> accumUpdate, Operand<T> lr, Operand<T> rho, Operand<T> epsilon,
-      Operand<T> grad, ResourceApplyAdadelta.Options... options) {
-    return ResourceApplyAdadelta.create(scope, var, accum, accumUpdate, lr, rho, epsilon, grad, options);
-  }
-
-  /**
-   * Builds an {@link ResourceApplyKerasMomentum} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param grad The gradient.
-   * @param momentum Momentum. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceApplyKerasMomentum
-   * @see org.tensorflow.op.train.ResourceApplyKerasMomentum
-   */
-  public <T extends TType> ResourceApplyKerasMomentum resourceApplyKerasMomentum(Operand<?> var,
-      Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<T> momentum,
-      ResourceApplyKerasMomentum.Options... options) {
-    return ResourceApplyKerasMomentum.create(scope, var, accum, lr, grad, momentum, options);
-  }
-
-  /**
-   * Builds an {@link NegTrain} operation
-   *
-   * @param wIn input word embedding.
-   * @param wOut output word embedding.
-   * @param examples A vector of word ids.
-   * @param labels A vector of word ids.
-   * @param lr 
-   * @param vocabCount Count of words in the vocabulary.
-   * @param numNegativeSamples Number of negative samples per example.
-   * @return a new instance of NegTrain
-   * @see org.tensorflow.op.train.NegTrain
-   */
-  public NegTrain negTrain(Operand<TFloat32> wIn, Operand<TFloat32> wOut, Operand<TInt32> examples,
-      Operand<TInt32> labels, Operand<TFloat32> lr, List<Long> vocabCount,
-      Long numNegativeSamples) {
-    return NegTrain.create(scope, wIn, wOut, examples, labels, lr, vocabCount, numNegativeSamples);
-  }
-
-  /**
-   * Builds an {@link ResourceApplyMomentum} operation
-   *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param grad The gradient.
-   * @param momentum Momentum. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of ResourceApplyMomentum
-   * @see org.tensorflow.op.train.ResourceApplyMomentum
-   */
-  public <T extends TType> ResourceApplyMomentum resourceApplyMomentum(Operand<?> var,
-      Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<T> momentum,
-      ResourceApplyMomentum.Options... options) {
-    return ResourceApplyMomentum.create(scope, var, accum, lr, grad, momentum, options);
+  public <T extends TType, U extends TNumber> ResourceSparseApplyAdagradDa resourceSparseApplyAdagradDa(
+      Operand<?> var, Operand<?> gradientAccumulator, Operand<?> gradientSquaredAccumulator,
+      Operand<T> grad, Operand<U> indices, Operand<T> lr, Operand<T> l1, Operand<T> l2,
+      Operand<TInt64> globalStep, ResourceSparseApplyAdagradDa.Options... options) {
+    return ResourceSparseApplyAdagradDa.create(scope, var, gradientAccumulator, gradientSquaredAccumulator, grad, indices, lr, l1, l2, globalStep, options);
   }
 
   /**
@@ -1089,34 +856,104 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link ApplyAddSign} operation
+   * Builds an {@link ResourceSparseApplyFtrl} operation
    *
    * @param var Should be from a Variable().
-   * @param m Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param alpha Must be a scalar.
-   * @param signDecay Must be a scalar.
-   * @param beta Must be a scalar.
+   * @param accum Should be from a Variable().
+   * @param linear Should be from a Variable().
    * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param lr Scaling factor. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 shrinkage regulariation. Must be a scalar.
+   * @param l2Shrinkage 
+   * @param lrPower Scaling factor. Must be a scalar.
    * @param options carries optional attributes values
-   * @return a new instance of ApplyAddSign
-   * @see org.tensorflow.op.train.ApplyAddSign
+   * @return a new instance of ResourceSparseApplyFtrl
+   * @see org.tensorflow.op.train.ResourceSparseApplyFtrl
    */
-  public <T extends TType> ApplyAddSign<T> applyAddSign(Operand<T> var, Operand<T> m, Operand<T> lr,
-      Operand<T> alpha, Operand<T> signDecay, Operand<T> beta, Operand<T> grad,
-      ApplyAddSign.Options... options) {
-    return ApplyAddSign.create(scope, var, m, lr, alpha, signDecay, beta, grad, options);
+  public <T extends TType, U extends TNumber> ResourceSparseApplyFtrl resourceSparseApplyFtrl(
+      Operand<?> var, Operand<?> accum, Operand<?> linear, Operand<T> grad, Operand<U> indices,
+      Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<T> l2Shrinkage, Operand<T> lrPower,
+      ResourceSparseApplyFtrl.Options... options) {
+    return ResourceSparseApplyFtrl.create(scope, var, accum, linear, grad, indices, lr, l1, l2, l2Shrinkage, lrPower, options);
   }
 
   /**
-   * Builds an {@link SdcaFprint} operation
+   * Builds an {@link ResourceSparseApplyKerasMomentum} operation
    *
-   * @param input vector of strings to compute fingerprints on.
-   * @return a new instance of SdcaFprint
-   * @see org.tensorflow.op.train.SdcaFprint
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param lr Learning rate. Must be a scalar.
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param momentum Momentum. Must be a scalar.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceSparseApplyKerasMomentum
+   * @see org.tensorflow.op.train.ResourceSparseApplyKerasMomentum
    */
-  public SdcaFprint sdcaFprint(Operand<TString> input) {
-    return SdcaFprint.create(scope, input);
+  public <T extends TType, U extends TNumber> ResourceSparseApplyKerasMomentum resourceSparseApplyKerasMomentum(
+      Operand<?> var, Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<U> indices,
+      Operand<T> momentum, ResourceSparseApplyKerasMomentum.Options... options) {
+    return ResourceSparseApplyKerasMomentum.create(scope, var, accum, lr, grad, indices, momentum, options);
+  }
+
+  /**
+   * Builds an {@link ResourceSparseApplyMomentum} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param lr Learning rate. Must be a scalar.
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param momentum Momentum. Must be a scalar.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceSparseApplyMomentum
+   * @see org.tensorflow.op.train.ResourceSparseApplyMomentum
+   */
+  public <T extends TType, U extends TNumber> ResourceSparseApplyMomentum resourceSparseApplyMomentum(
+      Operand<?> var, Operand<?> accum, Operand<T> lr, Operand<T> grad, Operand<U> indices,
+      Operand<T> momentum, ResourceSparseApplyMomentum.Options... options) {
+    return ResourceSparseApplyMomentum.create(scope, var, accum, lr, grad, indices, momentum, options);
+  }
+
+  /**
+   * Builds an {@link ResourceSparseApplyProximalAdagrad} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param lr Learning rate. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 regularization. Must be a scalar.
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceSparseApplyProximalAdagrad
+   * @see org.tensorflow.op.train.ResourceSparseApplyProximalAdagrad
+   */
+  public <T extends TType, U extends TNumber> ResourceSparseApplyProximalAdagrad resourceSparseApplyProximalAdagrad(
+      Operand<?> var, Operand<?> accum, Operand<T> lr, Operand<T> l1, Operand<T> l2,
+      Operand<T> grad, Operand<U> indices, ResourceSparseApplyProximalAdagrad.Options... options) {
+    return ResourceSparseApplyProximalAdagrad.create(scope, var, accum, lr, l1, l2, grad, indices, options);
+  }
+
+  /**
+   * Builds an {@link ResourceSparseApplyProximalGradientDescent} operation
+   *
+   * @param var Should be from a Variable().
+   * @param alpha Scaling factor. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 regularization. Must be a scalar.
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param options carries optional attributes values
+   * @return a new instance of ResourceSparseApplyProximalGradientDescent
+   * @see org.tensorflow.op.train.ResourceSparseApplyProximalGradientDescent
+   */
+  public <T extends TType, U extends TNumber> ResourceSparseApplyProximalGradientDescent resourceSparseApplyProximalGradientDescent(
+      Operand<?> var, Operand<T> alpha, Operand<T> l1, Operand<T> l2, Operand<T> grad,
+      Operand<U> indices, ResourceSparseApplyProximalGradientDescent.Options... options) {
+    return ResourceSparseApplyProximalGradientDescent.create(scope, var, alpha, l1, l2, grad, indices, options);
   }
 
   /**
@@ -1143,42 +980,182 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link ApplyMomentum} operation
+   * Builds an {@link Restore} operation
    *
-   * @param var Should be from a Variable().
-   * @param accum Should be from a Variable().
-   * @param lr Scaling factor. Must be a scalar.
-   * @param grad The gradient.
-   * @param momentum Momentum. Must be a scalar.
-   * @param options carries optional attributes values
-   * @return a new instance of ApplyMomentum
-   * @see org.tensorflow.op.train.ApplyMomentum
+   * @param prefix Must have a single element.  The prefix of a V2 checkpoint.
+   * @param tensorNames shape {N}.  The names of the tensors to be restored.
+   * @param shapeAndSlices shape {N}.  The slice specs of the tensors to be restored.
+   * @param dtypes shape {N}.  The list of expected dtype for the tensors.  Must match
+   * @return a new instance of Restore
+   * @see org.tensorflow.op.train.Restore
    */
-  public <T extends TType> ApplyMomentum<T> applyMomentum(Operand<T> var, Operand<T> accum,
-      Operand<T> lr, Operand<T> grad, Operand<T> momentum, ApplyMomentum.Options... options) {
-    return ApplyMomentum.create(scope, var, accum, lr, grad, momentum, options);
+  public Restore restore(Operand<TString> prefix, Operand<TString> tensorNames,
+      Operand<TString> shapeAndSlices, List<DataType<?>> dtypes) {
+    return Restore.create(scope, prefix, tensorNames, shapeAndSlices, dtypes);
   }
 
   /**
-   * Builds an {@link ResourceApplyAdagradDa} operation
+   * Builds an {@link RestoreSlice} operation
+   *
+   * @param filePattern Must have a single element. The pattern of the files from
+   * @param tensorName Must have a single element. The name of the tensor to be
+   * @param shapeAndSlice Scalar. The shapes and slice specifications to use when
+   * @param dt The type of the tensor to be restored.
+   * @param options carries optional attributes values
+   * @return a new instance of RestoreSlice
+   * @see org.tensorflow.op.train.RestoreSlice
+   */
+  public <T extends TType> RestoreSlice<T> restoreSlice(Operand<TString> filePattern,
+      Operand<TString> tensorName, Operand<TString> shapeAndSlice, DataType<T> dt,
+      RestoreSlice.Options... options) {
+    return RestoreSlice.create(scope, filePattern, tensorName, shapeAndSlice, dt, options);
+  }
+
+  /**
+   * Builds an {@link Save} operation
+   *
+   * @param prefix Must have a single element. The prefix of the V2 checkpoint to which we
+   * @param tensorNames shape {N}. The names of the tensors to be saved.
+   * @param shapeAndSlices shape {N}.  The slice specs of the tensors to be saved.
+   * @param tensors `N` tensors to save.
+   * @return a new instance of Save
+   * @see org.tensorflow.op.train.Save
+   */
+  public Save save(Operand<TString> prefix, Operand<TString> tensorNames,
+      Operand<TString> shapeAndSlices, Iterable<Operand<?>> tensors) {
+    return Save.create(scope, prefix, tensorNames, shapeAndSlices, tensors);
+  }
+
+  /**
+   * Builds an {@link SaveSlices} operation
+   *
+   * @param filename Must have a single element. The name of the file to which we write the
+   * @param tensorNames Shape `[N]`. The names of the tensors to be saved.
+   * @param shapesAndSlices Shape `[N]`.  The shapes and slice specifications to use when
+   * @param data `N` tensors to save.
+   * @return a new instance of SaveSlices
+   * @see org.tensorflow.op.train.SaveSlices
+   */
+  public SaveSlices saveSlices(Operand<TString> filename, Operand<TString> tensorNames,
+      Operand<TString> shapesAndSlices, Iterable<Operand<?>> data) {
+    return SaveSlices.create(scope, filename, tensorNames, shapesAndSlices, data);
+  }
+
+  /**
+   * Builds an {@link SdcaFprint} operation
+   *
+   * @param input vector of strings to compute fingerprints on.
+   * @return a new instance of SdcaFprint
+   * @see org.tensorflow.op.train.SdcaFprint
+   */
+  public SdcaFprint sdcaFprint(Operand<TString> input) {
+    return SdcaFprint.create(scope, input);
+  }
+
+  /**
+   * Builds an {@link SdcaShrinkL1} operation
+   *
+   * @param weights a list of vectors where each value is the weight associated with a
+   * @param l1 Symmetric l1 regularization strength.
+   * @param l2 Symmetric l2 regularization strength. Should be a positive float.
+   * @return a new instance of SdcaShrinkL1
+   * @see org.tensorflow.op.train.SdcaShrinkL1
+   */
+  public SdcaShrinkL1 sdcaShrinkL1(Iterable<Operand<TFloat32>> weights, Float l1, Float l2) {
+    return SdcaShrinkL1.create(scope, weights, l1, l2);
+  }
+
+  /**
+   * Builds an {@link SparseApplyAdadelta} operation
+   *
+   * @param var 
+   * @param accum Should be from a Variable().
+   * @param accumUpdate : Should be from a Variable().
+   * @param lr Learning rate. Must be a scalar.
+   * @param rho Decay factor. Must be a scalar.
+   * @param epsilon Constant factor. Must be a scalar.
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param options carries optional attributes values
+   * @return a new instance of SparseApplyAdadelta
+   * @see org.tensorflow.op.train.SparseApplyAdadelta
+   */
+  public <T extends TType, U extends TNumber> SparseApplyAdadelta<T> sparseApplyAdadelta(
+      Operand<T> var, Operand<T> accum, Operand<T> accumUpdate, Operand<T> lr, Operand<T> rho,
+      Operand<T> epsilon, Operand<T> grad, Operand<U> indices,
+      SparseApplyAdadelta.Options... options) {
+    return SparseApplyAdadelta.create(scope, var, accum, accumUpdate, lr, rho, epsilon, grad, indices, options);
+  }
+
+  /**
+   * Builds an {@link SparseApplyAdagradDa} operation
    *
    * @param var Should be from a Variable().
    * @param gradientAccumulator Should be from a Variable().
    * @param gradientSquaredAccumulator Should be from a Variable().
    * @param grad The gradient.
-   * @param lr Scaling factor. Must be a scalar.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param lr Learning rate. Must be a scalar.
    * @param l1 L1 regularization. Must be a scalar.
    * @param l2 L2 regularization. Must be a scalar.
    * @param globalStep Training step number. Must be a scalar.
    * @param options carries optional attributes values
-   * @return a new instance of ResourceApplyAdagradDa
-   * @see org.tensorflow.op.train.ResourceApplyAdagradDa
+   * @return a new instance of SparseApplyAdagradDa
+   * @see org.tensorflow.op.train.SparseApplyAdagradDa
    */
-  public <T extends TType> ResourceApplyAdagradDa resourceApplyAdagradDa(Operand<?> var,
-      Operand<?> gradientAccumulator, Operand<?> gradientSquaredAccumulator, Operand<T> grad,
-      Operand<T> lr, Operand<T> l1, Operand<T> l2, Operand<TInt64> globalStep,
-      ResourceApplyAdagradDa.Options... options) {
-    return ResourceApplyAdagradDa.create(scope, var, gradientAccumulator, gradientSquaredAccumulator, grad, lr, l1, l2, globalStep, options);
+  public <T extends TType, U extends TNumber> SparseApplyAdagradDa<T> sparseApplyAdagradDa(
+      Operand<T> var, Operand<T> gradientAccumulator, Operand<T> gradientSquaredAccumulator,
+      Operand<T> grad, Operand<U> indices, Operand<T> lr, Operand<T> l1, Operand<T> l2,
+      Operand<TInt64> globalStep, SparseApplyAdagradDa.Options... options) {
+    return SparseApplyAdagradDa.create(scope, var, gradientAccumulator, gradientSquaredAccumulator, grad, indices, lr, l1, l2, globalStep, options);
+  }
+
+  /**
+   * Builds an {@link SparseApplyCenteredRmsProp} operation
+   *
+   * @param var Should be from a Variable().
+   * @param mg Should be from a Variable().
+   * @param ms Should be from a Variable().
+   * @param mom Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param rho Decay rate. Must be a scalar.
+   * @param momentum 
+   * @param epsilon Ridge term. Must be a scalar.
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var, ms and mom.
+   * @param options carries optional attributes values
+   * @return a new instance of SparseApplyCenteredRmsProp
+   * @see org.tensorflow.op.train.SparseApplyCenteredRmsProp
+   */
+  public <T extends TType, U extends TNumber> SparseApplyCenteredRmsProp<T> sparseApplyCenteredRmsProp(
+      Operand<T> var, Operand<T> mg, Operand<T> ms, Operand<T> mom, Operand<T> lr, Operand<T> rho,
+      Operand<T> momentum, Operand<T> epsilon, Operand<T> grad, Operand<U> indices,
+      SparseApplyCenteredRmsProp.Options... options) {
+    return SparseApplyCenteredRmsProp.create(scope, var, mg, ms, mom, lr, rho, momentum, epsilon, grad, indices, options);
+  }
+
+  /**
+   * Builds an {@link SparseApplyFtrl} operation
+   *
+   * @param var Should be from a Variable().
+   * @param accum Should be from a Variable().
+   * @param linear Should be from a Variable().
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var and accum.
+   * @param lr Scaling factor. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 shrinkage regulariation. Must be a scalar.
+   * @param l2Shrinkage 
+   * @param lrPower Scaling factor. Must be a scalar.
+   * @param options carries optional attributes values
+   * @return a new instance of SparseApplyFtrl
+   * @see org.tensorflow.op.train.SparseApplyFtrl
+   */
+  public <T extends TType, U extends TNumber> SparseApplyFtrl<T> sparseApplyFtrl(Operand<T> var,
+      Operand<T> accum, Operand<T> linear, Operand<T> grad, Operand<U> indices, Operand<T> lr,
+      Operand<T> l1, Operand<T> l2, Operand<T> l2Shrinkage, Operand<T> lrPower,
+      SparseApplyFtrl.Options... options) {
+    return SparseApplyFtrl.create(scope, var, accum, linear, grad, indices, lr, l1, l2, l2Shrinkage, lrPower, options);
   }
 
   /**
@@ -1201,53 +1178,76 @@ public final class TrainOps {
   }
 
   /**
-   * Builds an {@link AccumulatorTakeGradient} operation
+   * Builds an {@link SparseApplyProximalAdagrad} operation
    *
-   * @param handle The handle to an accumulator.
-   * @param numRequired Number of gradients required before we return an aggregate.
-   * @param dtype The data type of accumulated gradients. Needs to correspond to the type
-   * @return a new instance of AccumulatorTakeGradient
-   * @see org.tensorflow.op.train.AccumulatorTakeGradient
-   */
-  public <T extends TType> AccumulatorTakeGradient<T> accumulatorTakeGradient(
-      Operand<TString> handle, Operand<TInt32> numRequired, DataType<T> dtype) {
-    return AccumulatorTakeGradient.create(scope, handle, numRequired, dtype);
-  }
-
-  /**
-   * Builds an {@link ResourceSparseApplyAdadelta} operation
-   *
-   * @param var 
+   * @param var Should be from a Variable().
    * @param accum Should be from a Variable().
-   * @param accumUpdate : Should be from a Variable().
    * @param lr Learning rate. Must be a scalar.
-   * @param rho Decay factor. Must be a scalar.
-   * @param epsilon Constant factor. Must be a scalar.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 regularization. Must be a scalar.
    * @param grad The gradient.
    * @param indices A vector of indices into the first dimension of var and accum.
    * @param options carries optional attributes values
-   * @return a new instance of ResourceSparseApplyAdadelta
-   * @see org.tensorflow.op.train.ResourceSparseApplyAdadelta
+   * @return a new instance of SparseApplyProximalAdagrad
+   * @see org.tensorflow.op.train.SparseApplyProximalAdagrad
    */
-  public <T extends TType, U extends TNumber> ResourceSparseApplyAdadelta resourceSparseApplyAdadelta(
-      Operand<?> var, Operand<?> accum, Operand<?> accumUpdate, Operand<T> lr, Operand<T> rho,
-      Operand<T> epsilon, Operand<T> grad, Operand<U> indices,
-      ResourceSparseApplyAdadelta.Options... options) {
-    return ResourceSparseApplyAdadelta.create(scope, var, accum, accumUpdate, lr, rho, epsilon, grad, indices, options);
+  public <T extends TType, U extends TNumber> SparseApplyProximalAdagrad<T> sparseApplyProximalAdagrad(
+      Operand<T> var, Operand<T> accum, Operand<T> lr, Operand<T> l1, Operand<T> l2,
+      Operand<T> grad, Operand<U> indices, SparseApplyProximalAdagrad.Options... options) {
+    return SparseApplyProximalAdagrad.create(scope, var, accum, lr, l1, l2, grad, indices, options);
   }
 
   /**
-   * Builds an {@link ApplyGradientDescent} operation
+   * Builds an {@link SparseApplyProximalGradientDescent} operation
    *
    * @param var Should be from a Variable().
    * @param alpha Scaling factor. Must be a scalar.
-   * @param delta The change.
+   * @param l1 L1 regularization. Must be a scalar.
+   * @param l2 L2 regularization. Must be a scalar.
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var and accum.
    * @param options carries optional attributes values
-   * @return a new instance of ApplyGradientDescent
-   * @see org.tensorflow.op.train.ApplyGradientDescent
+   * @return a new instance of SparseApplyProximalGradientDescent
+   * @see org.tensorflow.op.train.SparseApplyProximalGradientDescent
    */
-  public <T extends TType> ApplyGradientDescent<T> applyGradientDescent(Operand<T> var,
-      Operand<T> alpha, Operand<T> delta, ApplyGradientDescent.Options... options) {
-    return ApplyGradientDescent.create(scope, var, alpha, delta, options);
+  public <T extends TType, U extends TNumber> SparseApplyProximalGradientDescent<T> sparseApplyProximalGradientDescent(
+      Operand<T> var, Operand<T> alpha, Operand<T> l1, Operand<T> l2, Operand<T> grad,
+      Operand<U> indices, SparseApplyProximalGradientDescent.Options... options) {
+    return SparseApplyProximalGradientDescent.create(scope, var, alpha, l1, l2, grad, indices, options);
+  }
+
+  /**
+   * Builds an {@link SparseApplyRmsProp} operation
+   *
+   * @param var Should be from a Variable().
+   * @param ms Should be from a Variable().
+   * @param mom Should be from a Variable().
+   * @param lr Scaling factor. Must be a scalar.
+   * @param rho Decay rate. Must be a scalar.
+   * @param momentum 
+   * @param epsilon Ridge term. Must be a scalar.
+   * @param grad The gradient.
+   * @param indices A vector of indices into the first dimension of var, ms and mom.
+   * @param options carries optional attributes values
+   * @return a new instance of SparseApplyRmsProp
+   * @see org.tensorflow.op.train.SparseApplyRmsProp
+   */
+  public <T extends TType, U extends TNumber> SparseApplyRmsProp<T> sparseApplyRmsProp(
+      Operand<T> var, Operand<T> ms, Operand<T> mom, Operand<T> lr, Operand<T> rho,
+      Operand<T> momentum, Operand<T> epsilon, Operand<T> grad, Operand<U> indices,
+      SparseApplyRmsProp.Options... options) {
+    return SparseApplyRmsProp.create(scope, var, ms, mom, lr, rho, momentum, epsilon, grad, indices, options);
+  }
+
+  /**
+   * Builds an {@link TileGrad} operation
+   *
+   * @param input 
+   * @param multiples 
+   * @return a new instance of TileGrad
+   * @see org.tensorflow.op.train.TileGrad
+   */
+  public <T extends TType> TileGrad<T> tileGrad(Operand<T> input, Operand<TInt32> multiples) {
+    return TileGrad.create(scope, input, multiples);
   }
 }

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
@@ -160,19 +160,18 @@ public final class OperatorProcessor extends AbstractProcessor {
         return 1;
       } else if (o1.parameters.size() < o2.parameters.size()) {
         return -1;
-      } else {
-        List<ParameterSpec> firstParams = o1.parameters;
-        List<ParameterSpec> secondParams = o2.parameters;
-        for (int i = 0; i < firstParams.size(); i++) {
-          ParameterSpec first = firstParams.get(i);
-          ParameterSpec second = secondParams.get(i);
-          int compare = first.name.compareTo(second.name);
-          if (compare != 0) {
-            return compare;
-          }
-        }
-        return 0;
       }
+      List<ParameterSpec> firstParams = o1.parameters;
+      List<ParameterSpec> secondParams = o2.parameters;
+      for (int i = 0; i < firstParams.size(); i++) {
+        ParameterSpec first = firstParams.get(i);
+        ParameterSpec second = secondParams.get(i);
+        int compare = first.name.compareTo(second.name);
+        if (compare != 0) {
+          return compare;
+        }
+      }
+      return 0;
     };
     private static final Comparator<MethodSpec> METHOD_SPEC_COMPARATOR = Comparator.comparing((MethodSpec m) -> m.name).thenComparing(PARAMETER_SPEC_COMPARATOR);
 

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -154,17 +155,39 @@ public final class OperatorProcessor extends AbstractProcessor {
   }
 
   private static class OpsSpec {
+    private static final Comparator<MethodSpec> PARAMETER_SPEC_COMPARATOR = (o1, o2) -> {
+      if (o1.parameters.size() > o2.parameters.size()) {
+        return 1;
+      } else if (o1.parameters.size() < o2.parameters.size()) {
+        return -1;
+      } else {
+        List<ParameterSpec> firstParams = o1.parameters;
+        List<ParameterSpec> secondParams = o2.parameters;
+        for (int i = 0; i < firstParams.size(); i++) {
+          ParameterSpec first = firstParams.get(i);
+          ParameterSpec second = secondParams.get(i);
+          int compare = first.name.compareTo(second.name);
+          if (compare != 0) {
+            return compare;
+          }
+        }
+        return 0;
+      }
+    };
+    private static final Comparator<MethodSpec> METHOD_SPEC_COMPARATOR = Comparator.comparing((MethodSpec m) -> m.name).thenComparing(PARAMETER_SPEC_COMPARATOR);
+
     final String groupName;
     final String fieldName;
     final ClassName className;
-    final Collection<MethodSpec> methods;
+    final List<MethodSpec> methods;
     final List<OpsSpec> subGroups = new ArrayList<>();
 
     OpsSpec(String groupName, String fieldName, ClassName className, Collection<MethodSpec> methods) {
       this.groupName = groupName;
       this.fieldName = fieldName;
       this.className = className;
-      this.methods = methods;
+      this.methods = new ArrayList<>(methods);
+      this.methods.sort(METHOD_SPEC_COMPARATOR);
     }
   }
 

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
@@ -158,7 +158,8 @@ public final class OperatorProcessor extends AbstractProcessor {
     private static final Comparator<MethodSpec> PARAMETER_SPEC_COMPARATOR = (o1, o2) -> {
       if (o1.parameters.size() > o2.parameters.size()) {
         return 1;
-      } else if (o1.parameters.size() < o2.parameters.size()) {
+      }
+      if (o1.parameters.size() < o2.parameters.size()) {
         return -1;
       }
       List<ParameterSpec> firstParams = o1.parameters;


### PR DESCRIPTION
This enforces a deterministic order on the ops generation by passing each `OpsSpec`'s method collection through a comparator before building the Java output. The comparator first compares the method name using String's natural ordering, then compares the number of arguments to the methods, then compares the name of each method argument at a specific position using String's natural ordering.

The only real edit in this commit is to `OperatorProcessor.java` the rest is just the rearrangement of the ops according to the above comparator. Unfortunately this means it does rearrange the ops again, but it should be for the final time.