### PR TITLE
Recycle objects when iterating an element sequence

### DIFF
--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/BooleanDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/BooleanDataBuffer.java
@@ -157,4 +157,9 @@ public interface BooleanDataBuffer extends DataBuffer<Boolean> {
 
   @Override
   BooleanDataBuffer slice(long index, long size);
+
+  @Override
+  default DataBufferWindow<BooleanDataBuffer> window(long size) {
+    return null;
+  }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/BooleanDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/BooleanDataBuffer.java
@@ -160,6 +160,6 @@ public interface BooleanDataBuffer extends DataBuffer<Boolean> {
 
   @Override
   default DataBufferWindow<BooleanDataBuffer> window(long size) {
-    return null;
+    throw new UnsupportedOperationException();
   }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/ByteDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/ByteDataBuffer.java
@@ -224,4 +224,9 @@ public interface ByteDataBuffer extends DataBuffer<Byte> {
 
   @Override
   ByteDataBuffer slice(long index, long size);
+
+  @Override
+  default DataBufferWindow<ByteDataBuffer> window(long size) {
+    return null;
+  }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/ByteDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/ByteDataBuffer.java
@@ -227,6 +227,6 @@ public interface ByteDataBuffer extends DataBuffer<Byte> {
 
   @Override
   default DataBufferWindow<ByteDataBuffer> window(long size) {
-    return null;
+    throw new UnsupportedOperationException();
   }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBuffer.java
@@ -248,6 +248,38 @@ public interface DataBuffer<T> {
   DataBuffer<T> slice(long index, long size);
 
   /**
+   * Creates a {@link DataBufferWindow} that provides a partial view of this buffer.
+   *
+   * <p>The created window has a fixed size and can be {@link DataBufferWindow#slideTo(long) "slide"}
+   * across this buffer at different offsets to provide different views of the data without allocating
+   * a new buffer instance, like {@link #offset(long)} does. This improves overall performances when
+   * this operation is repeated frequently. For example:
+   *
+   * <pre>{@code
+   * IntDataBuffer bufferA = DataBuffers.ofInts(1024);
+   * // ... init buffer data
+   * IntDataBuffer bufferB = DataBuffers.ofInts(1, 2, 3, 4);
+   *
+   * // Return the index of the first occurrence of bufferB in bufferA using a sliding window
+   * DataBufferWindow<IntDataBuffer> windowA = bufferA.window(4);
+   * for (int i = 0; i < bufferA.size() - bufferB.size(); ++i) {
+   *     if (windowA.slideTo(i).buffer().equals(bufferB)) {
+   *         return i;
+   *     }
+   * }
+   * }</pre>
+   *
+   * <p>The returned object is stateful and is not thread-safe.
+   *
+   * @param size size of the window
+   * @return a new window that starts at the index 0 of this buffer,
+   *         or null if this type of buffer does not support buffer windows
+   */
+  default DataBufferWindow<? extends DataBuffer<T>> window(long size) {
+    return null;
+  }
+
+  /**
    * Visits the backing storage of this buffer.
    *
    * <p>The buffer implementation is responsible of passing back a reference to the actual data

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBuffer.java
@@ -250,10 +250,10 @@ public interface DataBuffer<T> {
   /**
    * Creates a {@link DataBufferWindow} that provides a partial view of this buffer.
    *
-   * <p>The created window has a fixed size and can be {@link DataBufferWindow#slideTo(long) "slide"}
-   * across this buffer at different offsets to provide different views of the data without allocating
-   * a new buffer instance, like {@link #offset(long)} does. This improves overall performances when
-   * this operation is repeated frequently. For example:
+   * <p>The created window has a fixed size and can {@link DataBufferWindow#slide(long) "slide"}
+   * along this buffer to provide different views of the data without allocating a new buffer
+   * instance, like {@link #offset(long)} does. This improves overall performance when this
+   * operation is repeated frequently. For example:
    *
    * <pre>{@code
    * IntDataBuffer bufferA = DataBuffers.ofInts(1024);

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBuffer.java
@@ -272,11 +272,11 @@ public interface DataBuffer<T> {
    * <p>The returned object is stateful and is not thread-safe.
    *
    * @param size size of the window
-   * @return a new window that starts at the index 0 of this buffer,
-   *         or null if this type of buffer does not support buffer windows
+   * @return a new window that starts at the index 0 of this buffer
+   * @throws UnsupportedOperationException if this type of buffer does not support buffer windows
    */
   default DataBufferWindow<? extends DataBuffer<T>> window(long size) {
-    return null;
+    throw new UnsupportedOperationException();
   }
 
   /**

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBufferWindow.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBufferWindow.java
@@ -1,7 +1,7 @@
 package org.tensorflow.tools.buffer;
 
 /**
- * A mutable container for view part of a {@link DataBuffer}.
+ * A mutable container for viewing part of a {@link DataBuffer}.
  *
  * <p>Data buffer windows have a fixed size and can {@link DataBufferWindow#slide(long) "slide"}
  * along a buffer to provide different views of the data without allocating a new buffer instance,
@@ -29,7 +29,7 @@ package org.tensorflow.tools.buffer;
 public interface DataBufferWindow<B extends DataBuffer<?>> {
 
   /**
-   * Returns the current offset of this window in the underlying buffer.
+   * Returns the current offset of this window in the original buffer.
    */
   long offset();
 
@@ -39,20 +39,21 @@ public interface DataBufferWindow<B extends DataBuffer<?>> {
   long size();
 
   /**
-   * Moves the window at the given position in the underlying buffer.
+   * Moves the window at the given position in the original buffer.
    *
    * <p>The size of the window remains the same and its offset is set to {@code index}, so that
    * accessing the value of {@link #buffer()} at index {@code x} will return the value at
-   * {@code index + x} in the underlying buffer.
+   * {@code index + x} in the original buffer.
    *
    * @param index new offset for this window
    * @return this instance
-   * @throws IndexOutOfBoundsException if the window cannot be slid because it goes beyond buffer limits
+   * @throws IndexOutOfBoundsException if the window cannot be slid because it goes beyond
+   *                                   the original buffer limits
    */
   DataBufferWindow<B> slideTo(long index);
 
   /**
-   * Moves the window of {@code step} elements in the underlying buffer.
+   * Moves the window of {@code step} elements in the original buffer.
    *
    * <p>The size of the window remains the same and its offset is set to {@code offset() + step}.
    * If {@code step} is positive, then the window will slide forward. If it is negative, it will
@@ -60,15 +61,17 @@ public interface DataBufferWindow<B extends DataBuffer<?>> {
    *
    * @param step value to add to the current offset of this window
    * @return this instance
-   * @throws IndexOutOfBoundsException if the window cannot be slid because it goes beyond buffer limits
+   * @throws IndexOutOfBoundsException if the window cannot be slid because it goes beyond
+   *                                   the original buffer limits
    */
   DataBufferWindow<B> slide(long step);
 
   /**
-   * Returns a buffer presenting the data currently viewed by this window.
+   * Returns the buffer backing this window.
    *
-   * <p>The same instance is always returned for a given window, even after sliding it at
-   * different offsets in the underlying buffer. For example:
+   * <p>Each window instance has it's own buffer providing a view onto the original
+   * {@link DataBuffer}. The buffers are mutated when the window slides to different offsets.
+   * For example:
    *
    * <pre>{@code
    * IntDataBuffer buffer = DataBuffers.of(0, 1, 2, 3);

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBufferWindow.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBufferWindow.java
@@ -1,0 +1,90 @@
+package org.tensorflow.tools.buffer;
+
+/**
+ * A mutable container for viewing partially a {@link DataBuffer}.
+ *
+ * <p>Data buffer windows have a fixed size and can be {@link DataBufferWindow#slideTo(long) "slide"}
+ * across a buffer at different offsets to provide different views of the data without allocating
+ * a new buffer instance, like {@link #offset(long)} does. This improves overall performances when
+ * this operation is repeated frequently. For example:
+ *
+ * <pre>{@code
+ * IntDataBuffer bufferA = DataBuffers.ofInts(1024);
+ * // ... init buffer data
+ * IntDataBuffer bufferB = DataBuffers.ofInts(1, 2, 3, 4);
+ *
+ * // Return the index of the first occurrence of bufferB in bufferA using a sliding window
+ * DataBufferWindow<IntDataBuffer> windowA = bufferA.window(4);
+ * for (int i = 0; i < bufferA.size() - bufferB.size(); ++i) {
+ *     if (windowA.slideTo(i).buffer().equals(bufferB)) {
+ *         return i;
+ *     }
+ * }
+ * }</pre>>
+ *
+ * <p>{@code DataBufferWindow} instances are stateful and not thread-safe.
+ *
+ * @param <B> the type of buffer being viewed
+ */
+public interface DataBufferWindow<B extends DataBuffer<?>> {
+
+  /**
+   * Returns the current offset of this window in the underlying buffer.
+   */
+  long offset();
+
+  /**
+   * Returns the size of this buffer window.
+   */
+  long size();
+
+  /**
+   * Moves the window at the given position in the underlying buffer.
+   *
+   * <p>The size of the window remains the same and its offset is reset to {@code index}, so that
+   * accessing the value of {@link #buffer()} at index {@code x} will return the value at
+   * {@code index + x} in the underlying buffer.
+   *
+   * @param index new offset for this window
+   * @return this instance
+   * @throws IndexOutOfBoundsException if index is beyond the underlying buffer limits
+   */
+  DataBufferWindow<B> slideTo(long index);
+
+  /**
+   * Moves the window of {@code step} elements in the underlying buffer.
+   *
+   * <p>The size of the window remains the same and its offset is reset to {@code offset() + step}.
+   * If {@code step} is positive, then the window will slide forward. If it is negative, it will
+   * slide backward.
+   *
+   * @param step value to add to the current offset of this window
+   * @return this instance
+   * @throws IndexOutOfBoundsException if the resulting offset goes beyond the underlying buffer limits
+   */
+  DataBufferWindow<B> slideOf(long step);
+
+  /**
+   * Returns a buffer presenting the data currently viewed by this window.
+   *
+   * <p>The same instance is always returned for a given window, even after sliding it at
+   * different offsets in the underlying buffer. For example:
+   *
+   * <pre>{@code
+   * IntDataBuffer buffer = DataBuffers.of(0, 1, 2, 3);
+   * DataBufferWindow<IntDataBuffer> window = buffer.window(0, 2);
+   *
+   * IntDataBuffer windowBuffer = window.buffer();
+   * assertEquals(0, windowBuffer.getInt(0));
+   * assertEquals(1, windowBuffer.getInt(1));
+   *
+   * window.slideTo(2);
+   * assertEquals(2, windowBuffer.getInt(0));
+   * assertEquals(3, windowBuffer.getInt(1));
+   * assertSame(windowBuffer, window.buffer());
+   * }</pre>
+   *
+   * @return this window's buffer
+   */
+  B buffer();
+}

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBufferWindow.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DataBufferWindow.java
@@ -1,12 +1,12 @@
 package org.tensorflow.tools.buffer;
 
 /**
- * A mutable container for viewing partially a {@link DataBuffer}.
+ * A mutable container for view part of a {@link DataBuffer}.
  *
- * <p>Data buffer windows have a fixed size and can be {@link DataBufferWindow#slideTo(long) "slide"}
- * across a buffer at different offsets to provide different views of the data without allocating
- * a new buffer instance, like {@link #offset(long)} does. This improves overall performances when
- * this operation is repeated frequently. For example:
+ * <p>Data buffer windows have a fixed size and can {@link DataBufferWindow#slide(long) "slide"}
+ * along a buffer to provide different views of the data without allocating a new buffer instance,
+ * like {@link #offset(long)} does. This improves overall performance when this operation is
+ * repeated frequently. For example:
  *
  * <pre>{@code
  * IntDataBuffer bufferA = DataBuffers.ofInts(1024);
@@ -41,28 +41,28 @@ public interface DataBufferWindow<B extends DataBuffer<?>> {
   /**
    * Moves the window at the given position in the underlying buffer.
    *
-   * <p>The size of the window remains the same and its offset is reset to {@code index}, so that
+   * <p>The size of the window remains the same and its offset is set to {@code index}, so that
    * accessing the value of {@link #buffer()} at index {@code x} will return the value at
    * {@code index + x} in the underlying buffer.
    *
    * @param index new offset for this window
    * @return this instance
-   * @throws IndexOutOfBoundsException if index is beyond the underlying buffer limits
+   * @throws IndexOutOfBoundsException if the window cannot be slid because it goes beyond buffer limits
    */
   DataBufferWindow<B> slideTo(long index);
 
   /**
    * Moves the window of {@code step} elements in the underlying buffer.
    *
-   * <p>The size of the window remains the same and its offset is reset to {@code offset() + step}.
+   * <p>The size of the window remains the same and its offset is set to {@code offset() + step}.
    * If {@code step} is positive, then the window will slide forward. If it is negative, it will
    * slide backward.
    *
    * @param step value to add to the current offset of this window
    * @return this instance
-   * @throws IndexOutOfBoundsException if the resulting offset goes beyond the underlying buffer limits
+   * @throws IndexOutOfBoundsException if the window cannot be slid because it goes beyond buffer limits
    */
-  DataBufferWindow<B> slideOf(long step);
+  DataBufferWindow<B> slide(long step);
 
   /**
    * Returns a buffer presenting the data currently viewed by this window.

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DoubleDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DoubleDataBuffer.java
@@ -160,6 +160,6 @@ public interface DoubleDataBuffer extends DataBuffer<Double> {
 
   @Override
   default DataBufferWindow<DoubleDataBuffer> window(long size) {
-    return null;
+    throw new UnsupportedOperationException();
   }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DoubleDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/DoubleDataBuffer.java
@@ -157,4 +157,9 @@ public interface DoubleDataBuffer extends DataBuffer<Double> {
 
   @Override
   DoubleDataBuffer slice(long index, long size);
+
+  @Override
+  default DataBufferWindow<DoubleDataBuffer> window(long size) {
+    return null;
+  }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/FloatDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/FloatDataBuffer.java
@@ -157,4 +157,9 @@ public interface FloatDataBuffer extends DataBuffer<Float> {
 
   @Override
   FloatDataBuffer slice(long index, long size);
+
+  @Override
+  default DataBufferWindow<FloatDataBuffer> window(long size) {
+    return null;
+  }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/FloatDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/FloatDataBuffer.java
@@ -160,6 +160,6 @@ public interface FloatDataBuffer extends DataBuffer<Float> {
 
   @Override
   default DataBufferWindow<FloatDataBuffer> window(long size) {
-    return null;
+    throw new UnsupportedOperationException();
   }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/IntDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/IntDataBuffer.java
@@ -157,4 +157,9 @@ public interface IntDataBuffer extends DataBuffer<Integer> {
 
   @Override
   IntDataBuffer slice(long index, long size);
+
+  @Override
+  default DataBufferWindow<IntDataBuffer> window(long size) {
+    return null;
+  }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/IntDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/IntDataBuffer.java
@@ -160,6 +160,6 @@ public interface IntDataBuffer extends DataBuffer<Integer> {
 
   @Override
   default DataBufferWindow<IntDataBuffer> window(long size) {
-    return null;
+    throw new UnsupportedOperationException();
   }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/LongDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/LongDataBuffer.java
@@ -160,6 +160,6 @@ public interface LongDataBuffer extends DataBuffer<Long> {
 
   @Override
   default DataBufferWindow<LongDataBuffer> window(long size) {
-    return null;
+    throw new UnsupportedOperationException();
   }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/LongDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/LongDataBuffer.java
@@ -157,4 +157,9 @@ public interface LongDataBuffer extends DataBuffer<Long> {
 
   @Override
   LongDataBuffer slice(long index, long size);
+
+  @Override
+  default DataBufferWindow<LongDataBuffer> window(long size) {
+    return null;
+  }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/ShortDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/ShortDataBuffer.java
@@ -157,4 +157,9 @@ public interface ShortDataBuffer extends DataBuffer<Short> {
 
   @Override
   ShortDataBuffer slice(long index, long size);
+
+  @Override
+  default DataBufferWindow<ShortDataBuffer> window(long size) {
+    return null;
+  }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/ShortDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/ShortDataBuffer.java
@@ -160,6 +160,6 @@ public interface ShortDataBuffer extends DataBuffer<Short> {
 
   @Override
   default DataBufferWindow<ShortDataBuffer> window(long size) {
-    return null;
+    throw new UnsupportedOperationException();
   }
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/AbstractDataBufferWindow.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/AbstractDataBufferWindow.java
@@ -26,7 +26,7 @@ public abstract class AbstractDataBufferWindow<B extends DataBuffer<?>> implemen
   }
 
   @Override
-  public final DataBufferWindow<B> slideOf(long step) {
+  public final DataBufferWindow<B> slide(long step) {
     return slideTo(offset + step);
   }
 

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/AbstractDataBufferWindow.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/AbstractDataBufferWindow.java
@@ -1,0 +1,48 @@
+package org.tensorflow.tools.buffer.impl;
+
+import org.tensorflow.tools.buffer.DataBuffer;
+import org.tensorflow.tools.buffer.DataBufferWindow;
+
+public abstract class AbstractDataBufferWindow<B extends DataBuffer<?>> implements DataBufferWindow<B> {
+
+  @Override
+  public final long offset() {
+    return offset;
+  }
+
+  @Override
+  public final long size() {
+    return windowBuffer.size();
+  }
+
+  @Override
+  public final DataBufferWindow<B> slideTo(long index) {
+    if (index < 0 || index > maxOffset) {
+      throw new IndexOutOfBoundsException();
+    }
+    offset(index);
+    offset = index;
+    return this;
+  }
+
+  @Override
+  public final DataBufferWindow<B> slideOf(long step) {
+    return slideTo(offset + step);
+  }
+
+  @Override
+  public final B buffer() {
+    return windowBuffer;
+  }
+
+  protected abstract void offset(long offset);
+
+  protected AbstractDataBufferWindow(B windowBuffer, long bufferLimit) {
+    this.windowBuffer = windowBuffer;
+    maxOffset = bufferLimit - windowBuffer.size();
+  }
+
+  private final B windowBuffer;
+  private final long maxOffset;
+  private long offset = 0;
+}

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/adapter/AbstractDataBufferAdapter.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/adapter/AbstractDataBufferAdapter.java
@@ -27,7 +27,7 @@ abstract class AbstractDataBufferAdapter<S extends DataBuffer<?>, T, U extends D
 
   @Override
   public long size() {
-    return buffer.size() / layout.scale();
+    return size;
   }
 
   @Override
@@ -51,6 +51,7 @@ abstract class AbstractDataBufferAdapter<S extends DataBuffer<?>, T, U extends D
   AbstractDataBufferAdapter(S buffer, DataLayout<S, T> layout) {
     this.buffer = buffer;
     this.layout = layout;
+    size = buffer.size() / layout.scale();
   }
 
   DataLayout<S, T> layout() {
@@ -63,4 +64,5 @@ abstract class AbstractDataBufferAdapter<S extends DataBuffer<?>, T, U extends D
 
   private final S buffer;
   private final DataLayout<S, T> layout;
+  private final long size;
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/AbstractRawDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/AbstractRawDataBuffer.java
@@ -18,6 +18,7 @@
 package org.tensorflow.tools.buffer.impl.raw;
 
 import org.tensorflow.tools.buffer.DataBuffer;
+import org.tensorflow.tools.buffer.DataBufferWindow;
 import org.tensorflow.tools.buffer.impl.AbstractDataBuffer;
 import org.tensorflow.tools.buffer.impl.Validator;
 
@@ -73,6 +74,12 @@ abstract class AbstractRawDataBuffer<T, B extends DataBuffer<T>> extends Abstrac
   public B slice(long index, long size) {
     Validator.sliceArgs(this, index, size);
     return instantiate(memory.slice(index, size));
+  }
+
+  @Override
+  public DataBufferWindow<B> window(long size) {
+    B windowBuffer = instantiate(memory.slice(0, size));
+    return new RawDataBufferWindow<>((AbstractRawDataBuffer<?, B>)windowBuffer, size());
   }
 
   protected final UnsafeMemoryHandle memory;

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/ByteRawDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/ByteRawDataBuffer.java
@@ -73,7 +73,7 @@ final class ByteRawDataBuffer extends AbstractRawDataBuffer<Byte, ByteDataBuffer
       @Override
       public ByteDataBuffer visit(ByteBuffer buffer) {
         if (buffer.hasArray()) {
-          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.capacity()), size);
+          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.limit()), size);
         } else if (memory.isArray()) {
           buffer.put(memory.toArrayByteBuffer());
         } else {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/DoubleRawDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/DoubleRawDataBuffer.java
@@ -67,7 +67,7 @@ final class DoubleRawDataBuffer extends AbstractRawDataBuffer<Double, DoubleData
       @Override
       public DoubleDataBuffer visit(DoubleBuffer buffer) {
         if (buffer.hasArray()) {
-          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.capacity()), size);
+          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.limit()), size);
         } else if (memory.isArray()) {
           buffer.put(memory.toArrayDoubleBuffer());
         } else {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/FloatRawDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/FloatRawDataBuffer.java
@@ -18,6 +18,7 @@
 package org.tensorflow.tools.buffer.impl.raw;
 
 import java.nio.FloatBuffer;
+
 import org.tensorflow.tools.buffer.DataBuffer;
 import org.tensorflow.tools.buffer.DataStorageVisitor;
 import org.tensorflow.tools.buffer.FloatDataBuffer;
@@ -67,7 +68,7 @@ final class FloatRawDataBuffer extends AbstractRawDataBuffer<Float, FloatDataBuf
       @Override
       public FloatDataBuffer visit(FloatBuffer buffer) {
         if (buffer.hasArray()) {
-          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.capacity()), size);
+          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.limit()), size);
         } else if (memory.isArray()) {
           buffer.put(memory.toArrayFloatBuffer());
         } else {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/IntRawDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/IntRawDataBuffer.java
@@ -67,7 +67,7 @@ final class IntRawDataBuffer extends AbstractRawDataBuffer<Integer, IntDataBuffe
       @Override
       public IntDataBuffer visit(IntBuffer buffer) {
         if (buffer.hasArray()) {
-          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.capacity()), size);
+          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.limit()), size);
         } else if (memory.isArray()) {
           buffer.put(memory.toArrayIntBuffer());
         } else {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/LongRawDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/LongRawDataBuffer.java
@@ -67,7 +67,7 @@ final class LongRawDataBuffer extends AbstractRawDataBuffer<Long, LongDataBuffer
       @Override
       public LongDataBuffer visit(LongBuffer buffer) {
         if (buffer.hasArray()) {
-          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.capacity()), size);
+          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.limit()), size);
         } else if (memory.isArray()) {
           buffer.put(memory.toArrayLongBuffer());
         } else {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/RawDataBufferWindow.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/RawDataBufferWindow.java
@@ -1,0 +1,19 @@
+package org.tensorflow.tools.buffer.impl.raw;
+
+import org.tensorflow.tools.buffer.DataBuffer;
+import org.tensorflow.tools.buffer.impl.AbstractDataBufferWindow;
+
+final class RawDataBufferWindow<B extends DataBuffer<?>> extends AbstractDataBufferWindow<B> {
+
+  @Override
+  public void offset(long offset) {
+    windowMemory.rebase(offset);
+  }
+
+  <R extends AbstractRawDataBuffer<?, B>> RawDataBufferWindow(R windowBuffer, long bufferLimit) {
+    super((B)windowBuffer, bufferLimit);
+    this.windowMemory = windowBuffer.memory;
+  }
+
+  private final UnsafeMemoryHandle windowMemory;
+}

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/ShortRawDataBuffer.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/buffer/impl/raw/ShortRawDataBuffer.java
@@ -67,7 +67,7 @@ final class ShortRawDataBuffer extends AbstractRawDataBuffer<Short, ShortDataBuf
       @Override
       public ShortDataBuffer visit(ShortBuffer buffer) {
         if (buffer.hasArray()) {
-          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.capacity()), size);
+          memory.copyTo(UnsafeMemoryHandle.fromArray(buffer.array(), buffer.position(), buffer.limit()), size);
         } else if (memory.isArray()) {
           buffer.put(memory.toArrayShortBuffer());
         } else {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/NdArray.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/NdArray.java
@@ -81,19 +81,19 @@ public interface NdArray<T> {
   }
 
   /**
-   * Visit all elements of a given dimension.
+   * Returns a sequence of all elements at a given dimension.
    *
    * <p>Logically, the N-dimensional array can be flatten in a single vector, where the scalars of
    * the {@code (n - 1)}th element precedes those of the {@code (n)}th element, for a total of
    * {@link #size()} values.
    *
-   * <p>For example, given a {@code n x m} matrix on the {@code [x, y]} axes, values are iterated in
+   * <p>For example, given a {@code n x m} matrix on the {@code [x, y]} axes, elements are iterated in
    * the following order:
    * <pre>
    * x<sub>0</sub>y<sub>0</sub>, x<sub>0</sub>y<sub>1</sub>, ..., x<sub>0</sub>y<sub>m-1</sub>, x<sub>1</sub>y<sub>0</sub>, x<sub>1</sub>y<sub>1</sub>, ..., x<sub>n-1</sub>y<sub>m-1</sub>
    * </pre>
    *
-   * <p>The returned cursor is used to visit each elements, either by calling
+   * <p>The returned sequence can then be iterated to visit each elements, either by calling
    * {@link NdArraySequence#forEach(Consumer)} or {@link NdArraySequence#forEachIndexed(BiConsumer)}.
    * <pre>{@code
    *    // Iterate matrix for initializing each of its vectors
@@ -107,16 +107,16 @@ public interface NdArray<T> {
    *    });
    * }</pre>
    *
-   * @return a new cursor to visit all elements at the requested dimension
+   * @return an {@code NdArray} sequence
    */
   NdArraySequence<? extends NdArray<T>> elements(int dimensionIdx);
 
   /**
-   * Visit all scalars of this array.
+   * Returns a sequence of all scalars in this array.
    *
    * <p>This is equivalent to call {@code elements(shape().numDimensions() - 1)}
    *
-   * @return a new cursor to visit all scalars of this array
+   * @return an {@code NdArray} sequence
    */
   NdArraySequence<? extends NdArray<T>> scalars();
 

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/NdArraySequence.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/NdArraySequence.java
@@ -47,10 +47,10 @@ public interface NdArraySequence<T extends NdArray<?>> extends Iterable<T> {
    * Returns each element as a new slice.
    *
    * <p>Unlike conventional Java collections, elements of a {@code NdArraySequence} are transient, i.e. new {@code NdArray}
-   * instances are allocated for each iteration. To improve performances, the same instance can be recycled to view
+   * instances are allocated for each iteration. To improve performance, the same instance can be recycled to view
    * all elements of this sequence, using a {@link org.tensorflow.tools.buffer.DataBufferWindow}.
    *
-   * <p>In some cases though, it might be preferable to disable such optimization to ensure that each elements returned is a
+   * <p>In some cases though, it might be preferable to disable such optimizations to ensure that each element returned is a
    * new slice of the original array. For example, if one or more elements visited must live beyond the scope of the sequence
    * iteration, {@code asSlices()} makes sure that all elements returned by the sequence are unique instances.
    *

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/AbstractNdArray.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/AbstractNdArray.java
@@ -21,7 +21,6 @@ import org.tensorflow.tools.Shape;
 import org.tensorflow.tools.ndarray.NdArray;
 import org.tensorflow.tools.ndarray.NdArraySequence;
 import org.tensorflow.tools.ndarray.impl.dimension.DimensionalSpace;
-import org.tensorflow.tools.ndarray.impl.sequence.ElementSequence;
 
 @SuppressWarnings("unchecked")
 public abstract class AbstractNdArray<T, U extends NdArray<T>> implements NdArray<T> {
@@ -38,17 +37,9 @@ public abstract class AbstractNdArray<T, U extends NdArray<T>> implements NdArra
   }
 
   @Override
-  public NdArraySequence<U> elements(int dimensionIdx) {
-    if (dimensionIdx >= shape().numDimensions()) {
-      throw new IllegalArgumentException("Cannot iterate elements in dimension '" + dimensionIdx +
-          "' of array with shape " + shape());
-    }
-    return ElementSequence.create(this, dimensionIdx);
-  }
-
-  @Override
   public NdArraySequence<U> scalars() {
-    return ElementSequence.create(this, shape().numDimensions() - 1);  // negative if this array is a scalar
+    // negative if this array is a scalar, should be handled in `elements(dimIdx)`
+    return (NdArraySequence<U>)elements(shape().numDimensions() - 1);
   }
 
   @Override
@@ -97,5 +88,5 @@ public abstract class AbstractNdArray<T, U extends NdArray<T>> implements NdArra
     return true;
   }
 
-  private DimensionalSpace dimensions;
+  protected final DimensionalSpace dimensions;
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/dense/AbstractDenseNdArray.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/dense/AbstractDenseNdArray.java
@@ -136,7 +136,7 @@ public abstract class AbstractDenseNdArray<T, U extends NdArray<T>> extends Abst
     super(dimensions);
   }
 
-  abstract protected <P> DataBuffer<T> buffer();
+  abstract protected DataBuffer<T> buffer();
 
   abstract U instantiate(DataBuffer<T> buffer, DimensionalSpace dimensions);
 

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/dense/AbstractDenseNdArray.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/dense/AbstractDenseNdArray.java
@@ -17,15 +17,37 @@
 package org.tensorflow.tools.ndarray.impl.dense;
 
 import org.tensorflow.tools.buffer.DataBuffer;
-import org.tensorflow.tools.ndarray.IllegalRankException;
+import org.tensorflow.tools.buffer.DataBufferWindow;
 import org.tensorflow.tools.ndarray.NdArray;
+import org.tensorflow.tools.ndarray.NdArraySequence;
 import org.tensorflow.tools.ndarray.impl.AbstractNdArray;
 import org.tensorflow.tools.ndarray.impl.dimension.DimensionalSpace;
 import org.tensorflow.tools.ndarray.impl.dimension.RelativeDimensionalSpace;
+import org.tensorflow.tools.ndarray.impl.sequence.SlicingElementSequence;
+import org.tensorflow.tools.ndarray.impl.sequence.SingleElementSequence;
+import org.tensorflow.tools.ndarray.impl.sequence.FastElementSequence;
 import org.tensorflow.tools.ndarray.index.Index;
 
 @SuppressWarnings("unchecked")
 public abstract class AbstractDenseNdArray<T, U extends NdArray<T>> extends AbstractNdArray<T, U> {
+
+  @Override
+  public NdArraySequence<U> elements(int dimensionIdx) {
+    if (dimensionIdx >= shape().numDimensions()) {
+      throw new IllegalArgumentException("Cannot iterate elements in dimension '" + dimensionIdx +
+          "' of array with shape " + shape());
+    }
+    if (rank() == 0 && dimensionIdx < 0) {
+      return new SingleElementSequence<>(this);
+    }
+    DimensionalSpace elemDims = dimensions().from(dimensionIdx + 1);
+    DataBufferWindow<? extends DataBuffer<T>> elemWindow = buffer().window(elemDims.physicalSize());
+    if (elemWindow != null) {
+      U element = instantiate(elemWindow.buffer(), elemDims);
+      return new FastElementSequence(this, dimensionIdx, element, elemWindow);
+    }
+    return new SlicingElementSequence<>(this, dimensionIdx, elemDims);
+  }
 
   @Override
   public U slice(long position, DimensionalSpace sliceDimensions) {
@@ -112,7 +134,7 @@ public abstract class AbstractDenseNdArray<T, U extends NdArray<T>> extends Abst
     super(dimensions);
   }
 
-  abstract protected DataBuffer<T> buffer();
+  abstract protected <P> DataBuffer<T> buffer();
 
   abstract U instantiate(DataBuffer<T> buffer, DimensionalSpace dimensions);
 
@@ -120,13 +142,8 @@ public abstract class AbstractDenseNdArray<T, U extends NdArray<T>> extends Abst
     if (coords == null || coords.length == 0) {
       return 0;
     }
-    if (coords.length > dimensions().numDimensions()) {
-      throw new IndexOutOfBoundsException();
-    }
-    if (isValue && coords.length != dimensions().numDimensions()) {
-      throw new IllegalRankException("Not a scalar value");
-    }
-    return dimensions().positionOf(coords);
+    Validator.coordinates(dimensions, coords, isValue);
+    return dimensions.positionOf(coords);
   }
 
   @Override

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/dense/AbstractDenseNdArray.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/dense/AbstractDenseNdArray.java
@@ -41,12 +41,14 @@ public abstract class AbstractDenseNdArray<T, U extends NdArray<T>> extends Abst
       return new SingleElementSequence<>(this);
     }
     DimensionalSpace elemDims = dimensions().from(dimensionIdx + 1);
-    DataBufferWindow<? extends DataBuffer<T>> elemWindow = buffer().window(elemDims.physicalSize());
-    if (elemWindow != null) {
+    try {
+      DataBufferWindow<? extends DataBuffer<T>> elemWindow = buffer().window(elemDims.physicalSize());
       U element = instantiate(elemWindow.buffer(), elemDims);
       return new FastElementSequence(this, dimensionIdx, element, elemWindow);
+    } catch (UnsupportedOperationException e) {
+      // If buffer windows are not supported, fallback to slicing (and slower) sequence
+      return new SlicingElementSequence<>(this, dimensionIdx, elemDims);
     }
-    return new SlicingElementSequence<>(this, dimensionIdx, elemDims);
   }
 
   @Override

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/dense/Validator.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/dense/Validator.java
@@ -18,8 +18,20 @@ package org.tensorflow.tools.ndarray.impl.dense;
 
 import org.tensorflow.tools.Shape;
 import org.tensorflow.tools.buffer.DataBuffer;
+import org.tensorflow.tools.ndarray.IllegalRankException;
+import org.tensorflow.tools.ndarray.impl.dimension.DimensionalSpace;
 
 final class Validator extends org.tensorflow.tools.ndarray.impl.Validator {
+
+  static void coordinates(DimensionalSpace dimensions, long[] coords,
+      boolean isValue) {
+    if (coords.length > dimensions.numDimensions()) {
+      throw new IndexOutOfBoundsException();
+    }
+    if (isValue && coords.length != dimensions.numDimensions()) {
+      throw new IllegalRankException("Not a scalar value");
+    }
+  }
 
   static void denseShape(DataBuffer<?> buffer, Shape shape) {
     if (shape == null) {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/CoordinatesIncrementor.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/CoordinatesIncrementor.java
@@ -17,35 +17,26 @@
 
 package org.tensorflow.tools.ndarray.impl.sequence;
 
+import java.util.NoSuchElementException;
+
 import org.tensorflow.tools.ndarray.impl.dimension.DimensionalSpace;
 
-class IndexedSequentialPositionIterator extends SequentialPositionIterator implements IndexedPositionIterator {
+final class CoordinatesIncrementor {
 
-  @Override
-  public void forEachIndexed(CoordsLongConsumer consumer) {
-    while (hasNext()) {
-      consumer.consume(coords, nextLong());
-      incrementCoords();
-    }
-  }
-
-  private void incrementCoords() {
+  boolean increment() {
     for (int i = coords.length - 1; i >= 0; --i) {
-      if (coords[i] < shape[i] - 1) {
-        coords[i] += 1L;
-        return;
+      if ((coords[i] = (coords[i] + 1) % shape[i]) > 0) {
+        return true;
       }
-      coords[i] = 0L;
     }
+    return false;
   }
 
-  IndexedSequentialPositionIterator(DimensionalSpace dimensions, int dimensionIdx) {
-    super(dimensions, dimensionIdx);
-    this.shape = dimensions.shape().asArray();
+  CoordinatesIncrementor(long[] shape, int dimensionIdx) {
+    this.shape = shape;
     this.coords = new long[dimensionIdx + 1];
-    //this.coordsIncrementor = new CoordinatesIncrementor(dimensions.shape().asArray(), dimensionIdx);
   }
 
-  private final long[] shape;
-  private final long[] coords;
+  final long[] shape;
+  final long[] coords;
 }

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/CoordinatesIncrementor.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/CoordinatesIncrementor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2020 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
  */
 
 package org.tensorflow.tools.ndarray.impl.sequence;
-
-import java.util.NoSuchElementException;
-
-import org.tensorflow.tools.ndarray.impl.dimension.DimensionalSpace;
 
 final class CoordinatesIncrementor {
 

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/FastElementSequence.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/FastElementSequence.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2020 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ import org.tensorflow.tools.ndarray.NdArray;
 import org.tensorflow.tools.ndarray.NdArraySequence;
 import org.tensorflow.tools.ndarray.impl.AbstractNdArray;
 
+/**
+ * A sequence recycling the same {@code NdArray} instance when iterating its elements
+ *
+ * @param <T> Type of the elements
+ * @param <U> Type of the {@code NdArray} with this sequence
+ */
 public final class FastElementSequence<T, U extends NdArray<T>> implements NdArraySequence<U> {
 
   public FastElementSequence(AbstractNdArray<T, U> ndArray, int dimensionIdx, U element, DataBufferWindow<?> elementWindow) {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/SingleElementSequence.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/SingleElementSequence.java
@@ -24,6 +24,12 @@ import org.tensorflow.tools.ndarray.NdArray;
 import org.tensorflow.tools.ndarray.NdArraySequence;
 import org.tensorflow.tools.ndarray.impl.AbstractNdArray;
 
+/**
+ * A sequence of one single element
+ *
+ * @param <T> Type of the element
+ * @param <U> Type of the {@code NdArray} with this sequence
+ */
 public final class SingleElementSequence<T, U extends NdArray<T>> implements NdArraySequence<U> {
 
   public SingleElementSequence(AbstractNdArray<T, U> ndArray) {

--- a/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/SlicingElementSequence.java
+++ b/tensorflow-tools/src/main/java/org/tensorflow/tools/ndarray/impl/sequence/SlicingElementSequence.java
@@ -24,6 +24,12 @@ import org.tensorflow.tools.ndarray.NdArraySequence;
 import org.tensorflow.tools.ndarray.impl.AbstractNdArray;
 import org.tensorflow.tools.ndarray.impl.dimension.DimensionalSpace;
 
+/**
+ * A sequence creating a new {@code NdArray} instance (slice) for each element of an iteration
+ *
+ * @param <T> Type of the element
+ * @param <U> Type of the {@code NdArray} with this sequence
+ */
 public final class SlicingElementSequence<T, U extends NdArray<T>> implements NdArraySequence<U> {
 
   public SlicingElementSequence(AbstractNdArray<T, U> ndArray, int dimensionIdx) {

--- a/tensorflow-tools/src/test/java/org/tensorflow/tools/benchmark/NdArrayBenchmark.java
+++ b/tensorflow-tools/src/test/java/org/tensorflow/tools/benchmark/NdArrayBenchmark.java
@@ -18,6 +18,7 @@ package org.tensorflow.tools.benchmark;
 
 import static org.tensorflow.tools.ndarray.index.Indices.all;
 import static org.tensorflow.tools.ndarray.index.Indices.at;
+import static org.tensorflow.tools.ndarray.index.Indices.odd;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.Raster;
@@ -38,7 +39,7 @@ import org.tensorflow.tools.ndarray.FloatNdArray;
 import org.tensorflow.tools.ndarray.NdArrays;
 import org.tensorflow.tools.ndarray.StdArrays;
 
-@Fork(value = 1, jvmArgs = {"-Xms4G", "-Xmx4G"})
+@Fork(value = 0, jvmArgs = {"-Xms4G", "-Xmx4G"})
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
@@ -83,8 +84,24 @@ public class NdArrayBenchmark {
 	}
 
 	@Benchmark
-	public void iteratingAllPixels() {
-		pixels.elements(0).forEach(pixel -> {});
+	public void readingAllPixelsChannelsBySequence() {
+		pixels.scalars().forEach(pixel -> pixel.getFloat());
+	}
+
+	@Benchmark
+	public void readingAllPixelsChannelsBySequenceSlices() {
+		pixels.scalars().asSlices().forEach(pixel -> pixel.getFloat());
+	}
+
+	@Benchmark
+	@Measurement(batchSize = 100)
+	public void readingAllPixelsChannelsByIndex() {
+		long[] shape = pixels.shape().asArray();
+		for (int i = 0; i < shape[0]; ++i) {
+			for (int j = 0; j < shape[1]; ++j) {
+				pixels.getFloat(i, j);
+			}
+		}
 	}
 
 	@Benchmark

--- a/tensorflow-tools/src/test/java/org/tensorflow/tools/buffer/DataBufferTestBase.java
+++ b/tensorflow-tools/src/test/java/org/tensorflow/tools/buffer/DataBufferTestBase.java
@@ -246,13 +246,13 @@ public abstract class DataBufferTestBase<T> {
     assertEquals(valueOf(2L), bufferWindow.buffer().getObject(2));
     DataBuffer<T> windowBuffer = bufferWindow.buffer();
 
-    bufferWindow.slideOf(10);
+    bufferWindow.slide(10);
     assertEquals(10, bufferWindow.offset());
     assertEquals(4, bufferWindow.size());
     assertEquals(valueOf(12L), bufferWindow.buffer().getObject(2));
     assertSame(windowBuffer, bufferWindow.buffer());
 
-    bufferWindow.slideOf(-2);
+    bufferWindow.slide(-2);
     assertEquals(8, bufferWindow.offset());
     assertEquals(4, bufferWindow.size());
     assertEquals(valueOf(10L), bufferWindow.buffer().getObject(2));
@@ -263,13 +263,13 @@ public abstract class DataBufferTestBase<T> {
     assertEquals(valueOf(18L), bufferWindow.buffer().getObject(2));
 
     try {
-      bufferWindow.slideOf(1);
+      bufferWindow.slide(1);
       fail();
     } catch (IndexOutOfBoundsException e) {
       // as expected
     }
     try {
-      bufferWindow.slideOf(-17);
+      bufferWindow.slide(-17);
       fail();
     } catch (IndexOutOfBoundsException e) {
       // as expected

--- a/tensorflow-tools/src/test/java/org/tensorflow/tools/buffer/DataBufferTestBase.java
+++ b/tensorflow-tools/src/test/java/org/tensorflow/tools/buffer/DataBufferTestBase.java
@@ -230,8 +230,10 @@ public abstract class DataBufferTestBase<T> {
   @Test
   public void bufferWindow() {
     DataBuffer<T> buffer = allocate(20);
-    DataBufferWindow<? extends DataBuffer<T>> bufferWindow = buffer.window(4);
-    if (bufferWindow == null) {
+    DataBufferWindow<? extends DataBuffer<T>> bufferWindow;
+    try {
+      bufferWindow = buffer.window(4);
+    } catch (UnsupportedOperationException e) {
       return;  // skip test if this buffer does not support windows
     }
     assertEquals(0, bufferWindow.offset());

--- a/tensorflow-tools/src/test/java/org/tensorflow/tools/ndarray/impl/sequence/ElementSequenceTest.java
+++ b/tensorflow-tools/src/test/java/org/tensorflow/tools/ndarray/impl/sequence/ElementSequenceTest.java
@@ -40,8 +40,8 @@ public class ElementSequenceTest {
   public void iterateVectorsWithIndex() {
     IntNdArray array = NdArrays.ofInts(Shape.of(2, 3, 2));
 
-    @SuppressWarnings("unchecked")
-    NdArraySequence<IntNdArray> sequence = new SlicingElementSequence((AbstractNdArray<Integer, IntNdArray>)array, 1);
+    NdArraySequence<IntNdArray> sequence = new SlicingElementSequence(
+        (AbstractNdArray<Integer, IntNdArray>)array, 1);
     List<long[]> coords = new ArrayList<>((int)array.shape().size());
     sequence.forEachIndexed((c, e) -> coords.add(Arrays.copyOf(c, c.length)));
 
@@ -58,8 +58,8 @@ public class ElementSequenceTest {
   public void iterateScalarsWithIndex() {
     IntNdArray array = NdArrays.ofInts(Shape.of(2, 3, 2));
 
-    @SuppressWarnings("unchecked")
-    NdArraySequence<IntNdArray> cursor = new SlicingElementSequence((AbstractNdArray<Integer, IntNdArray>)array, 2);
+    NdArraySequence<IntNdArray> cursor = new SlicingElementSequence(
+        (AbstractNdArray<Integer, IntNdArray>)array, 2);
     List<long[]> coords = new ArrayList<>((int)array.shape().size());
     cursor.forEachIndexed((c, e) -> coords.add(Arrays.copyOf(c, c.length)));
 
@@ -81,7 +81,6 @@ public class ElementSequenceTest {
   @Test
   public void slicingElementSequenceReturnsUniqueInstances() {
     IntNdArray array = NdArrays.ofInts(Shape.of(2, 3, 2));
-    @SuppressWarnings("unchecked")
     NdArraySequence<IntNdArray> sequence = new SlicingElementSequence(
         (AbstractNdArray<Integer, IntNdArray>) array, 1);
     List<IntNdArray> elements = new ArrayList<>();
@@ -99,7 +98,6 @@ public class ElementSequenceTest {
   public void fastElementSequenceReturnsSameInstance() {
     IntNdArray array = NdArrays.ofInts(Shape.of(2, 3, 2));
     IntNdArray element = array.get(0);
-    @SuppressWarnings("unchecked")
     NdArraySequence<IntNdArray> sequence = new FastElementSequence(
         (AbstractNdArray<Integer, IntNdArray>) array, 1, element, mockDataBufferWindow(2));
     sequence.forEach(e -> {
@@ -129,7 +127,7 @@ public class ElementSequenceTest {
       }
 
       @Override
-      public DataBufferWindow<IntDataBuffer> slideOf(long step) {
+      public DataBufferWindow<IntDataBuffer> slide(long step) {
         offset += step;
         return this;
       }

--- a/tensorflow-tools/src/test/java/org/tensorflow/tools/ndarray/impl/sequence/ElementSequenceTest.java
+++ b/tensorflow-tools/src/test/java/org/tensorflow/tools/ndarray/impl/sequence/ElementSequenceTest.java
@@ -19,12 +19,16 @@ package org.tensorflow.tools.ndarray.impl.sequence;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.tensorflow.tools.Shape;
+import org.tensorflow.tools.buffer.DataBufferWindow;
+import org.tensorflow.tools.buffer.DataBuffers;
+import org.tensorflow.tools.buffer.IntDataBuffer;
 import org.tensorflow.tools.ndarray.IntNdArray;
 import org.tensorflow.tools.ndarray.NdArraySequence;
 import org.tensorflow.tools.ndarray.NdArrays;
@@ -37,8 +41,7 @@ public class ElementSequenceTest {
     IntNdArray array = NdArrays.ofInts(Shape.of(2, 3, 2));
 
     @SuppressWarnings("unchecked")
-    NdArraySequence<IntNdArray> sequence = ElementSequence
-        .create((AbstractNdArray<Integer, IntNdArray>)array, 1);
+    NdArraySequence<IntNdArray> sequence = new SlicingElementSequence((AbstractNdArray<Integer, IntNdArray>)array, 1);
     List<long[]> coords = new ArrayList<>((int)array.shape().size());
     sequence.forEachIndexed((c, e) -> coords.add(Arrays.copyOf(c, c.length)));
 
@@ -56,7 +59,7 @@ public class ElementSequenceTest {
     IntNdArray array = NdArrays.ofInts(Shape.of(2, 3, 2));
 
     @SuppressWarnings("unchecked")
-    NdArraySequence<IntNdArray> cursor = ElementSequence.create((AbstractNdArray<Integer, IntNdArray>)array, 2);
+    NdArraySequence<IntNdArray> cursor = new SlicingElementSequence((AbstractNdArray<Integer, IntNdArray>)array, 2);
     List<long[]> coords = new ArrayList<>((int)array.shape().size());
     cursor.forEachIndexed((c, e) -> coords.add(Arrays.copyOf(c, c.length)));
 
@@ -73,5 +76,72 @@ public class ElementSequenceTest {
     assertArrayEquals(new long[] {1, 1, 1}, coords.get(9));
     assertArrayEquals(new long[] {1, 2, 0}, coords.get(10));
     assertArrayEquals(new long[] {1, 2, 1}, coords.get(11));
+  }
+
+  @Test
+  public void slicingElementSequenceReturnsUniqueInstances() {
+    IntNdArray array = NdArrays.ofInts(Shape.of(2, 3, 2));
+    @SuppressWarnings("unchecked")
+    NdArraySequence<IntNdArray> sequence = new SlicingElementSequence(
+        (AbstractNdArray<Integer, IntNdArray>) array, 1);
+    List<IntNdArray> elements = new ArrayList<>();
+    sequence.forEach(e -> {
+      elements.forEach(tmp -> {
+        if (tmp == e) {
+          fail();
+        }
+      });
+      elements.add(e);
+    });
+  }
+
+  @Test
+  public void fastElementSequenceReturnsSameInstance() {
+    IntNdArray array = NdArrays.ofInts(Shape.of(2, 3, 2));
+    IntNdArray element = array.get(0);
+    @SuppressWarnings("unchecked")
+    NdArraySequence<IntNdArray> sequence = new FastElementSequence(
+        (AbstractNdArray<Integer, IntNdArray>) array, 1, element, mockDataBufferWindow(2));
+    sequence.forEach(e -> {
+      if (e != element) {
+        fail();
+      }
+    });
+  }
+
+  private DataBufferWindow<IntDataBuffer> mockDataBufferWindow(long size) {
+    return new DataBufferWindow<IntDataBuffer>() {
+
+      @Override
+      public long offset() {
+        return offset;
+      }
+
+      @Override
+      public long size() {
+        return size;
+      }
+
+      @Override
+      public DataBufferWindow<IntDataBuffer> slideTo(long index) {
+        offset = index;
+        return this;
+      }
+
+      @Override
+      public DataBufferWindow<IntDataBuffer> slideOf(long step) {
+        offset += step;
+        return this;
+      }
+
+      @Override
+      public IntDataBuffer buffer() {
+        return buffer;
+      }
+
+      private long offset;
+      private final long size = 2;
+      private final IntDataBuffer buffer = DataBuffers.ofInts(2);
+    };
   }
 }


### PR DESCRIPTION
The main addition of this PR is the creation on a `DataBufferWindow` interface, that allows a user to view partially the content of a given buffer and to move (or "slide") it across the memory segment so that the same window instance can reused to present different chunk of data.

This is particularly useful when visiting all values (or elements of a given dimension) of a `NdArray` in a given sequence (e.g. `ndArray.elements(0)` or `ndArray.scalars()`) and performance gains are substantial for large tensors (in the order of 5x faster).
