### PR TITLE
Add GitHub Actions job that redeploys snapshots to get consistent timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,24 @@ jobs:
           call mvn clean %MAVEN_PHASE% -Possrh -B -U -e -Djavacpp.platform=windows-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
           df -h
           wmic pagefile list /format:list
+  redeploy:
+    if: github.event_name == 'push'
+    needs: [linux-x86_64, macosx-x86_64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Redeploy snapshot artifacts
+        run: |
+          cd tensorflow-core
+          mvn dependency:resolve -Possrh -Predeploy -N -B -U -e -Djavacpp.platform.custom -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.macosx-x86_64
+          cp $HOME/.m2/repository/org/tensorflow/tensorflow-core-api/*-SNAPSHOT/tensorflow-core-api-*-SNAPSHOT*.jar .
+          for f in *.jar; do
+            if [[ $f =~ tensorflow-core-api-.*SNAPSHOT-(.*).jar ]]; then
+              [[ -n $FILES ]] && FILES=$FILES,$f || FILES=$f
+              [[ -n $TYPES ]] && TYPES=$TYPES,jar || TYPES=jar
+              [[ -n $CLASSIFIERS ]] && CLASSIFIERS=$CLASSIFIERS,${BASH_REMATCH[1]} || CLASSIFIERS=${BASH_REMATCH[1]}
+            fi
+          done
+          echo "<settings><servers><server><id>ossrh</id><username>${{ secrets.CI_DEPLOY_USERNAME }}</username><password>${{ secrets.CI_DEPLOY_PASSWORD }}</password></server></servers></settings>" > $HOME/.m2/settings.xml
+          mvn clean deploy -Possrh -Predeploy -N -B -U -e -Dfiles=$FILES -Dtypes=$TYPES -Dclassifiers=$CLASSIFIERS

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,33 @@
     <skipAssembly>true</skipAssembly>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -56,6 +56,60 @@
   </properties>
 
   <profiles>
+    <!-- Redeploys in one shot the snapshot artifacts of tensorflow-core-api
+         given to maven-deploy-plugin to get consistent timestamps among them -->
+    <profile>
+      <id>redeploy</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-platform</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-platform-mkl</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-platform-gpu</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-platform-mkl-gpu</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8.2</version>
+            <executions>
+              <execution>
+                <id>deploy-file</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <file>tensorflow-core-api-${project.version}.jar</file>
+                  <repositoryId>${project.distributionManagement.snapshotRepository.id}</repositoryId>
+                  <url>${project.distributionManagement.snapshotRepository.url}</url>
+                  <groupId>org.tensorflow</groupId>
+                  <artifactId>tensorflow-core-api</artifactId>
+                  <version>${project.version}</version>
+                  <packaging>jar</packaging>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>javacpp-platform-default</id>
       <activation>

--- a/tensorflow-core/tensorflow-core-platform-gpu/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform-gpu/pom.xml
@@ -48,12 +48,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
-      <classifier>${javacpp.platform.macosx-x86_64}</classifier>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
       <classifier>${javacpp.platform.windows-x86_64}</classifier>
     </dependency>
   </dependencies>
@@ -68,7 +62,7 @@
             <configuration>
               <archive>
                 <manifestEntries>
-                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-x86_64-gpu.jar ${javacpp.moduleId}-macosx-x86_64-gpu.jar ${javacpp.moduleId}-windows-x86_64-gpu.jar</Class-Path>
+                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-x86_64-gpu.jar ${javacpp.moduleId}-windows-x86_64-gpu.jar</Class-Path>
                 </manifestEntries>
               </archive>
             </configuration>

--- a/tensorflow-core/tensorflow-core-platform-mkl-gpu/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform-mkl-gpu/pom.xml
@@ -53,12 +53,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
-      <classifier>${javacpp.platform.macosx-x86_64}</classifier>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
       <classifier>${javacpp.platform.windows-x86_64}</classifier>
     </dependency>
   </dependencies>
@@ -73,7 +67,7 @@
             <configuration>
               <archive>
                 <manifestEntries>
-                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-x86_64-mkl-gpu.jar ${javacpp.moduleId}-macosx-x86_64-mkl-gpu.jar ${javacpp.moduleId}-windows-x86_64-mkl-gpu.jar</Class-Path>
+                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-x86_64-mkl-gpu.jar ${javacpp.moduleId}-windows-x86_64-mkl-gpu.jar</Class-Path>
                 </manifestEntries>
               </archive>
             </configuration>


### PR DESCRIPTION
As required for most build tools other than Maven, that is Gradle, sbt, etc.

On GitHub Actions, the result looks like this at
https://github.com/saudet/tensorflow-java/runs/559706945
which ultimately deployed those files:

```
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64-gpu.jar.md5 | Sat Apr 04 01:58:54 UTC 2020 | 32 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64-gpu.jar.sha1 | Sat Apr 04 01:58:54 UTC 2020 | 40 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64-mkl-gpu.jar | Sat Apr 04 01:58:54 UTC 2020 | 152881432 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64-mkl-gpu.jar.md5 | Sat Apr 04 01:59:01 UTC 2020 | 32 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64-mkl-gpu.jar.sha1 | Sat Apr 04 01:59:01 UTC 2020 | 40 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64-mkl.jar | Sat Apr 04 01:59:01 UTC 2020 | 39131128 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64-mkl.jar.md5 | Sat Apr 04 01:59:02 UTC 2020 | 32 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64-mkl.jar.sha1 | Sat Apr 04 01:59:02 UTC 2020 | 40 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64.jar | Sat Apr 04 01:59:02 UTC 2020 | 36061068 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64.jar.md5 | Sat Apr 04 01:59:03 UTC 2020 | 32 |  
tensorflow-core-api-0.1.0-20200404.015837-100-linux-x86_64.jar.sha1 | Sat Apr 04 01:59:03 UTC 2020 | 40 |  
tensorflow-core-api-0.1.0-20200404.015837-100-macosx-x86_64-mkl.jar | Sat Apr 04 01:59:03 UTC 2020 | 46506587 |  
tensorflow-core-api-0.1.0-20200404.015837-100-macosx-x86_64-mkl.jar.md5 | Sat Apr 04 01:59:04 UTC 2020 | 32 |  
tensorflow-core-api-0.1.0-20200404.015837-100-macosx-x86_64-mkl.jar.sha1 | Sat Apr 04 01:59:04 UTC 2020 | 40 |  
tensorflow-core-api-0.1.0-20200404.015837-100-macosx-x86_64.jar | Sat Apr 04 01:59:05 UTC 2020 | 45371550 |  
tensorflow-core-api-0.1.0-20200404.015837-100-macosx-x86_64.jar.md5 | Sat Apr 04 01:59:06 UTC 2020 | 32 |  
tensorflow-core-api-0.1.0-20200404.015837-100-macosx-x86_64.jar.sha1 | Sat Apr 04 01:59:06 UTC 2020 | 40 |  
tensorflow-core-api-0.1.0-20200404.015837-100.jar | Sat Apr 04 01:58:37 UTC 2020 | 2267498 |  
tensorflow-core-api-0.1.0-20200404.015837-100.jar.md5 | Sat Apr 04 01:58:37 UTC 2020 | 32 |  
tensorflow-core-api-0.1.0-20200404.015837-100.jar.sha1 | Sat Apr 04 01:58:37 UTC 2020 | 40 |  
tensorflow-core-api-0.1.0-20200404.015837-100.pom | Sat Apr 04 01:58:37 UTC 2020 | 416 |  
tensorflow-core-api-0.1.0-20200404.015837-100.pom.md5 | Sat Apr 04 01:58:37 UTC 2020 | 32 |  
tensorflow-core-api-0.1.0-20200404.015837-100.pom.sha1 | Sat Apr 04 01:58:37 UTC 2020 | 40 |  
```
https://oss.sonatype.org/content/repositories/snapshots/org/tensorflow/tensorflow-core-api/0.1.0-SNAPSHOT/

Also remove from GPU platform artifacts unavailable dependencies for Mac

/cc @frankfliu