### PR TITLE
Add Maven profile for quick development build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,21 @@ on:
   pull_request:
     branches:
       - master
-
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 jobs:
+  quick-build:
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI build')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Build project
+        run: |
+          git --version
+          mvn -version
+          mvn clean install -Pdev -B -U -e
   linux-x86_64:
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: ubuntu-latest
     container: nvidia/cuda:10.1-cudnn7-devel-centos7
     strategy:
@@ -46,6 +58,7 @@ jobs:
           mvn clean $MAVEN_PHASE -Possrh -B -U -e -Djavacpp.platform=linux-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
           df -h
   macosx-x86_64:
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: macos-latest
     strategy:
       matrix:
@@ -74,10 +87,11 @@ jobs:
           mvn clean $MAVEN_PHASE -Possrh -B -U -e -Djavacpp.platform=macosx-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }}
           df -h
   windows-x86_64:
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: windows-latest
-#    strategy:
-#      matrix:
-#        ext: ["", -mkl, -gpu, -mkl-gpu]
+    #    strategy:
+    #      matrix:
+    #        ext: ["", -mkl, -gpu, -mkl-gpu]
     steps:
       - name: Configure page file
         uses: al-cheb/configure-pagefile-action@v1.2

--- a/README.md
+++ b/README.md
@@ -42,11 +42,19 @@ the Maven command of your choice). It is also possible to build artifacts with s
 `mvn install -Djavacpp.platform.extension=-mkl` or CUDA with `mvn install -Djavacpp.platform.extension=-gpu`
 or both with `mvn install -Djavacpp.platform.extension=-mkl-gpu`.
 
-Note that in some cases, if a version of the TensorFlow runtime library is not found for your environment,
-this process will fetch TensorFlow sources and trigger a build of all the native code (which can take
-many hours on a standard laptop). In this case, you will also need to have a valid environment for building
-TensorFlow, including the [bazel](https://bazel.build/) build tool and a few python dependencies. Please
-read [TensorFlow documentation](https://www.tensorflow.org/install/source) for more details.
+When building this project for the first time in a given workspace, the script will attempt to download
+the [TensorFlow runtime library sources](https://github.com/tensorflow/tensorflow) and build of all the native code
+for your platform. This requires a valid environment for building TensorFlow, including the [bazel](https://bazel.build/)
+build tool and a few Python dependencies (please read [TensorFlow documentation](https://www.tensorflow.org/install/source)
+for more details).
+
+This step can take multiple hours on a regular laptop. It is possible though to skip completely the native build if you are
+working on a version that already has pre-compiled native artifacts for your platform [available on Sonatype OSS Nexus repository](#Snapshots).
+You just need to activate the `dev` profile in your Maven command to use those artifacts instead of building them from scratch
+(e.g. `mvn install -Pdev`).
+
+Note that modifying any source files under `tensorflow-core` may impact the low-level TensorFlow bindings, in which case a
+complete build could be required to reflect the changes.
 
 ## Using Maven Artifacts
 

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -70,6 +70,33 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <!--
+    Dev Profile
+      This profile skips the native libraries build and other resource-consuming tasks for local
+      development. Note that any changes to the code that may impact low-level bindings with
+      the TensorFlow runtime library will require a complete build, in which case this profile
+      cannot be used.
+    -->
+    <profile>
+      <id>dev</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-api</artifactId>
+          <version>${project.version}</version>
+          <classifier>${native.classifier}</classifier>
+        </dependency>
+      </dependencies>
+      <properties>
+        <javacpp.build.skip>true</javacpp.build.skip>
+        <javacpp.parser.skip>true</javacpp.parser.skip>
+        <javacpp.compiler.skip>true</javacpp.compiler.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+      </properties>
+    </profile>
+  </profiles>
+  
   <build>
     <plugins>
       <plugin>
@@ -323,9 +350,6 @@
             -Djava.library.path=${project.build.directory}/native/org/tensorflow/internal/c_api/${native.classifier}
           </argLine>
           <additionalClasspathElements>${project.build.directory}/native/</additionalClasspathElements>
-          <systemPropertyVariables>
-            <NATIVE_PLATFORM>${javacpp.platform}</NATIVE_PLATFORM>
-          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR adds a new Maven profile to facilitate the environment setup for developers by skipping the native library build completely and fetching pre-compiled native artifacts from Nexus instead.

This profile is also applied by default for all incoming pull requests to `master`, which in most case do not require a complete build status check to be approved and will release some of our limited resources on GitHub Action. It is still possible though to build the native libraries on a given pull request by adding the `CI build` label to it.

I've picked the name `dev` for this profile as I wanted something very brief since, while not being applied by default, this profile might be used very often by developers.