### PR TITLE
Do not visit underlying buffer when layout is applied

### DIFF
--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/adapter/AbstractDataBufferAdapter.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/adapter/AbstractDataBufferAdapter.java
@@ -18,7 +18,6 @@
 package org.tensorflow.tools.buffer.impl.adapter;
 
 import org.tensorflow.tools.buffer.DataBuffer;
-import org.tensorflow.tools.buffer.DataStorageVisitor;
 import org.tensorflow.tools.buffer.impl.AbstractDataBuffer;
 import org.tensorflow.tools.buffer.impl.Validator;
 import org.tensorflow.tools.buffer.layout.DataLayout;
@@ -47,11 +46,6 @@ abstract class AbstractDataBufferAdapter<S extends DataBuffer<?>, T, U extends D
     Validator.setArgs(this, index);
     layout.writeObject(buffer, value, index * layout.scale());
     return (U)this;
-  }
-
-  @Override
-  public <R> R accept(DataStorageVisitor<R> visitor) {
-    return buffer().accept(visitor);
   }
 
   AbstractDataBufferAdapter(S buffer, DataLayout<S, T> layout) {


### PR DESCRIPTION
This is a fix for #61 

The problem was that we should not visit directly a buffer that has a specific layout. Visiting buffers is used to apply bulk operations between two buffers, like copies or equality checks, but when there is a layout, those are not possible (unless both buffers uses the same layout, which could eventually be supported...)

In the specific case of #61 , we ended up trying to copy all bytes of the source array (32-bits values) to the target (16-bits values), hence why the first value (0) was overflowing on the second one.