### PR TITLE
Removed unnecessary examples for shape attribute which is not there in tensor_scatter_nd_add

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/TensorScatterNdAdd.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/TensorScatterNdAdd.java
@@ -37,18 +37,6 @@ import org.tensorflow.types.family.TType;
  * are added onto an existing tensor (as opposed to a variable). If the memory
  * for the existing tensor cannot be re-used, a copy is made and updated.
  * <p>
- * `indices` is an integer tensor containing indices into a new tensor of shape
- * `shape`.  The last dimension of `indices` can be at most the rank of `shape`:
- * <p>
- *     indices.shape[-1] <= shape.rank
- * <p>
- * The last dimension of `indices` corresponds to indices into elements
- * (if `indices.shape[-1] = shape.rank`) or slices
- * (if `indices.shape[-1] < shape.rank`) along dimension `indices.shape[-1]` of
- * `shape`.  `updates` is a tensor with shape
- * <p>
- *     indices.shape[:-1] + shape[indices.shape[-1]:]
- * <p>
  * The simplest form of tensor_scatter_add is to add individual elements to a
  * tensor by index. For example, say we want to add 4 elements in a rank-1
  * tensor with 8 elements.

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/TensorScatterNdAdd.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/TensorScatterNdAdd.java
@@ -37,6 +37,19 @@ import org.tensorflow.types.family.TType;
  * are added onto an existing tensor (as opposed to a variable). If the memory
  * for the existing tensor cannot be re-used, a copy is made and updated.
  * <p>
+ * `indices` is an integer tensor containing indices into a new tensor of shape
+ * `tensor.shape`.  The last dimension of `indices` can be at most the rank of
+ * `tensor.shape`:
+ * <p>
+ *     indices.shape[-1] <= tensor.shape.rank
+ * <p>
+ * The last dimension of `indices` corresponds to indices into elements
+ * (if `indices.shape[-1] = tensor.shape.rank`) or slices
+ * (if `indices.shape[-1] < tensor.shape.rank`) along dimension
+ * `indices.shape[-1]` of `tensor.shape`.  `updates` is a tensor with shape
+ * <p>
+ *     indices.shape[:-1] + tensor.shape[indices.shape[-1]:]
+ * <p>
  * The simplest form of tensor_scatter_add is to add individual elements to a
  * tensor by index. For example, say we want to add 4 elements in a rank-1
  * tensor with 8 elements.


### PR DESCRIPTION
Fixes [#37669](https://github.com/tensorflow/tensorflow/issues/37669).
Removed code corresponding to example doc string for `shape` parameter which is not present in `tensor_scatter_nd_add`.

@mihaimaruseac, please review.