### PR TITLE
Remove dependency on javacpp-platform to avoid pulling unused code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
           df -h
   windows-x86_64:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        ext: ["", -mkl, -gpu, -mkl-gpu]
+#    strategy:
+#      matrix:
+#        ext: ["", -mkl, -gpu, -mkl-gpu]
     steps:
       - name: Configure page file
         uses: al-cheb/configure-pagefile-action@v1.2
@@ -131,7 +131,7 @@ jobs:
           wmic pagefile list /format:list
   redeploy:
     if: github.event_name == 'push'
-    needs: [linux-x86_64, macosx-x86_64]
+    needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -139,7 +139,7 @@ jobs:
       - name: Redeploy snapshot artifacts
         run: |
           cd tensorflow-core
-          mvn dependency:resolve -Possrh -Predeploy -N -B -U -e -Djavacpp.platform.custom -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.macosx-x86_64
+          mvn dependency:resolve -Possrh -Predeploy -N -B -U -e
           cp $HOME/.m2/repository/org/tensorflow/tensorflow-core-api/*-SNAPSHOT/tensorflow-core-api-*-SNAPSHOT*.jar .
           for f in *.jar; do
             if [[ $f =~ tensorflow-core-api-.*SNAPSHOT-(.*).jar ]]; then

--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -43,14 +43,22 @@
     <javacpp.compiler.skip>false</javacpp.compiler.skip> <!-- To skip native compilation phase: -Djavacpp.compiler.skip=true -->
     <javacpp.platform.extension></javacpp.platform.extension>
     <javacpp.platform.properties>${javacpp.platform}</javacpp.platform.properties>
-    <javacpp.platform.linux-armhf>linux-armhf${javacpp.platform.extension}</javacpp.platform.linux-armhf>
-    <javacpp.platform.linux-arm64>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64>
-    <javacpp.platform.linux-ppc64le>linux-ppc64le${javacpp.platform.extension}</javacpp.platform.linux-ppc64le>
-    <javacpp.platform.linux-x86>linux-x86${javacpp.platform.extension}</javacpp.platform.linux-x86>
-    <javacpp.platform.linux-x86_64>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
-    <javacpp.platform.macosx-x86_64>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
-    <javacpp.platform.windows-x86>windows-x86${javacpp.platform.extension}</javacpp.platform.windows-x86>
-    <javacpp.platform.windows-x86_64>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+    <javacpp.platform.linux-armhf>linux-armhf</javacpp.platform.linux-armhf>
+    <javacpp.platform.linux-arm64>linux-arm64</javacpp.platform.linux-arm64>
+    <javacpp.platform.linux-ppc64le>linux-ppc64le</javacpp.platform.linux-ppc64le>
+    <javacpp.platform.linux-x86>linux-x86</javacpp.platform.linux-x86>
+    <javacpp.platform.linux-x86_64>linux-x86_64</javacpp.platform.linux-x86_64>
+    <javacpp.platform.macosx-x86_64>macosx-x86_64</javacpp.platform.macosx-x86_64>
+    <javacpp.platform.windows-x86>windows-x86</javacpp.platform.windows-x86>
+    <javacpp.platform.windows-x86_64>windows-x86_64</javacpp.platform.windows-x86_64>
+    <javacpp.platform.linux-armhf.extension>linux-armhf${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
+    <javacpp.platform.linux-arm64.extension>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
+    <javacpp.platform.linux-ppc64le.extension>linux-ppc64le${javacpp.platform.extension}</javacpp.platform.linux-ppc64le.extension>
+    <javacpp.platform.linux-x86.extension>linux-x86${javacpp.platform.extension}</javacpp.platform.linux-x86.extension>
+    <javacpp.platform.linux-x86_64.extension>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
+    <javacpp.platform.macosx-x86_64.extension>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
+    <javacpp.platform.windows-x86.extension>windows-x86${javacpp.platform.extension}</javacpp.platform.windows-x86.extension>
+    <javacpp.platform.windows-x86_64.extension>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
     <javacpp.version>1.5.3</javacpp.version>
     <mkl-dnn.version>0.21.4-${javacpp.version}</mkl-dnn.version>
   </properties>
@@ -130,14 +138,22 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.linux-armhf>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-armhf>
-        <javacpp.platform.linux-arm64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-arm64>
-        <javacpp.platform.linux-ppc64le>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le>
-        <javacpp.platform.linux-x86>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86>
-        <javacpp.platform.linux-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
-        <javacpp.platform.macosx-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
-        <javacpp.platform.windows-x86>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86>
-        <javacpp.platform.windows-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf>${javacpp.platform}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-arm64>${javacpp.platform}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-ppc64le>${javacpp.platform}</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-x86>${javacpp.platform}</javacpp.platform.linux-x86>
+        <javacpp.platform.linux-x86_64>${javacpp.platform}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.macosx-x86_64>${javacpp.platform}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.windows-x86>${javacpp.platform}</javacpp.platform.windows-x86>
+        <javacpp.platform.windows-x86_64>${javacpp.platform}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -149,15 +165,23 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform>
-        <javacpp.platform.linux-armhf>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-armhf>
-        <javacpp.platform.linux-arm64>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-arm64>
-        <javacpp.platform.linux-ppc64le>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le>
-        <javacpp.platform.linux-x86>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-x86>
-        <javacpp.platform.linux-x86_64>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
-        <javacpp.platform.macosx-x86_64>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
-        <javacpp.platform.windows-x86>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.windows-x86>
-        <javacpp.platform.windows-x86_64>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+        <javacpp.platform>${os.name}-${os.arch}</javacpp.platform>
+        <javacpp.platform.linux-armhf>${os.name}-${os.arch}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-arm64>${os.name}-${os.arch}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-ppc64le>${os.name}-${os.arch}</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-x86>${os.name}-${os.arch}</javacpp.platform.linux-x86>
+        <javacpp.platform.linux-x86_64>${os.name}-${os.arch}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.macosx-x86_64>${os.name}-${os.arch}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.windows-x86>${os.name}-${os.arch}</javacpp.platform.windows-x86>
+        <javacpp.platform.windows-x86_64>${os.name}-${os.arch}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -178,6 +202,14 @@
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -198,6 +230,14 @@
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -210,7 +250,7 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.linux-armhf>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-armhf>${javacpp.platform}</javacpp.platform.linux-armhf>
         <javacpp.platform.linux-arm64></javacpp.platform.linux-arm64>
         <javacpp.platform.linux-ppc64le></javacpp.platform.linux-ppc64le>
         <javacpp.platform.linux-x86></javacpp.platform.linux-x86>
@@ -218,6 +258,14 @@
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -231,13 +279,21 @@
       </activation>
       <properties>
         <javacpp.platform.linux-armhf></javacpp.platform.linux-armhf>
-        <javacpp.platform.linux-arm64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64>${javacpp.platform}</javacpp.platform.linux-arm64>
         <javacpp.platform.linux-ppc64le></javacpp.platform.linux-ppc64le>
         <javacpp.platform.linux-x86></javacpp.platform.linux-x86>
         <javacpp.platform.linux-x86_64></javacpp.platform.linux-x86_64>
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -252,12 +308,20 @@
       <properties>
         <javacpp.platform.linux-armhf></javacpp.platform.linux-armhf>
         <javacpp.platform.linux-arm64></javacpp.platform.linux-arm64>
-        <javacpp.platform.linux-ppc64le>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-ppc64le>${javacpp.platform}</javacpp.platform.linux-ppc64le>
         <javacpp.platform.linux-x86></javacpp.platform.linux-x86>
         <javacpp.platform.linux-x86_64></javacpp.platform.linux-x86_64>
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -273,11 +337,19 @@
         <javacpp.platform.linux-armhf></javacpp.platform.linux-armhf>
         <javacpp.platform.linux-arm64></javacpp.platform.linux-arm64>
         <javacpp.platform.linux-ppc64le></javacpp.platform.linux-ppc64le>
-        <javacpp.platform.linux-x86>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86>
+        <javacpp.platform.linux-x86>${javacpp.platform}</javacpp.platform.linux-x86>
         <javacpp.platform.linux-x86_64></javacpp.platform.linux-x86_64>
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -294,10 +366,18 @@
         <javacpp.platform.linux-arm64></javacpp.platform.linux-arm64>
         <javacpp.platform.linux-ppc64le></javacpp.platform.linux-ppc64le>
         <javacpp.platform.linux-x86></javacpp.platform.linux-x86>
-        <javacpp.platform.linux-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64>${javacpp.platform}</javacpp.platform.linux-x86_64>
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -315,9 +395,17 @@
         <javacpp.platform.linux-ppc64le></javacpp.platform.linux-ppc64le>
         <javacpp.platform.linux-x86></javacpp.platform.linux-x86>
         <javacpp.platform.linux-x86_64></javacpp.platform.linux-x86_64>
-        <javacpp.platform.macosx-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64>${javacpp.platform}</javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -336,8 +424,16 @@
         <javacpp.platform.linux-x86></javacpp.platform.linux-x86>
         <javacpp.platform.linux-x86_64></javacpp.platform.linux-x86_64>
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
-        <javacpp.platform.windows-x86>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86>
+        <javacpp.platform.windows-x86>${javacpp.platform}</javacpp.platform.windows-x86>
         <javacpp.platform.windows-x86_64></javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension></javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -357,7 +453,15 @@
         <javacpp.platform.linux-x86_64></javacpp.platform.linux-x86_64>
         <javacpp.platform.macosx-x86_64></javacpp.platform.macosx-x86_64>
         <javacpp.platform.windows-x86></javacpp.platform.windows-x86>
-        <javacpp.platform.windows-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64>${javacpp.platform}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension></javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension></javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension></javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension></javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension></javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension></javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension></javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -370,14 +474,22 @@
         </file>
       </activation>
       <properties>
-        <javacpp.platform.linux-armhf>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-armhf>
-        <javacpp.platform.linux-arm64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-arm64>
-        <javacpp.platform.linux-ppc64le>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le>
-        <javacpp.platform.linux-x86>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86>
-        <javacpp.platform.linux-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
-        <javacpp.platform.macosx-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
-        <javacpp.platform.windows-x86>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86>
-        <javacpp.platform.windows-x86_64>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf>${javacpp.platform}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-arm64>${javacpp.platform}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-ppc64le>${javacpp.platform}</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-x86>${javacpp.platform}</javacpp.platform.linux-x86>
+        <javacpp.platform.linux-x86_64>${javacpp.platform}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.macosx-x86_64>${javacpp.platform}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.windows-x86>${javacpp.platform}</javacpp.platform.windows-x86>
+        <javacpp.platform.windows-x86_64>${javacpp.platform}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-ppc64le.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-ppc64le.extension>
+        <javacpp.platform.linux-x86.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86.extension>
+        <javacpp.platform.linux-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86.extension>
+        <javacpp.platform.windows-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -391,7 +503,8 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.linux-armhf>linux-armhf${javacpp.platform.extension}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-armhf>linux-armhf</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-armhf.extension>linux-armhf${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
       </properties>
     </profile>
 
@@ -403,7 +516,8 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.linux-arm64>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64>linux-arm64</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64.extension>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
       </properties>
     </profile>
 
@@ -415,7 +529,8 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.linux-ppc64le>linux-ppc64le${javacpp.platform.extension}</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-ppc64le>linux-ppc64le</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-ppc64le.extension>linux-ppc64le${javacpp.platform.extension}</javacpp.platform.linux-ppc64le.extension>
       </properties>
     </profile>
 
@@ -427,7 +542,8 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.linux-x86>linux-x86${javacpp.platform.extension}</javacpp.platform.linux-x86>
+        <javacpp.platform.linux-x86>linux-x86</javacpp.platform.linux-x86>
+        <javacpp.platform.linux-x86.extension>linux-x86${javacpp.platform.extension}</javacpp.platform.linux-x86.extension>
       </properties>
     </profile>
 
@@ -439,7 +555,8 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.linux-x86_64>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64>linux-x86_64</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64.extension>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
       </properties>
     </profile>
 
@@ -451,7 +568,8 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.macosx-x86_64>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64>macosx-x86_64</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64.extension>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
       </properties>
     </profile>
 
@@ -463,7 +581,8 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.windows-x86>windows-x86${javacpp.platform.extension}</javacpp.platform.windows-x86>
+        <javacpp.platform.windows-x86>windows-x86</javacpp.platform.windows-x86>
+        <javacpp.platform.windows-x86.extension>windows-x86${javacpp.platform.extension}</javacpp.platform.windows-x86.extension>
       </properties>
     </profile>
 
@@ -475,7 +594,8 @@
         </property>
       </activation>
       <properties>
-        <javacpp.platform.windows-x86_64>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64>windows-x86_64</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64.extension>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -488,7 +608,8 @@
         <os><name>linux</name><arch>arm</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-armhf>linux-armhf${javacpp.platform.extension}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-armhf>linux-armhf</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-armhf.extension>linux-armhf${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
       </properties>
     </profile>
 
@@ -501,7 +622,8 @@
         <os><name>linux</name><arch>armhf</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-armhf>linux-armhf${javacpp.platform.extension}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-armhf>linux-armhf</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-armhf.extension>linux-armhf${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
       </properties>
     </profile>
 
@@ -514,7 +636,8 @@
         <os><name>linux</name><arch>aarch64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-arm64>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64>linux-arm64</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64.extension>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
       </properties>
     </profile>
 
@@ -527,7 +650,8 @@
         <os><name>linux</name><arch>armv8</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-arm64>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64>linux-arm64</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64.extension>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
       </properties>
     </profile>
 
@@ -540,7 +664,8 @@
         <os><name>linux</name><arch>arm64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-arm64>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64>linux-arm64</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-arm64.extension>linux-arm64${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
       </properties>
     </profile>
 
@@ -553,7 +678,8 @@
         <os><name>linux</name><arch>ppc64le</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-ppc64le>linux-ppc64le${javacpp.platform.extension}</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-ppc64le>linux-ppc64le</javacpp.platform.linux-ppc64le>
+        <javacpp.platform.linux-ppc64le.extension>linux-ppc64le${javacpp.platform.extension}</javacpp.platform.linux-ppc64le.extension>
       </properties>
     </profile>
 
@@ -566,7 +692,8 @@
         <os><name>linux</name><arch>amd64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-x86_64>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64>linux-x86_64</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64.extension>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
       </properties>
     </profile>
 
@@ -579,7 +706,8 @@
         <os><name>linux</name><arch>x86-64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-x86_64>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64>linux-x86_64</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64.extension>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
       </properties>
     </profile>
 
@@ -592,7 +720,8 @@
         <os><name>linux</name><arch>x86_64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.linux-x86_64>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64>linux-x86_64</javacpp.platform.linux-x86_64>
+        <javacpp.platform.linux-x86_64.extension>linux-x86_64${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
       </properties>
     </profile>
 
@@ -605,7 +734,8 @@
         <os><name>mac os x</name><arch>amd64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.macosx-x86_64>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64>macosx-x86_64</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64.extension>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
       </properties>
     </profile>
 
@@ -618,7 +748,8 @@
         <os><name>mac os x</name><arch>x86-64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.macosx-x86_64>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64>macosx-x86_64</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64.extension>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
       </properties>
     </profile>
 
@@ -631,7 +762,8 @@
         <os><name>mac os x</name><arch>x86_64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.macosx-x86_64>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64>macosx-x86_64</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.macosx-x86_64.extension>macosx-x86_64${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
       </properties>
     </profile>
 
@@ -644,7 +776,8 @@
         <os><family>windows</family><arch>amd64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.windows-x86_64>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64>windows-x86_64</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64.extension>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -657,7 +790,8 @@
         <os><family>windows</family><arch>x86-64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.windows-x86_64>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64>windows-x86_64</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64.extension>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -670,7 +804,8 @@
         <os><family>windows</family><arch>x86_64</arch></os>
       </activation>
       <properties>
-        <javacpp.platform.windows-x86_64>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64>windows-x86_64</javacpp.platform.windows-x86_64>
+        <javacpp.platform.windows-x86_64.extension>windows-x86_64${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 

--- a/tensorflow-core/tensorflow-core-platform-gpu/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform-gpu/pom.xml
@@ -35,25 +35,37 @@
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>
-      <artifactId>javacpp-platform</artifactId>
+      <artifactId>javacpp</artifactId>
       <version>${javacpp.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
     <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64}</classifier>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
     </dependency>
   </dependencies>
 

--- a/tensorflow-core/tensorflow-core-platform-gpu/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform-gpu/pom.xml
@@ -44,12 +44,12 @@
       <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.bytedeco</groupId>
-      <artifactId>javacpp</artifactId>
-      <version>${javacpp.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.bytedeco</groupId>-->
+<!--      <artifactId>javacpp</artifactId>-->
+<!--      <version>${javacpp.version}</version>-->
+<!--      <classifier>${javacpp.platform.windows-x86_64}</classifier>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
@@ -61,12 +61,12 @@
       <version>${project.version}</version>
       <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>${project.groupId}</groupId>-->
+<!--      <artifactId>${javacpp.moduleId}</artifactId>-->
+<!--      <version>${project.version}</version>-->
+<!--      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>-->
+<!--    </dependency>-->
   </dependencies>
 
   <build>

--- a/tensorflow-core/tensorflow-core-platform-mkl-gpu/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform-mkl-gpu/pom.xml
@@ -44,12 +44,12 @@
       <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.bytedeco</groupId>
-      <artifactId>javacpp</artifactId>
-      <version>${javacpp.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.bytedeco</groupId>-->
+<!--      <artifactId>javacpp</artifactId>-->
+<!--      <version>${javacpp.version}</version>-->
+<!--      <classifier>${javacpp.platform.windows-x86_64}</classifier>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.bytedeco</groupId>
       <artifactId>mkl-dnn</artifactId>
@@ -61,12 +61,12 @@
       <version>${mkl-dnn.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.bytedeco</groupId>
-      <artifactId>mkl-dnn</artifactId>
-      <version>${mkl-dnn.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.bytedeco</groupId>-->
+<!--      <artifactId>mkl-dnn</artifactId>-->
+<!--      <version>${mkl-dnn.version}</version>-->
+<!--      <classifier>${javacpp.platform.windows-x86_64}</classifier>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
@@ -78,12 +78,12 @@
       <version>${project.version}</version>
       <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>${project.groupId}</groupId>-->
+<!--      <artifactId>${javacpp.moduleId}</artifactId>-->
+<!--      <version>${project.version}</version>-->
+<!--      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>-->
+<!--    </dependency>-->
   </dependencies>
 
   <build>

--- a/tensorflow-core/tensorflow-core-platform-mkl-gpu/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform-mkl-gpu/pom.xml
@@ -35,25 +35,54 @@
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>
-      <artifactId>mkl-dnn-platform</artifactId>
-      <version>${mkl-dnn.version}</version>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
     <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>mkl-dnn</artifactId>
+      <version>${mkl-dnn.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>mkl-dnn</artifactId>
+      <version>${mkl-dnn.version}</version>
+      <classifier>${javacpp.platform.linux-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>mkl-dnn</artifactId>
+      <version>${mkl-dnn.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64}</classifier>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
     </dependency>
   </dependencies>
 

--- a/tensorflow-core/tensorflow-core-platform-mkl/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform-mkl/pom.xml
@@ -50,12 +50,12 @@
       <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.macosx-x86_64}</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.bytedeco</groupId>
-      <artifactId>javacpp</artifactId>
-      <version>${javacpp.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.bytedeco</groupId>-->
+<!--      <artifactId>javacpp</artifactId>-->
+<!--      <version>${javacpp.version}</version>-->
+<!--      <classifier>${javacpp.platform.windows-x86_64}</classifier>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.bytedeco</groupId>
       <artifactId>mkl-dnn</artifactId>
@@ -73,12 +73,12 @@
       <version>${mkl-dnn.version}</version>
       <classifier>${javacpp.platform.macosx-x86_64}</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.bytedeco</groupId>
-      <artifactId>mkl-dnn</artifactId>
-      <version>${mkl-dnn.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.bytedeco</groupId>-->
+<!--      <artifactId>mkl-dnn</artifactId>-->
+<!--      <version>${mkl-dnn.version}</version>-->
+<!--      <classifier>${javacpp.platform.windows-x86_64}</classifier>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
@@ -96,12 +96,12 @@
       <version>${project.version}</version>
       <classifier>${javacpp.platform.macosx-x86_64.extension}</classifier>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>${project.groupId}</groupId>-->
+<!--      <artifactId>${javacpp.moduleId}</artifactId>-->
+<!--      <version>${project.version}</version>-->
+<!--      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>-->
+<!--    </dependency>-->
   </dependencies>
 
   <build>

--- a/tensorflow-core/tensorflow-core-platform-mkl/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform-mkl/pom.xml
@@ -35,31 +35,72 @@
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>
-      <artifactId>mkl-dnn-platform</artifactId>
-      <version>${mkl-dnn.version}</version>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.macosx-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>mkl-dnn</artifactId>
+      <version>${mkl-dnn.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>mkl-dnn</artifactId>
+      <version>${mkl-dnn.version}</version>
+      <classifier>${javacpp.platform.linux-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>mkl-dnn</artifactId>
+      <version>${mkl-dnn.version}</version>
+      <classifier>${javacpp.platform.macosx-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>mkl-dnn</artifactId>
+      <version>${mkl-dnn.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64}</classifier>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.macosx-x86_64.extension}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
     </dependency>
   </dependencies>
 

--- a/tensorflow-core/tensorflow-core-platform/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform/pom.xml
@@ -34,31 +34,49 @@
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>
-      <artifactId>javacpp-platform</artifactId>
+      <artifactId>javacpp</artifactId>
       <version>${javacpp.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>${javacpp.moduleId}</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
       <classifier>${javacpp.platform.macosx-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>javacpp</artifactId>
+      <version>${javacpp.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64}</classifier>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.macosx-x86_64.extension}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Also disable MKL and CUDA builds for Windows until we get machines for them

But add plain Windows snapshots to the redeploy job on GitHub Actions