### PR TITLE
Fix Windows build on GitHub Actions by increasing page file size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
           wmic pagefile list /format:list
           echo Executing Maven %MAVEN_PHASE%
           call mvn clean %MAVEN_PHASE% -Possrh -B -U -e -Djavacpp.platform=windows-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
+          if ERRORLEVEL 1 exit /b
           df -h
           wmic pagefile list /format:list
   redeploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
       matrix:
         ext: ["", -mkl, -gpu, -mkl-gpu]
     steps:
+      - name: Configure page file
+        uses: al-cheb/configure-pagefile-action@v1.2
       - name: Install environment
         shell: cmd
         run: |

--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -370,14 +370,14 @@
         </file>
       </activation>
       <properties>
-        <javacpp.platform.linux-armhf></javacpp.platform.linux-armhf>
-        <javacpp.platform.linux-arm64></javacpp.platform.linux-arm64>
-        <javacpp.platform.linux-ppc64le></javacpp.platform.linux-ppc64le>
-        <javacpp.platform.linux-x86></javacpp.platform.linux-x86>
-        <javacpp.platform.linux-x86_64></javacpp.platform.linux-x86_64>
-        <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
-        <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
-        <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-arm64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-ppc64le>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-x86>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86>
+        <javacpp.platform.linux-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.macosx-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.windows-x86>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86>
+        <javacpp.platform.windows-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
       </properties>
     </profile>
 

--- a/tensorflow-framework/pom.xml
+++ b/tensorflow-framework/pom.xml
@@ -33,6 +33,10 @@
     serving TensorFlow models.
   </description>
 
+  <properties>
+    <javacpp.platform.extension></javacpp.platform.extension>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.tensorflow</groupId>
@@ -52,6 +56,13 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Include native binaries dependencies only for testing -->
+    <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-core-platform${javacpp.platform.extension}</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Works for CPU builds, but not CUDA builds, which take too much time:
https://github.com/saudet/tensorflow-java/runs/669792547
Well, it's already better than nothing for now :)