### PR TITLE
Fix some issues with String tensor slicing

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/StringTensorBuffer.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/StringTensorBuffer.java
@@ -110,7 +110,9 @@ public class StringTensorBuffer extends AbstractDataBuffer<byte[]> {
 
     // Read string of the given length
     byte[] bytes = new byte[length];
-    data.offset(offset).read(bytes);
+    if (length > 0) {
+      data.offset(offset).read(bytes);
+    }
     return bytes;
   }
 
@@ -142,20 +144,17 @@ public class StringTensorBuffer extends AbstractDataBuffer<byte[]> {
 
   @Override
   public DataBuffer<byte[]> offset(long index) {
-    return new StringTensorBuffer(offsets.offset(index), data.offset(offsets.getLong(index)));
+    return new StringTensorBuffer(offsets.offset(index), data);
   }
 
   @Override
   public DataBuffer<byte[]> narrow(long size) {
-    return new StringTensorBuffer(offsets.narrow(size), data.narrow(offsets.getLong(size)));
+    return new StringTensorBuffer(offsets.narrow(size), data);
   }
 
   @Override
   public DataBuffer<byte[]> slice(long index, long size) {
-    return new StringTensorBuffer(
-        offsets.slice(index, size),
-        data.slice(offsets.getLong(index), offsets.getLong(index + size))
-    );
+    return new StringTensorBuffer(offsets.slice(index, size), data);
   }
 
   StringTensorBuffer(LongDataBuffer offsets, ByteDataBuffer data) {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/AbstractDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/AbstractDataBuffer.java
@@ -44,11 +44,7 @@ public abstract class AbstractDataBuffer<T> implements DataBuffer<T> {
 
   @Override
   public DataBuffer<T> copyTo(DataBuffer<T> dst, long size) {
-    Validator.copyToArgs(this, dst, size);
-    for (long idx = 0L; idx < size; ++idx) {
-      dst.setObject(getObject(idx), idx);
-    }
-    return this;
+    return slowCopyTo(dst, size);
   }
 
   @Override


### PR DESCRIPTION
We only need to apply slicing dimensions on the `offset` buffer, which provides the position of each element in the `data` buffer (that should therefore be left intact).