### PR TITLE
Add ShapeOps Enhancement to work with org.tensorflow.op.core.Shape

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/ShapeOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/ShapeOps.java
@@ -1,8 +1,17 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 package org.tensorflow.op.core;
 
 import java.util.Arrays;
@@ -38,7 +47,7 @@ import org.tensorflow.types.family.TType;
 public abstract class ShapeOps {
 
     /**
-     * flatten the shape to 1 dimension
+     * Flatten the operand to 1 dimension
      *
      * @param <T> the type of operand
      * @param scope current scope
@@ -51,7 +60,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * flatten the shape to 1 dimension
+     * Flatten the operand to 1 dimension
      *
      * @param <T> the type of operand
      * @param <U> the shape datatype.
@@ -67,12 +76,11 @@ public abstract class ShapeOps {
     }
 
     /**
-     * flatten the shape to 1 dimension
+     * Flatten the shape to 1 dimension
      *
      * @param scope current scope
      * @param shape the TensorFlow shape
      * @return the flattened shape
-     * @see reduceDims
      */
     @Endpoint(name = "flatten")
     public static Operand<TInt32> flatten(Scope scope, Shape<TInt32> shape) {
@@ -80,14 +88,13 @@ public abstract class ShapeOps {
     }
 
     /**
-     * flatten the shape to 1 dimension
+     * Flatten the shape to 1 dimension
      *
      * @param <U> the shape datatype.
      * @param scope current scope
      * @param shape the TensorFlow shape
      * @param dType the shape datatype.
      * @return the flattened shape
-     * @see reduceDims
      */
     @Endpoint(name = "flatten")
     public static <U extends TNumber> Operand<U> flatten(Scope scope, Shape<U> shape, DataType<U> dType) {
@@ -97,7 +104,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * get the size represented by the TensorFlow shape
+     * Get the size represented by the TensorFlow shape
      *
      * @param scope current scope
      * @param shape the TensorFlow shape
@@ -109,7 +116,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * get the size represented by the TensorFlow shape
+     * Get the size represented by the TensorFlow shape
      *
      * @param <U> the shape datatype. the type of the shape
      * @param scope current scope
@@ -120,12 +127,20 @@ public abstract class ShapeOps {
     @Endpoint(name = "size")
     public static <U extends TNumber> Operand<U> size(Scope scope, Shape<U> shape, DataType<U> dType) {
         Slice<U> dims = Slice.create(scope, shape,
-                Cast.create(scope, Constant.arrayOf(scope, (new int[]{0})), dType),
+                Cast.create(scope, Constant.arrayOf(scope, new int[]{0}), dType),
                 ExpandDims.create(scope, Cast.create(scope, Constant.scalarOf(scope, -1), dType), Constant.scalarOf(scope, -1)));
         ReduceProd<U> total = ReduceProd.create(scope, dims, Constant.scalarOf(scope, 0));
         return total;
     }
 
+    /**
+     * Get the size of the specified dimension in the shape
+     *
+     * @param scope current scope
+     * @param shape the TensorFlow shape
+     * @param dim the dimension
+     * @return the size of the specified dimension
+     */
     @Endpoint(name = "size")
     public static Operand<TInt32> size(Scope scope, Shape<TInt32> shape, Operand<TInt32> dim) {
         return size(scope, shape, dim, TInt32.DTYPE);
@@ -133,7 +148,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * get the size of the specified dimension in the shape
+     * Get the size of the specified dimension in the shape
      *
      * @param <U> the shape datatype.
      * @param scope current scope
@@ -153,7 +168,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * get the size of the specified dimension for the shape of the tensor
+     * Get the size of the specified dimension for the shape of the tensor
      *
      * @param scope current scope
      * @param input the operand
@@ -166,7 +181,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * get the size of the specified dimension for the shape of the tensor
+     * Get the size of the specified dimension for the shape of the tensor
      *
      * @param <U> the shape datatype.
      * @param scope current scope
@@ -182,12 +197,11 @@ public abstract class ShapeOps {
     }
 
     /**
-     * get the number of dimensions of the shape object
+     * Get the number of dimensions of the shape object
      *
      * @param scope current scope
      * @param shape the shape
      * @return the number of dimensions
-     * @see tf.rank
      */
     @Endpoint(name = "numDimensions")
     public static Operand<TInt32> numDimensions(Scope scope, Shape<TInt32> shape) {
@@ -195,14 +209,13 @@ public abstract class ShapeOps {
     }
 
     /**
-     * get the number of dimensions of the shape object
+     * Get the number of dimensions of the shape object
      *
      * @param <U> the shape datatype.
      * @param scope the curren scope
      * @param shape the shape
      * @param dType the shape datatype.
      * @return the number of dimensions
-     * @see tf.rank
      */
     @Endpoint(name = "numDimensions")
     public static <U extends TNumber> Operand<U> numDimensions(Scope scope,
@@ -211,7 +224,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * reshapes the operand to the specified axis,
+     * Reshapes the operand to the specified axis,
      *
      * @param <T> the type of Operand
      * @param scope current scope
@@ -226,7 +239,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * reshapes the operand to the specified axis,
+     * Reshapes the operand to the specified axis,
      *
      * @param <T> the type of Operand
      * @param <U> the shape datatype.
@@ -244,7 +257,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * reduces the shape to the specified axis,
+     * Reduces the shape to the specified axis,
      *
      * @param scope current scope
      * @param shape the TensorFlow shape
@@ -258,7 +271,7 @@ public abstract class ShapeOps {
     }
 
     /**
-     * reduces the shape to the specified axis,
+     * Reduces the shape to the specified axis,
      *
      * @param <U> the shape datatype.
      * @param scope current scope
@@ -275,7 +288,7 @@ public abstract class ShapeOps {
         Sub<U> remainder = Sub.create(scope, rank, axis);
 
         Operand<U> dims1 = Slice.create(scope, shape,
-                Cast.create(scope, Constant.arrayOf(scope, (new int[]{0})), dType),
+                Cast.create(scope, Constant.arrayOf(scope, new int[]{0}), dType),
                 ExpandDims.create(scope, axis, Constant.scalarOf(scope, -1)));
 
         Operand<U> dims2 = Slice.create(scope, shape,
@@ -296,7 +309,6 @@ public abstract class ShapeOps {
      * @param scope current scope
      * @param shape the TensorFlow shape
      * @return the squeezed shape
-     * @see tf.squeeze
      */
     @Endpoint(name = "squeeze")
     public static Operand<TInt32> squeeze(Scope scope, Shape<TInt32> shape) {
@@ -312,7 +324,6 @@ public abstract class ShapeOps {
      * @param dType the shape datatype.
      * @return the squeezed shape
      *
-     * @see tf.squeeze
      */
     @Endpoint(name = "squeeze")
     public static <U extends TNumber> Operand<U> squeeze(Scope scope,

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/ShapeOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/ShapeOps.java
@@ -3,12 +3,14 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package org.tensorflow.keras.utils;
+package org.tensorflow.op.core;
 
 import java.util.Arrays;
 import org.tensorflow.DataType;
 import org.tensorflow.Operand;
 import org.tensorflow.op.Scope;
+import org.tensorflow.op.annotation.Endpoint;
+import org.tensorflow.op.annotation.Operator;
 import org.tensorflow.op.core.Concat;
 import org.tensorflow.op.core.ExpandDims;
 import org.tensorflow.op.core.Reshape;
@@ -30,188 +32,298 @@ import org.tensorflow.types.family.TNumber;
 import org.tensorflow.types.family.TType;
 
 /**
- *
- * @author Jim Clarke
- * @param <T> the type of operand
+ * An operator working with org.tensorflow.op.core.Shape tensors
  */
+@Operator
+public abstract class ShapeOps {
 
-// TODO should shape be based on  TInt64  ???
-public class ShapeOps<U extends TNumber > {
-    private final Scope scope;
-    private final DataType<U> dType;
-    
-    /**
-     * Create a ShapeUtils with a DataType of TInt32
-     * 
-     * @param scope is a scope used to add the underlying operations
-     * @return the ShapeUtils
-     */
-    public static ShapeOps<TInt32> create(Scope scope) {
-        return create(scope, TInt32.DTYPE);
-    }
-    
-    /**
-     * 
-     * @param <U> the Shape type
-     * @param scope is a scope used to add the underlying operations
-     * @param dType the Shape datatype
-     * @return the ShapeUtils
-     */
-    public static <U extends TNumber> ShapeOps<U> create(Scope scope, DataType<U> dType) {
-        return new ShapeOps<>(scope, dType);
-    }
-    
-    /**
-     * The constructor for ShapeUtils
-     * @param scope is a scope used to add the underlying operations
-     * @param dType the Shape datatype
-     */
-    private ShapeOps(Scope scope,  DataType<U> dType) {
-        this.scope = scope;
-        this.dType = dType;
-    }
-    
-    public Scope scope() {
-        return this.scope;
-    }
-    
-    public  DataType<U> datatype() {
-        return this.dType;
-    }
-    
     /**
      * flatten the shape to 1 dimension
-     * 
+     *
      * @param <T> the type of operand
+     * @param scope current scope
      * @param operand the operand to flatten
      * @return the reshaped operand
      */
-    public <T extends TType> Operand<T> flatten(Operand<T> operand) {
-        Operand<U> flatShape =  flatten(Shape.create(scope, operand, dType)); 
-        return Reshape.create(scope, operand, flatShape);
+    @Endpoint(name = "flatten")
+    public static <T extends TType> Operand<T> flatten(Scope scope, Operand<T> operand) {
+        return flatten(scope, operand, TInt32.DTYPE);
     }
-    
+
     /**
      * flatten the shape to 1 dimension
-     * 
+     *
+     * @param <T> the type of operand
+     * @param <U> the shape datatype.
+     * @param scope current scope
+     * @param operand the operand to flatten
+     * @param dType the shape datatype.
+     * @return the reshaped operand
+     */
+    @Endpoint(name = "flatten")
+    public static <T extends TType, U extends TNumber> Operand<T> flatten(Scope scope, Operand<T> operand, DataType<U> dType) {
+        Operand<U> flatShape = flatten(scope, Shape.create(scope, operand, dType), dType);
+        return Reshape.create(scope, operand, flatShape);
+    }
+
+    /**
+     * flatten the shape to 1 dimension
+     *
+     * @param scope current scope
      * @param shape the TensorFlow shape
-     * @return  the flattened shape
+     * @return the flattened shape
      * @see reduceDims
      */
-    public Operand<U> flatten(Shape<U> shape) {
-        return ExpandDims.create(scope, 
-                        Cast.create(scope, size(shape), dType),
-                        Cast.create(scope, Constant.scalarOf(scope, -1), dType));
-        
+    @Endpoint(name = "flatten")
+    public static Operand<TInt32> flatten(Scope scope, Shape<TInt32> shape) {
+        return flatten(scope, shape, TInt32.DTYPE);
     }
-    
-    
-   /**
-    * get the size represented by the TensorFlow shape
-    * 
-    * @param shape the TensorFlow shape
-    * @return the size
-    */
-    public Operand<U> size(Shape<U> shape) {
-        Slice<U> dims = Slice.create(scope, shape, 
+
+    /**
+     * flatten the shape to 1 dimension
+     *
+     * @param <U> the shape datatype.
+     * @param scope current scope
+     * @param shape the TensorFlow shape
+     * @param dType the shape datatype.
+     * @return the flattened shape
+     * @see reduceDims
+     */
+    @Endpoint(name = "flatten")
+    public static <U extends TNumber> Operand<U> flatten(Scope scope, Shape<U> shape, DataType<U> dType) {
+        return ExpandDims.create(scope,
+                size(scope, shape, dType),
+                Cast.create(scope, Constant.scalarOf(scope, -1), TInt32.DTYPE));
+    }
+
+    /**
+     * get the size represented by the TensorFlow shape
+     *
+     * @param scope current scope
+     * @param shape the TensorFlow shape
+     * @return the size
+     */
+    @Endpoint(name = "size")
+    public static Operand<TInt32> size(Scope scope, Shape<TInt32> shape) {
+        return size(scope, shape, TInt32.DTYPE);
+    }
+
+    /**
+     * get the size represented by the TensorFlow shape
+     *
+     * @param <U> the shape datatype. the type of the shape
+     * @param scope current scope
+     * @param shape the TensorFlow shape
+     * @param dType the shape datatype.
+     * @return the size
+     */
+    @Endpoint(name = "size")
+    public static <U extends TNumber> Operand<U> size(Scope scope, Shape<U> shape, DataType<U> dType) {
+        Slice<U> dims = Slice.create(scope, shape,
                 Cast.create(scope, Constant.arrayOf(scope, (new int[]{0})), dType),
-                ExpandDims.create(scope, Cast.create(scope, Constant.scalarOf(scope, -1), dType),  Constant.scalarOf(scope, -1)));
+                ExpandDims.create(scope, Cast.create(scope, Constant.scalarOf(scope, -1), dType), Constant.scalarOf(scope, -1)));
         ReduceProd<U> total = ReduceProd.create(scope, dims, Constant.scalarOf(scope, 0));
         return total;
     }
-   
+
+    @Endpoint(name = "size")
+    public static Operand<TInt32> size(Scope scope, Shape<TInt32> shape, Operand<TInt32> dim) {
+        return size(scope, shape, dim, TInt32.DTYPE);
+
+    }
+
     /**
-     *  get the size of the specified dimension in the shape
-     * 
+     * get the size of the specified dimension in the shape
+     *
+     * @param <U> the shape datatype.
+     * @param scope current scope
      * @param shape the TensorFlow shape
-     * @param dim the dimension 
-     * @return  the size of the specified dimension
+     * @param dim the dimension
+     * @param dType the shape datatype.
+     * @return the size of the specified dimension
      */
-    public Operand<U> size(Shape<U> shape, Operand<U> dim) {
-        Slice<U> dims = Slice.create(scope, shape, 
-                ExpandDims.create(scope,  dim, Cast.create(scope, Constant.scalarOf(scope, -1), dType)), 
-                ExpandDims.create(scope, 
+    @Endpoint(name = "size")
+    public static <U extends TNumber> Operand<U> size(Scope scope, Shape<U> shape, Operand<U> dim, DataType<U> dType) {
+        Slice<U> dims = Slice.create(scope, shape,
+                ExpandDims.create(scope, dim, Cast.create(scope, Constant.scalarOf(scope, -1), dType)),
+                ExpandDims.create(scope,
                         Cast.create(scope, Constant.scalarOf(scope, 1), dType),
                         Cast.create(scope, Constant.scalarOf(scope, -1), dType)));
         return dims;
     }
-    
+
     /**
      * get the size of the specified dimension for the shape of the tensor
-     * 
+     *
+     * @param scope current scope
      * @param input the operand
      * @param dim the dimension
-     * @return  the size of the specified dimension
+     * @return the size of the specified dimension
      */
-     public Operand<U> size(Operand input, Operand<U> dim) {
-        return size(Shape.create(scope, input, dType), dim);
+    @Endpoint(name = "size")
+    public static Operand<TInt32> size(Scope scope, Operand input, Operand<TInt32> dim) {
+        return size(scope, input, dim, TInt32.DTYPE);
     }
-    
-     /**
-      * get the number of dimensions of the shape object
-      * 
-      * @param shape the shape
-      * @return the number of dimensions
-      * @see tf.rank
-      */
-    public Operand<U> numDimensions(Shape<U> shape) {
+
+    /**
+     * get the size of the specified dimension for the shape of the tensor
+     *
+     * @param <U> the shape datatype.
+     * @param scope current scope
+     * @param input the operand
+     * @param dim the dimension
+     * @param dType the shape datatype.
+     * @return the size of the specified dimension
+     */
+    @Endpoint(name = "size")
+    public static <U extends TNumber> Operand<U> size(Scope scope, Operand input,
+            Operand<U> dim, DataType<U> dType) {
+        return size(scope, Shape.create(scope, input, dType), dim, dType);
+    }
+
+    /**
+     * get the number of dimensions of the shape object
+     *
+     * @param scope current scope
+     * @param shape the shape
+     * @return the number of dimensions
+     * @see tf.rank
+     */
+    @Endpoint(name = "numDimensions")
+    public static Operand<TInt32> numDimensions(Scope scope, Shape<TInt32> shape) {
+        return Size.create(scope, shape, TInt32.DTYPE);
+    }
+
+    /**
+     * get the number of dimensions of the shape object
+     *
+     * @param <U> the shape datatype.
+     * @param scope the curren scope
+     * @param shape the shape
+     * @param dType the shape datatype.
+     * @return the number of dimensions
+     * @see tf.rank
+     */
+    @Endpoint(name = "numDimensions")
+    public static <U extends TNumber> Operand<U> numDimensions(Scope scope,
+            Shape<U> shape, DataType<U> dType) {
         return Size.create(scope, shape, dType);
     }
-    
+
     /**
-     * reshapes the operand to the specified axis, 
+     * reshapes the operand to the specified axis,
+     *
      * @param <T> the type of Operand
+     * @param scope current scope
      * @param operand the operand
      * @param axis the axis
      * @return the reshaped operand
      */
-    public <T extends TType> Operand<T> reduceDims(Operand<T> operand , Operand<U> axis) {
-        Shape<U> newShape = Shape.create(scope, operand, dType);
-        return Reshape.create(scope, operand, reduceDims(newShape, axis));
+    @Endpoint(name = "reduceDims")
+    public static <T extends TType> Operand<T> reduceDims(Scope scope,
+            Operand<T> operand, Operand<TInt32> axis) {
+        return reduceDims(scope, operand, axis, TInt32.DTYPE);
     }
-    
+
     /**
-     * reduces the shape to the specified axis, 
+     * reshapes the operand to the specified axis,
+     *
+     * @param <T> the type of Operand
+     * @param <U> the shape datatype.
+     * @param scope current scope
+     * @param operand the operand
+     * @param axis the axis
+     * @param dType the shape datatype.
+     * @return the reshaped operand
+     */
+    @Endpoint(name = "reduceDims")
+    public static <T extends TType, U extends TNumber> Operand<T> reduceDims(
+            Scope scope, Operand<T> operand, Operand<U> axis, DataType<U> dType) {
+        Shape<U> newShape = Shape.create(scope, operand, dType);
+        return Reshape.create(scope, operand, reduceDims(scope, newShape, axis, dType));
+    }
+
+    /**
+     * reduces the shape to the specified axis,
+     *
+     * @param scope current scope
      * @param shape the TensorFlow shape
      * @param axis the axis
      * @return the reduced shape
      */
-    public Operand<U> reduceDims(Shape<U> shape , Operand<U> axis) {
+    @Endpoint(name = "reduceDims")
+    public static Operand<TInt32> reduceDims(Scope scope,
+            Shape<TInt32> shape, Operand<TInt32> axis) {
+        return reduceDims(scope, shape, axis, TInt32.DTYPE);
+    }
+
+    /**
+     * reduces the shape to the specified axis,
+     *
+     * @param <U> the shape datatype.
+     * @param scope current scope
+     * @param shape the TensorFlow shape
+     * @param axis the axis
+     * @param dType the shape datatype.
+     * @return the reduced shape
+     */
+    @Endpoint(name = "reduceDims")
+    public static <U extends TNumber> Operand<U> reduceDims(Scope scope,
+            Shape<U> shape, Operand<U> axis, DataType<U> dType) {
         Size<U> rank = Size.create(scope, shape, dType);
         axis = FloorMod.create(scope, axis, rank);
         Sub<U> remainder = Sub.create(scope, rank, axis);
-        
-        Operand<U> dims1 = Slice.create(scope, shape, 
+
+        Operand<U> dims1 = Slice.create(scope, shape,
                 Cast.create(scope, Constant.arrayOf(scope, (new int[]{0})), dType),
                 ExpandDims.create(scope, axis, Constant.scalarOf(scope, -1)));
-        
+
         Operand<U> dims2 = Slice.create(scope, shape,
                 ExpandDims.create(scope, axis, Constant.scalarOf(scope, -1)),
-                ExpandDims.create(scope, Cast.create(scope, Constant.scalarOf(scope, -1), dType),  Constant.scalarOf(scope, -1)));
-        
+                ExpandDims.create(scope, Cast.create(scope, Constant.scalarOf(scope, -1), dType), Constant.scalarOf(scope, -1)));
+
         Operand<U> prod = ReduceProd.create(scope, dims2, Constant.scalarOf(scope, 0), ReduceProd.keepDims(Boolean.TRUE));
-        Concat<U> concat = Concat.create( scope, 
-                Arrays.asList(dims1, prod), Constant.scalarOf(scope, 0)); 
-                
+
+        Concat<U> concat = Concat.create(scope,
+                Arrays.asList(dims1, prod), Constant.scalarOf(scope, 0));
+
         return concat;
     }
-    
-    
-   
+
     /**
      * Removes dimensions of size 1 from the shape
-     * @param shape
+     *
+     * @param scope current scope
+     * @param shape the TensorFlow shape
      * @return the squeezed shape
      * @see tf.squeeze
      */
-    public Operand<U> squeeze(Shape<U> shape) {
-         Operand<TBool> mask = NotEqual.create(scope, shape, 
-                 Cast.create(scope, OnesLike.create(scope, shape), dType));
-         
-         Gather<U> gather = Gather.create(scope, shape, 
-                 Where.create(scope, mask), 
-                 Constant.scalarOf(scope, 0));
-         
-         return gather;
+    @Endpoint(name = "squeeze")
+    public static Operand<TInt32> squeeze(Scope scope, Shape<TInt32> shape) {
+        return squeeze(scope, shape, TInt32.DTYPE);
+    }
+
+    /**
+     * Removes dimensions of size 1 from the shape
+     *
+     * @param <U> the shape datatype.
+     * @param scope current scope
+     * @param shape the TensorFlow shape
+     * @param dType the shape datatype.
+     * @return the squeezed shape
+     *
+     * @see tf.squeeze
+     */
+    @Endpoint(name = "squeeze")
+    public static <U extends TNumber> Operand<U> squeeze(Scope scope,
+            Shape<U> shape, DataType<U> dType) {
+        Operand<TBool> mask = NotEqual.create(scope, shape,
+                Cast.create(scope, OnesLike.create(scope, shape), dType));
+
+        Gather<U> gather = Gather.create(scope, shape,
+                Where.create(scope, mask),
+                Constant.scalarOf(scope, 0));
+
+        return gather;
     }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/ShapeOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/ShapeOps.java
@@ -1,0 +1,217 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.tensorflow.keras.utils;
+
+import java.util.Arrays;
+import org.tensorflow.DataType;
+import org.tensorflow.Operand;
+import org.tensorflow.op.Scope;
+import org.tensorflow.op.core.Concat;
+import org.tensorflow.op.core.ExpandDims;
+import org.tensorflow.op.core.Reshape;
+import org.tensorflow.op.core.Shape;
+import org.tensorflow.op.core.Size;
+import org.tensorflow.op.core.Slice;
+import org.tensorflow.op.math.FloorMod;
+import org.tensorflow.op.core.Constant;
+import org.tensorflow.op.core.Gather;
+import org.tensorflow.op.core.OnesLike;
+import org.tensorflow.op.core.ReduceProd;
+import org.tensorflow.op.core.Where;
+import org.tensorflow.op.dtypes.Cast;
+import org.tensorflow.op.math.NotEqual;
+import org.tensorflow.op.math.Sub;
+import org.tensorflow.types.TBool;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.family.TNumber;
+import org.tensorflow.types.family.TType;
+
+/**
+ *
+ * @author Jim Clarke
+ * @param <T> the type of operand
+ */
+
+// TODO should shape be based on  TInt64  ???
+public class ShapeOps<U extends TNumber > {
+    private final Scope scope;
+    private final DataType<U> dType;
+    
+    /**
+     * Create a ShapeUtils with a DataType of TInt32
+     * 
+     * @param scope is a scope used to add the underlying operations
+     * @return the ShapeUtils
+     */
+    public static ShapeOps<TInt32> create(Scope scope) {
+        return create(scope, TInt32.DTYPE);
+    }
+    
+    /**
+     * 
+     * @param <U> the Shape type
+     * @param scope is a scope used to add the underlying operations
+     * @param dType the Shape datatype
+     * @return the ShapeUtils
+     */
+    public static <U extends TNumber> ShapeOps<U> create(Scope scope, DataType<U> dType) {
+        return new ShapeOps<>(scope, dType);
+    }
+    
+    /**
+     * The constructor for ShapeUtils
+     * @param scope is a scope used to add the underlying operations
+     * @param dType the Shape datatype
+     */
+    private ShapeOps(Scope scope,  DataType<U> dType) {
+        this.scope = scope;
+        this.dType = dType;
+    }
+    
+    public Scope scope() {
+        return this.scope;
+    }
+    
+    public  DataType<U> datatype() {
+        return this.dType;
+    }
+    
+    /**
+     * flatten the shape to 1 dimension
+     * 
+     * @param <T> the type of operand
+     * @param operand the operand to flatten
+     * @return the reshaped operand
+     */
+    public <T extends TType> Operand<T> flatten(Operand<T> operand) {
+        Operand<U> flatShape =  flatten(Shape.create(scope, operand, dType)); 
+        return Reshape.create(scope, operand, flatShape);
+    }
+    
+    /**
+     * flatten the shape to 1 dimension
+     * 
+     * @param shape the TensorFlow shape
+     * @return  the flattened shape
+     * @see reduceDims
+     */
+    public Operand<U> flatten(Shape<U> shape) {
+        return ExpandDims.create(scope, 
+                        Cast.create(scope, size(shape), dType),
+                        Cast.create(scope, Constant.scalarOf(scope, -1), dType));
+        
+    }
+    
+    
+   /**
+    * get the size represented by the TensorFlow shape
+    * 
+    * @param shape the TensorFlow shape
+    * @return the size
+    */
+    public Operand<U> size(Shape<U> shape) {
+        Slice<U> dims = Slice.create(scope, shape, 
+                Cast.create(scope, Constant.arrayOf(scope, (new int[]{0})), dType),
+                ExpandDims.create(scope, Cast.create(scope, Constant.scalarOf(scope, -1), dType),  Constant.scalarOf(scope, -1)));
+        ReduceProd<U> total = ReduceProd.create(scope, dims, Constant.scalarOf(scope, 0));
+        return total;
+    }
+   
+    /**
+     *  get the size of the specified dimension in the shape
+     * 
+     * @param shape the TensorFlow shape
+     * @param dim the dimension 
+     * @return  the size of the specified dimension
+     */
+    public Operand<U> size(Shape<U> shape, Operand<U> dim) {
+        Slice<U> dims = Slice.create(scope, shape, 
+                ExpandDims.create(scope,  dim, Cast.create(scope, Constant.scalarOf(scope, -1), dType)), 
+                ExpandDims.create(scope, 
+                        Cast.create(scope, Constant.scalarOf(scope, 1), dType),
+                        Cast.create(scope, Constant.scalarOf(scope, -1), dType)));
+        return dims;
+    }
+    
+    /**
+     * get the size of the specified dimension for the shape of the tensor
+     * 
+     * @param input the operand
+     * @param dim the dimension
+     * @return  the size of the specified dimension
+     */
+     public Operand<U> size(Operand input, Operand<U> dim) {
+        return size(Shape.create(scope, input, dType), dim);
+    }
+    
+     /**
+      * get the number of dimensions of the shape object
+      * 
+      * @param shape the shape
+      * @return the number of dimensions
+      * @see tf.rank
+      */
+    public Operand<U> numDimensions(Shape<U> shape) {
+        return Size.create(scope, shape, dType);
+    }
+    
+    /**
+     * reshapes the operand to the specified axis, 
+     * @param <T> the type of Operand
+     * @param operand the operand
+     * @param axis the axis
+     * @return the reshaped operand
+     */
+    public <T extends TType> Operand<T> reduceDims(Operand<T> operand , Operand<U> axis) {
+        Shape<U> newShape = Shape.create(scope, operand, dType);
+        return Reshape.create(scope, operand, reduceDims(newShape, axis));
+    }
+    
+    /**
+     * reduces the shape to the specified axis, 
+     * @param shape the TensorFlow shape
+     * @param axis the axis
+     * @return the reduced shape
+     */
+    public Operand<U> reduceDims(Shape<U> shape , Operand<U> axis) {
+        Size<U> rank = Size.create(scope, shape, dType);
+        axis = FloorMod.create(scope, axis, rank);
+        Sub<U> remainder = Sub.create(scope, rank, axis);
+        
+        Operand<U> dims1 = Slice.create(scope, shape, 
+                Cast.create(scope, Constant.arrayOf(scope, (new int[]{0})), dType),
+                ExpandDims.create(scope, axis, Constant.scalarOf(scope, -1)));
+        
+        Operand<U> dims2 = Slice.create(scope, shape,
+                ExpandDims.create(scope, axis, Constant.scalarOf(scope, -1)),
+                ExpandDims.create(scope, Cast.create(scope, Constant.scalarOf(scope, -1), dType),  Constant.scalarOf(scope, -1)));
+        
+        Operand<U> prod = ReduceProd.create(scope, dims2, Constant.scalarOf(scope, 0), ReduceProd.keepDims(Boolean.TRUE));
+        Concat<U> concat = Concat.create( scope, 
+                Arrays.asList(dims1, prod), Constant.scalarOf(scope, 0)); 
+                
+        return concat;
+    }
+    
+    
+   
+    /**
+     * Removes dimensions of size 1 from the shape
+     * @param shape
+     * @return the squeezed shape
+     * @see tf.squeeze
+     */
+    public Operand<U> squeeze(Shape<U> shape) {
+         Operand<TBool> mask = NotEqual.create(scope, shape, 
+                 Cast.create(scope, OnesLike.create(scope, shape), dType));
+         
+         Gather<U> gather = Gather.create(scope, shape, 
+                 Where.create(scope, mask), 
+                 Constant.scalarOf(scope, 0));
+         
+         return gather;
+    }
+}

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/ShapeOpsTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/ShapeOpsTest.java
@@ -1,0 +1,305 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.tensorflow.keras.utils;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/***
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+****/
+
+
+import org.tensorflow.Graph;
+import org.tensorflow.Operand;
+import org.tensorflow.Session;
+import org.tensorflow.Tensor;
+import org.tensorflow.op.Scope;
+import org.tensorflow.op.core.Constant;
+import org.tensorflow.op.core.Reshape;
+import org.tensorflow.op.core.Shape;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.TInt64;
+
+/**
+ *
+ * @author jbclarke
+ */
+@RunWith(JUnit4.class)
+public class ShapeOpsTest {
+    
+    public ShapeOpsTest() {
+    }
+    
+
+    /**
+     * Test of create method, of class ShapeOps.
+     */
+    @Test
+    public void testCreate_Scope() {
+        try (Graph g = new Graph();
+                Session sess = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps stf = ShapeOps.create(scope);
+            assertEquals(scope, stf.scope());
+            assertEquals(TInt32.DTYPE, stf.datatype());
+        }
+    }
+
+    /**
+     * Test of create method, of class ShapeOps.
+     */
+    @Test
+    public void testCreate_Scope_DataType() {
+        System.out.println("create DataType");
+        try (Graph g = new Graph();
+                Session sess = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps stf = ShapeOps.create(scope, TInt64.DTYPE);
+            assertEquals(scope, stf.scope());
+            assertEquals(TInt64.DTYPE, stf.datatype());
+        }
+    }
+
+    /**
+     * Test of flatten method, of class ShapeOps.
+     */
+    @Test
+    public void testFlatten_Operand() {
+        System.out.println("flatten operand");
+        try (Graph g = new Graph();
+                Session session = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps instance = ShapeOps.create(scope, TInt64.DTYPE);
+            Operand<TFloat32> operand = Constant.arrayOf(scope, new float[]{1, 2, 3, 4, 5, 6, 7, 8});
+            Shape<TInt64> expResult = Shape.create(scope, operand, TInt64.DTYPE);
+            Operand<TFloat32> reshaped = Reshape.create(scope, operand, Constant.vectorOf(scope, new long[]{4, 2, 1}));
+            Operand actual = instance.flatten(reshaped);
+            Shape<TInt64> tfshape = Shape.create(scope, actual, TInt64.DTYPE);
+
+            AtomicInteger index = new AtomicInteger();
+            try (Tensor<TInt64> result1 = session.runner().fetch(tfshape.asOutput()).run().get(0).expect(TInt64.DTYPE);
+                    Tensor<TInt64> result2 = session.runner().fetch(expResult.asOutput()).run().get(0).expect(TInt64.DTYPE)) {
+                result1.data().scalars().forEach(s -> assertEquals(
+                        result2.data().getLong(index.getAndIncrement()), s.getLong()));
+            }
+        }
+    }
+
+    /**
+     * Test of flatten method, of class ShapeOps.
+     */
+    @Test
+    public void testFlatten_Shape() {
+        System.out.println("flatten shape");
+        try (Graph g = new Graph();
+                Session session = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps instance = ShapeOps.create(scope, TInt64.DTYPE);
+            Operand operand = Constant.arrayOf(scope, new float[] {1, 2, 3, 4, 5, 6, 7, 8} );
+            Shape<TInt64> expShape = Shape.create(scope, operand, TInt64.DTYPE);
+            Operand actual = Reshape.create(scope, operand, Constant.vectorOf(scope, new long[] { 4,2,1} ));
+            Shape<TInt64> tfshape = Shape.create(scope, actual, TInt64.DTYPE);
+            Operand<TInt64> flattened = instance.flatten(tfshape);
+            
+            
+            AtomicInteger index = new AtomicInteger();
+            try (Tensor<TInt64> result1 = session.runner().fetch(flattened.asOutput()).run().get(0).expect(TInt64.DTYPE);
+                    Tensor<TInt64> result2 = session.runner().fetch(expShape.asOutput()).run().get(0).expect(TInt64.DTYPE)) {
+                result1.data().scalars().forEach(s -> assertEquals(
+                        result2.data().getLong(index.getAndIncrement()), s.getLong()));
+            }
+        }
+    }
+
+    /**
+     * Test of size method, of class ShapeOps.
+     */
+    @Test
+    public void testSize_Shape() {
+        System.out.println("size");
+        try (Graph g = new Graph();
+                Session session = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps instance = ShapeOps.create(scope, TInt64.DTYPE);
+            Operand operand = Constant.arrayOf(scope, new float[] {1, 2, 3, 4, 5, 6, 7, 8} );
+            Operand actual = Reshape.create(scope, operand, Constant.vectorOf(scope, new long[] { 4,2,1} ));
+            Shape<TInt64> tfshape = Shape.create(scope, actual, TInt64.DTYPE);
+            Operand<TInt64> size = instance.size(tfshape);
+            
+            
+            AtomicInteger index = new AtomicInteger();
+            try (Tensor<TInt64> result1 = session.runner().fetch(size.asOutput()).run().get(0).expect(TInt64.DTYPE)) {
+                result1.data().scalars().forEach(s -> assertEquals(8, s.getLong()));
+            }
+        }
+    }
+
+    /**
+     * Test of size method, of class ShapeOps.
+     */
+    @Test
+    public void testSize_Shape_Operand() {
+        System.out.println("size");
+        try (Graph g = new Graph();
+                Session session = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps instance = ShapeOps.create(scope);
+            Operand operand = Constant.arrayOf(scope, new float[] {1, 2, 3, 4, 5, 6, 7, 8} );
+            Operand actual = Reshape.create(scope, operand, Constant.vectorOf(scope, new long[] { 4,2,1} ));
+            Shape<TInt32> tfshape = Shape.create(scope, actual);
+            
+            Operand<TInt32> size = instance.size(tfshape, Constant.scalarOf(scope, 0));
+            try (Tensor<TInt32> result = session.runner().fetch(size.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> assertEquals(4, s.getInt()));
+            }
+            
+            size = instance.size(tfshape, Constant.scalarOf(scope, 1));
+            try (Tensor<TInt32> result = session.runner().fetch(size.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> assertEquals(2, s.getInt()));
+            }
+            
+            size = instance.size(tfshape, Constant.scalarOf(scope, 2));
+            try (Tensor<TInt32> result = session.runner().fetch(size.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> assertEquals(1, s.getInt()));
+            }
+        }
+    }
+
+    /**
+     * Test of size method, of class ShapeOps.
+     */
+    @Test
+    public void testSize_Operand_Operand() {
+        System.out.println("size");
+         try (Graph g = new Graph();
+                Session session = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps instance = ShapeOps.create(scope);
+            Operand operand = Constant.arrayOf(scope, new float[] {1, 2, 3, 4, 5, 6, 7, 8} );
+            Operand actual = Reshape.create(scope, operand, Constant.vectorOf(scope, new long[] { 4,2,1} ));
+            
+            Operand<TInt32> size = instance.size(actual, Constant.scalarOf(scope, 0));
+            try (Tensor<TInt32> result = session.runner().fetch(size.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> assertEquals(4, s.getInt()));
+            }
+            
+            size = instance.size(actual, Constant.scalarOf(scope, 1));
+            try (Tensor<TInt32> result = session.runner().fetch(size.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> assertEquals(2, s.getInt()));
+            }
+            
+            size = instance.size(actual, Constant.scalarOf(scope, 2));
+            try (Tensor<TInt32> result = session.runner().fetch(size.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> assertEquals(1, s.getInt()));
+            }
+        }
+    }
+
+    /**
+     * Test of numDimensions method, of class ShapeOps.
+     */
+    @Test
+    public void testNumDimensions() {
+        System.out.println("numDimensions");
+        try (Graph g = new Graph();
+                Session session = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps instance = ShapeOps.create(scope);
+            Operand operand = Constant.arrayOf(scope, new float[] {1, 2, 3, 4, 5, 6, 7, 8} );
+            Operand actual = Reshape.create(scope, operand, Constant.vectorOf(scope, new long[] { 4,2,1} ));
+            Shape<TInt32> tfshape = Shape.create(scope, actual);
+            
+            Operand<TInt32> nDims = instance.numDimensions(tfshape);
+            try (Tensor<TInt32> result = session.runner().fetch(nDims.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> assertEquals(3, s.getInt()));
+            }
+            
+        }
+    }
+
+    /**
+     * Test of reduceDims method, of class ShapeOps.
+     */
+    @Test
+    public void testReduceDims_Operand_Operand() {
+        System.out.println("reduceDims");
+        /**
+        ShapeOps instance = null;
+        Operand expResult = null;
+        Operand result = instance.reduceDims(null);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+        * * **/
+    }
+
+    /**
+     * Test of reduceDims method, of class ShapeOps.
+     */
+    @Test
+    public void testReduceDims_Shape_Operand() {
+        System.out.println("reduceDims shape Operand");
+        try (Graph g = new Graph();
+                Session session = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps instance = ShapeOps.create(scope);
+            Operand operand = Constant.arrayOf(scope, new float[] {1, 2, 3, 4, 5, 6, 7, 8} );
+            Operand actual = Reshape.create(scope, operand, Constant.vectorOf(scope, new long[] { 2,2,2} ));
+            Shape<TInt32> tfshape = Shape.create(scope, actual);
+            
+            Operand<TInt32> reduced = instance.reduceDims(tfshape, Constant.scalarOf(scope, 0));
+            AtomicInteger index = new AtomicInteger();
+            int[] expected = { 8 };
+            try (Tensor<TInt32> result = session.runner().fetch(reduced.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> {
+                    assertEquals(expected[index.getAndIncrement()], s.getInt());
+                        });
+            }
+            assertEquals(expected.length, index.get());
+            
+        }
+    }
+
+    /**
+     * Test of squeeze method, of class ShapeOps.
+     */
+    @Test
+    public void testSqueeze() {
+        System.out.println("squeeze");
+        try (Graph g = new Graph();
+                Session session = new Session(g)) {
+            Scope scope = new Scope(g);
+            ShapeOps instance = ShapeOps.create(scope);
+            Operand operand = Constant.arrayOf(scope, new float[] {1, 2, 3, 4, 5, 6, 7, 8} );
+            Operand actual = Reshape.create(scope, operand, Constant.vectorOf(scope, new long[] { 4,1,2,1} ));
+            Shape<TInt32> tfshape = Shape.create(scope, actual);
+            
+            Operand<TInt32> squeezed = instance.squeeze(tfshape);
+            AtomicInteger index = new AtomicInteger();
+            int[] expected = { 4, 2};
+            try (Tensor<TInt32> result = session.runner().fetch(squeezed.asOutput()).run().get(0).expect(TInt32.DTYPE)) {
+                result.data().scalars().forEach(s -> {
+                    assertEquals(expected[index.getAndIncrement()], s.getInt());
+                        });
+            }
+            assertEquals(expected.length, index.get());
+            
+        }
+    }
+    
+}


### PR DESCRIPTION
Add ShapeOps class as a tool for working with org.tensorflow.op.core.Shape objects directly during runtime as opposed to working with static shapes via org.tensorflow.tools.Shape. This is needed in Java TensorFlow frameworks, such as Keras,  to manipulate shapes when the actual shape is not known until the graph is run.