### PR TITLE
Copy NdArrays to standard arrays of n-dimensions

### DIFF
--- a/ndarray/pom.xml
+++ b/ndarray/pom.xml
@@ -29,9 +29,7 @@
 
   <name>TensorFlow NdArray Library</name>
   <description>
-    Utility library used by TensorFlow Java for n-dimensional data I/O operations. This library does
-    not depend on the TensorFlow runtime and therefore can be included by any other projects outside
-    the TensorFlow organization.
+    Utility library for N-dimensional data I/O operations.
   </description>
 
   <dependencies>

--- a/ndarray/src/main/java/org/tensorflow/ndarray/NdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/NdArray.java
@@ -106,7 +106,10 @@ public interface NdArray<T> {
    *    });
    * }</pre>
    *
+   * @params dimensionIdx index of the dimension
    * @return an {@code NdArray} sequence
+   * @throws IllegalArgumentException if {@code dimensionIdx} is greater or equal to the total
+   *                                  number of dimensions of this array
    */
   NdArraySequence<? extends NdArray<T>> elements(int dimensionIdx);
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
@@ -2,6 +2,9 @@ package org.tensorflow.ndarray;
 
 import static org.tensorflow.ndarray.NdArrays.vectorOf;
 
+import java.lang.reflect.Array;
+import org.tensorflow.ndarray.buffer.DataBuffers;
+
 /**
  * Utility class for working with {@link NdArray} instances mixed with standard Java arrays.
  */
@@ -15,7 +18,7 @@ public final class StdArrays {
    */
   public static IntNdArray ndCopyOf(int[] array) {
     IntNdArray ndArray = NdArrays.ofInts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -27,7 +30,7 @@ public final class StdArrays {
    */
   public static IntNdArray ndCopyOf(int[][] array) {
     IntNdArray ndArray = NdArrays.ofInts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -39,7 +42,7 @@ public final class StdArrays {
    */
   public static IntNdArray ndCopyOf(int[][][] array) {
     IntNdArray ndArray = NdArrays.ofInts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -51,7 +54,7 @@ public final class StdArrays {
    */
   public static IntNdArray ndCopyOf(int[][][][] array) {
     IntNdArray ndArray = NdArrays.ofInts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -63,7 +66,7 @@ public final class StdArrays {
    */
   public static IntNdArray ndCopyOf(int[][][][][] array) {
     IntNdArray ndArray = NdArrays.ofInts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -75,7 +78,7 @@ public final class StdArrays {
    */
   public static IntNdArray ndCopyOf(int[][][][][][] array) {
     IntNdArray ndArray = NdArrays.ofInts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -87,7 +90,7 @@ public final class StdArrays {
    */
   public static LongNdArray ndCopyOf(long[] array) {
     LongNdArray ndArray = NdArrays.ofLongs(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -99,7 +102,7 @@ public final class StdArrays {
    */
   public static LongNdArray ndCopyOf(long[][] array) {
     LongNdArray ndArray = NdArrays.ofLongs(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -111,7 +114,7 @@ public final class StdArrays {
    */
   public static LongNdArray ndCopyOf(long[][][] array) {
     LongNdArray ndArray = NdArrays.ofLongs(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -123,7 +126,7 @@ public final class StdArrays {
    */
   public static LongNdArray ndCopyOf(long[][][][] array) {
     LongNdArray ndArray = NdArrays.ofLongs(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -135,7 +138,7 @@ public final class StdArrays {
    */
   public static LongNdArray ndCopyOf(long[][][][][] array) {
     LongNdArray ndArray = NdArrays.ofLongs(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -147,7 +150,7 @@ public final class StdArrays {
    */
   public static LongNdArray ndCopyOf(long[][][][][][] array) {
     LongNdArray ndArray = NdArrays.ofLongs(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -159,7 +162,7 @@ public final class StdArrays {
    */
   public static FloatNdArray ndCopyOf(float[] array) {
     FloatNdArray ndArray = NdArrays.ofFloats(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -171,7 +174,7 @@ public final class StdArrays {
    */
   public static FloatNdArray ndCopyOf(float[][] array) {
     FloatNdArray ndArray = NdArrays.ofFloats(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -183,7 +186,7 @@ public final class StdArrays {
    */
   public static FloatNdArray ndCopyOf(float[][][] array) {
     FloatNdArray ndArray = NdArrays.ofFloats(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -195,7 +198,7 @@ public final class StdArrays {
    */
   public static FloatNdArray ndCopyOf(float[][][][] array) {
     FloatNdArray ndArray = NdArrays.ofFloats(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -207,7 +210,7 @@ public final class StdArrays {
    */
   public static FloatNdArray ndCopyOf(float[][][][][] array) {
     FloatNdArray ndArray = NdArrays.ofFloats(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -219,7 +222,7 @@ public final class StdArrays {
    */
   public static FloatNdArray ndCopyOf(float[][][][][][] array) {
     FloatNdArray ndArray = NdArrays.ofFloats(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -231,7 +234,7 @@ public final class StdArrays {
    */
   public static DoubleNdArray ndCopyOf(double[] array) {
     DoubleNdArray ndArray = NdArrays.ofDoubles(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -243,7 +246,7 @@ public final class StdArrays {
    */
   public static DoubleNdArray ndCopyOf(double[][] array) {
     DoubleNdArray ndArray = NdArrays.ofDoubles(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -255,7 +258,7 @@ public final class StdArrays {
    */
   public static DoubleNdArray ndCopyOf(double[][][] array) {
     DoubleNdArray ndArray = NdArrays.ofDoubles(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -267,7 +270,7 @@ public final class StdArrays {
    */
   public static DoubleNdArray ndCopyOf(double[][][][] array) {
     DoubleNdArray ndArray = NdArrays.ofDoubles(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -279,7 +282,7 @@ public final class StdArrays {
    */
   public static DoubleNdArray ndCopyOf(double[][][][][] array) {
     DoubleNdArray ndArray = NdArrays.ofDoubles(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -291,7 +294,7 @@ public final class StdArrays {
    */
   public static DoubleNdArray ndCopyOf(double[][][][][][] array) {
     DoubleNdArray ndArray = NdArrays.ofDoubles(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -303,7 +306,7 @@ public final class StdArrays {
    */
   public static ByteNdArray ndCopyOf(byte[] array) {
     ByteNdArray ndArray = NdArrays.ofBytes(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -315,7 +318,7 @@ public final class StdArrays {
    */
   public static ByteNdArray ndCopyOf(byte[][] array) {
     ByteNdArray ndArray = NdArrays.ofBytes(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -327,7 +330,7 @@ public final class StdArrays {
    */
   public static ByteNdArray ndCopyOf(byte[][][] array) {
     ByteNdArray ndArray = NdArrays.ofBytes(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -339,7 +342,7 @@ public final class StdArrays {
    */
   public static ByteNdArray ndCopyOf(byte[][][][] array) {
     ByteNdArray ndArray = NdArrays.ofBytes(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -351,7 +354,7 @@ public final class StdArrays {
    */
   public static ByteNdArray ndCopyOf(byte[][][][][] array) {
     ByteNdArray ndArray = NdArrays.ofBytes(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -363,7 +366,7 @@ public final class StdArrays {
    */
   public static ByteNdArray ndCopyOf(byte[][][][][][] array) {
     ByteNdArray ndArray = NdArrays.ofBytes(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -375,7 +378,7 @@ public final class StdArrays {
    */
   public static ShortNdArray ndCopyOf(short[] array) {
     ShortNdArray ndArray = NdArrays.ofShorts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -387,7 +390,7 @@ public final class StdArrays {
    */
   public static ShortNdArray ndCopyOf(short[][] array) {
     ShortNdArray ndArray = NdArrays.ofShorts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -399,7 +402,7 @@ public final class StdArrays {
    */
   public static ShortNdArray ndCopyOf(short[][][] array) {
     ShortNdArray ndArray = NdArrays.ofShorts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -411,7 +414,7 @@ public final class StdArrays {
    */
   public static ShortNdArray ndCopyOf(short[][][][] array) {
     ShortNdArray ndArray = NdArrays.ofShorts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -423,7 +426,7 @@ public final class StdArrays {
    */
   public static ShortNdArray ndCopyOf(short[][][][][] array) {
     ShortNdArray ndArray = NdArrays.ofShorts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -435,7 +438,7 @@ public final class StdArrays {
    */
   public static ShortNdArray ndCopyOf(short[][][][][][] array) {
     ShortNdArray ndArray = NdArrays.ofShorts(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -447,7 +450,7 @@ public final class StdArrays {
    */
   public static BooleanNdArray ndCopyOf(boolean[] array) {
     BooleanNdArray ndArray = NdArrays.ofBooleans(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -459,7 +462,7 @@ public final class StdArrays {
    */
   public static BooleanNdArray ndCopyOf(boolean[][] array) {
     BooleanNdArray ndArray = NdArrays.ofBooleans(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -471,7 +474,7 @@ public final class StdArrays {
    */
   public static BooleanNdArray ndCopyOf(boolean[][][] array) {
     BooleanNdArray ndArray = NdArrays.ofBooleans(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -483,7 +486,7 @@ public final class StdArrays {
    */
   public static BooleanNdArray ndCopyOf(boolean[][][][] array) {
     BooleanNdArray ndArray = NdArrays.ofBooleans(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -495,7 +498,7 @@ public final class StdArrays {
    */
   public static BooleanNdArray ndCopyOf(boolean[][][][][] array) {
     BooleanNdArray ndArray = NdArrays.ofBooleans(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -507,7 +510,7 @@ public final class StdArrays {
    */
   public static BooleanNdArray ndCopyOf(boolean[][][][][][] array) {
     BooleanNdArray ndArray = NdArrays.ofBooleans(shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -520,7 +523,7 @@ public final class StdArrays {
   public static <T> NdArray<T> ndCopyOf(T[] array) {
     @SuppressWarnings("unchecked")
     NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -533,7 +536,7 @@ public final class StdArrays {
   public static <T> NdArray<T> ndCopyOf(T[][] array) {
     @SuppressWarnings("unchecked")
     NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -546,7 +549,7 @@ public final class StdArrays {
   public static <T> NdArray<T> ndCopyOf(T[][][] array) {
     @SuppressWarnings("unchecked")
     NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -559,7 +562,7 @@ public final class StdArrays {
   public static <T> NdArray<T> ndCopyOf(T[][][][] array) {
     @SuppressWarnings("unchecked")
     NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -572,7 +575,7 @@ public final class StdArrays {
   public static <T> NdArray<T> ndCopyOf(T[][][][][] array) {
     @SuppressWarnings("unchecked")
     NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
   }
 
@@ -585,663 +588,2216 @@ public final class StdArrays {
   public static <T> NdArray<T> ndCopyOf(T[][][][][][] array) {
     @SuppressWarnings("unchecked")
     NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
-    copyTo(ndArray, array);
+    copyTo(array, ndArray);
     return ndArray;
+  }
+
+  /**
+   * Copy a {@link IntNdArray} in a new 1-dimension standard array of ints
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static int[] array1dCopyOf(IntNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 1);
+    int[] array = new int[dims[0]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link IntNdArray} in a new 2-dimension standard array of ints
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static int[][] array2dCopyOf(IntNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 2);
+    int[][] array = new int[dims[0]][dims[1]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link IntNdArray} in a new 3-dimension standard array of ints
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static int[][][] array3dCopyOf(IntNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 3);
+    int[][][] array = new int[dims[0]][dims[1]][dims[2]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link IntNdArray} in a new 4-dimension standard array of ints
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static int[][][][] array4dCopyOf(IntNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 4);
+    int[][][][] array = new int[dims[0]][dims[1]][dims[2]][dims[3]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link IntNdArray} in a new 5-dimension standard array of ints
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static int[][][][][] array5dCopyOf(IntNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 5);
+    int[][][][][] array = new int[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link IntNdArray} in a new 6-dimension standard array of ints
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static int[][][][][][] array6dCopyOf(IntNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 6);
+    int[][][][][][] array = new int[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]][dims[5]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link LongNdArray} in a new 1-dimension standard array of longs
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static long[] array1dCopyOf(LongNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 1);
+    long[] array = new long[dims[0]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link LongNdArray} in a new 2-dimension standard array of longs
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static long[][] array2dCopyOf(LongNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 2);
+    long[][] array = new long[dims[0]][dims[1]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link LongNdArray} in a new 3-dimension standard array of longs
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static long[][][] array3dCopyOf(LongNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 3);
+    long[][][] array = new long[dims[0]][dims[1]][dims[2]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link LongNdArray} in a new 4-dimension standard array of longs
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static long[][][][] array4dCopyOf(LongNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 4);
+    long[][][][] array = new long[dims[0]][dims[1]][dims[2]][dims[3]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link LongNdArray} in a new 5-dimension standard array of longs
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static long[][][][][] array5dCopyOf(LongNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 5);
+    long[][][][][] array = new long[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link LongNdArray} in a new 6-dimension standard array of longs
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static long[][][][][][] array6dCopyOf(LongNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 6);
+    long[][][][][][] array = new long[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]][dims[5]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link FloatNdArray} in a new 1-dimension standard array of floats
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static float[] array1dCopyOf(FloatNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 1);
+    float[] array = new float[dims[0]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link FloatNdArray} in a new 2-dimension standard array of floats
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static float[][] array2dCopyOf(FloatNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 2);
+    float[][] array = new float[dims[0]][dims[1]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link FloatNdArray} in a new 3-dimension standard array of floats
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static float[][][] array3dCopyOf(FloatNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 3);
+    float[][][] array = new float[dims[0]][dims[1]][dims[2]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link FloatNdArray} in a new 4-dimension standard array of floats
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static float[][][][] array4dCopyOf(FloatNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 4);
+    float[][][][] array = new float[dims[0]][dims[1]][dims[2]][dims[3]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link FloatNdArray} in a new 5-dimension standard array of floats
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static float[][][][][] array5dCopyOf(FloatNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 5);
+    float[][][][][] array = new float[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link FloatNdArray} in a new 6-dimension standard array of floats
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static float[][][][][][] array6dCopyOf(FloatNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 6);
+    float[][][][][][] array = new float[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]][dims[5]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link DoubleNdArray} in a new 1-dimension standard array of doubles
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static double[] array1dCopyOf(DoubleNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 1);
+    double[] array = new double[dims[0]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link DoubleNdArray} in a new 2-dimension standard array of doubles
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static double[][] array2dCopyOf(DoubleNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 2);
+    double[][] array = new double[dims[0]][dims[1]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link DoubleNdArray} in a new 3-dimension standard array of doubles
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static double[][][] array3dCopyOf(DoubleNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 3);
+    double[][][] array = new double[dims[0]][dims[1]][dims[2]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link DoubleNdArray} in a new 4-dimension standard array of doubles
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static double[][][][] array4dCopyOf(DoubleNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 4);
+    double[][][][] array = new double[dims[0]][dims[1]][dims[2]][dims[3]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link DoubleNdArray} in a new 5-dimension standard array of doubles
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static double[][][][][] array5dCopyOf(DoubleNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 5);
+    double[][][][][] array = new double[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link DoubleNdArray} in a new 6-dimension standard array of doubles
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static double[][][][][][] array6dCopyOf(DoubleNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 6);
+    double[][][][][][] array = new double[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]][dims[5]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ByteNdArray} in a new 1-dimension standard array of bytes
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static byte[] array1dCopyOf(ByteNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 1);
+    byte[] array = new byte[dims[0]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ByteNdArray} in a new 2-dimension standard array of bytes
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static byte[][] array2dCopyOf(ByteNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 2);
+    byte[][] array = new byte[dims[0]][dims[1]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ByteNdArray} in a new 3-dimension standard array of bytes
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static byte[][][] array3dCopyOf(ByteNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 3);
+    byte[][][] array = new byte[dims[0]][dims[1]][dims[2]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ByteNdArray} in a new 4-dimension standard array of bytes
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static byte[][][][] array4dCopyOf(ByteNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 4);
+    byte[][][][] array = new byte[dims[0]][dims[1]][dims[2]][dims[3]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ByteNdArray} in a new 5-dimension standard array of bytes
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static byte[][][][][] array5dCopyOf(ByteNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 5);
+    byte[][][][][] array = new byte[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ByteNdArray} in a new 6-dimension standard array of bytes
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static byte[][][][][][] array6dCopyOf(ByteNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 6);
+    byte[][][][][][] array = new byte[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]][dims[5]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ShortNdArray} in a new 1-dimension standard array of shorts
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static short[] array1dCopyOf(ShortNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 1);
+    short[] array = new short[dims[0]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ShortNdArray} in a new 2-dimension standard array of shorts
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static short[][] array2dCopyOf(ShortNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 2);
+    short[][] array = new short[dims[0]][dims[1]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ShortNdArray} in a new 3-dimension standard array of shorts
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static short[][][] array3dCopyOf(ShortNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 3);
+    short[][][] array = new short[dims[0]][dims[1]][dims[2]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ShortNdArray} in a new 4-dimension standard array of shorts
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static short[][][][] array4dCopyOf(ShortNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 4);
+    short[][][][] array = new short[dims[0]][dims[1]][dims[2]][dims[3]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ShortNdArray} in a new 5-dimension standard array of shorts
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static short[][][][][] array5dCopyOf(ShortNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 5);
+    short[][][][][] array = new short[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link ShortNdArray} in a new 6-dimension standard array of shorts
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static short[][][][][][] array6dCopyOf(ShortNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 6);
+    short[][][][][][] array = new short[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]][dims[5]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link BooleanNdArray} in a new 1-dimension standard array of booleans
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static boolean[] array1dCopyOf(BooleanNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 1);
+    boolean[] array = new boolean[dims[0]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link BooleanNdArray} in a new 2-dimension standard array of booleans
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static boolean[][] array2dCopyOf(BooleanNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 2);
+    boolean[][] array = new boolean[dims[0]][dims[1]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link BooleanNdArray} in a new 3-dimension standard array of booleans
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static boolean[][][] array3dCopyOf(BooleanNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 3);
+    boolean[][][] array = new boolean[dims[0]][dims[1]][dims[2]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link BooleanNdArray} in a new 4-dimension standard array of booleans
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static boolean[][][][] array4dCopyOf(BooleanNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 4);
+    boolean[][][][] array = new boolean[dims[0]][dims[1]][dims[2]][dims[3]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link BooleanNdArray} in a new 5-dimension standard array of booleans
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static boolean[][][][][] array5dCopyOf(BooleanNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 5);
+    boolean[][][][][] array = new boolean[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link BooleanNdArray} in a new 6-dimension standard array of booleans
+   *
+   * @param ndArray source array
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static boolean[][][][][][] array6dCopyOf(BooleanNdArray ndArray) {
+    int[] dims = computeArrayDims(ndArray, 6);
+    boolean[][][][][][] array = new boolean[dims[0]][dims[1]][dims[2]][dims[3]][dims[4]][dims[5]];
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link NdArray<T>} in a new 1-dimension standard array of objects
+   *
+   * @param ndArray source array
+   * @param objectType type of object
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static <T> T[] array1dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
+    int[] dims = computeArrayDims(ndArray, 1);
+    T[] array = (T[])Array.newInstance(objectType, dims[0]);
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link NdArray<T>} in a new 2-dimension standard array of objects
+   *
+   * @param ndArray source array
+   * @param objectType type of object
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static <T> T[][] array2dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
+    int[] dims = computeArrayDims(ndArray, 2);
+    T[][] array = (T[][])Array.newInstance(objectType, dims[0], dims[1]);
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link NdArray<T>} in a new 3-dimension standard array of objects
+   *
+   * @param ndArray source array
+   * @param objectType type of object
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static <T> T[][][] array3dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
+    int[] dims = computeArrayDims(ndArray, 3);
+    T[][][] array = (T[][][])Array.newInstance(objectType, dims[0], dims[1], dims[2]);
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link NdArray<T>} in a new 4-dimension standard array of objects
+   *
+   * @param ndArray source array
+   * @param objectType type of object
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static <T> T[][][][] array4dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
+    int[] dims = computeArrayDims(ndArray, 4);
+    T[][][][] array = (T[][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3]);
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link NdArray<T>} in a new 5-dimension standard array of objects
+   *
+   * @param ndArray source array
+   * @param objectType type of object
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static <T> T[][][][][] array5dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
+    int[] dims = computeArrayDims(ndArray, 5);
+    T[][][][][] array =
+        (T[][][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4]);
+    copyFrom(ndArray, array);
+    return array;
+  }
+
+  /**
+   * Copy a {@link NdArray<T>} in a new 6-dimension standard array of objects
+   *
+   * @param ndArray source array
+   * @param objectType type of object
+   * @return the array copy
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
+   */
+  public static <T> T[][][][][][] array6dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
+    int[] dims = computeArrayDims(ndArray, 6);
+    T[][][][][][] array =
+        (T[][][][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4], dims[5]);
+    copyFrom(ndArray, array);
+    return array;
   }
 
   /**
    * Copy a single-dimension array of ints into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-1 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(IntNdArray dst, int[] array) {
-    NdArrays.vectorOf(array).copyTo(dst);
+  public static void copyTo(int[] src, IntNdArray dst) {
+    NdArrays.vectorOf(src).copyTo(dst);
   }
 
   /**
    * Copy a 2-dimensions array of ints into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-2 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(IntNdArray dst, int[][] array) {
+  public static void copyTo(int[][] src, IntNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 3-dimensions array of ints into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-3 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(IntNdArray dst, int[][][] array) {
+  public static void copyTo(int[][][] src, IntNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 4-dimensions array of ints into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-4 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(IntNdArray dst, int[][][][] array) {
+  public static void copyTo(int[][][][] src, IntNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 5-dimensions array of ints into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-5 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(IntNdArray dst, int[][][][][] array) {
+  public static void copyTo(int[][][][][] src, IntNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 6-dimensions array of ints into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-6 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(IntNdArray dst, int[][][][][][] array) {
+  public static void copyTo(int[][][][][][] src, IntNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
   /**
    * Copy a single-dimension array of longs into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-1 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(LongNdArray dst, long[] array) {
-    NdArrays.vectorOf(array).copyTo(dst);
+  public static void copyTo(long[] src, LongNdArray dst) {
+    NdArrays.vectorOf(src).copyTo(dst);
   }
 
   /**
    * Copy a 2-dimensions array of longs into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-2 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(LongNdArray dst, long[][] array) {
+  public static void copyTo(long[][] src, LongNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 3-dimensions array of longs into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-3 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(LongNdArray dst, long[][][] array) {
+  public static void copyTo(long[][][] src, LongNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 4-dimensions array of longs into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-4 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(LongNdArray dst, long[][][][] array) {
+  public static void copyTo(long[][][][] src, LongNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 5-dimensions array of longs into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-5 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(LongNdArray dst, long[][][][][] array) {
+  public static void copyTo(long[][][][][] src, LongNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 6-dimensions array of longs into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-6 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(LongNdArray dst, long[][][][][][] array) {
+  public static void copyTo(long[][][][][][] src, LongNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
   /**
    * Copy a single-dimension array of floats into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-1 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(FloatNdArray dst, float[] array) {
-    NdArrays.vectorOf(array).copyTo(dst);
+  public static void copyTo(float[] src, FloatNdArray dst) {
+    NdArrays.vectorOf(src).copyTo(dst);
   }
 
   /**
    * Copy a 2-dimensions array of floats into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-2 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(FloatNdArray dst, float[][] array) {
+  public static void copyTo(float[][] src, FloatNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 3-dimensions array of floats into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-3 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(FloatNdArray dst, float[][][] array) {
+  public static void copyTo(float[][][] src, FloatNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 4-dimensions array of floats into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-4 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(FloatNdArray dst, float[][][][] array) {
+  public static void copyTo(float[][][][] src, FloatNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 5-dimensions array of floats into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-5 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(FloatNdArray dst, float[][][][][] array) {
+  public static void copyTo(float[][][][][] src, FloatNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 6-dimensions array of floats into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-6 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(FloatNdArray dst, float[][][][][][] array) {
+  public static void copyTo(float[][][][][][] src, FloatNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
   /**
    * Copy a single-dimension array of doubles into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-1 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(DoubleNdArray dst, double[] array) {
-    NdArrays.vectorOf(array).copyTo(dst);
+  public static void copyTo(double[] src, DoubleNdArray dst) {
+    NdArrays.vectorOf(src).copyTo(dst);
   }
 
   /**
    * Copy a 2-dimensions array of doubles into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-2 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(DoubleNdArray dst, double[][] array) {
+  public static void copyTo(double[][] src, DoubleNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 3-dimensions array of doubles into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-3 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(DoubleNdArray dst, double[][][] array) {
+  public static void copyTo(double[][][] src, DoubleNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 4-dimensions array of doubles into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-4 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(DoubleNdArray dst, double[][][][] array) {
+  public static void copyTo(double[][][][] src, DoubleNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 5-dimensions array of doubles into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-5 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(DoubleNdArray dst, double[][][][][] array) {
+  public static void copyTo(double[][][][][] src, DoubleNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 6-dimensions array of doubles into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-6 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(DoubleNdArray dst, double[][][][][][] array) {
+  public static void copyTo(double[][][][][][] src, DoubleNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
   /**
    * Copy a single-dimension array of bytes into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-1 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ByteNdArray dst, byte[] array) {
-    NdArrays.vectorOf(array).copyTo(dst);
+  public static void copyTo(byte[] src, ByteNdArray dst) {
+    NdArrays.vectorOf(src).copyTo(dst);
   }
 
   /**
    * Copy a 2-dimensions array of bytes into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-2 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ByteNdArray dst, byte[][] array) {
+  public static void copyTo(byte[][] src, ByteNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 3-dimensions array of bytes into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-3 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ByteNdArray dst, byte[][][] array) {
+  public static void copyTo(byte[][][] src, ByteNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 4-dimensions array of bytes into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-4 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ByteNdArray dst, byte[][][][] array) {
+  public static void copyTo(byte[][][][] src, ByteNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 5-dimensions array of bytes into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-5 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ByteNdArray dst, byte[][][][][] array) {
+  public static void copyTo(byte[][][][][] src, ByteNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 6-dimensions array of bytes into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-6 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ByteNdArray dst, byte[][][][][][] array) {
+  public static void copyTo(byte[][][][][][] src, ByteNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
   /**
    * Copy a single-dimension array of shorts into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-1 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ShortNdArray dst, short[] array) {
-    NdArrays.vectorOf(array).copyTo(dst);
+  public static void copyTo(short[] src, ShortNdArray dst) {
+    NdArrays.vectorOf(src).copyTo(dst);
   }
 
   /**
    * Copy a 2-dimensions array of shorts into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-2 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ShortNdArray dst, short[][] array) {
+  public static void copyTo(short[][] src, ShortNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 3-dimensions array of shorts into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-3 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ShortNdArray dst, short[][][] array) {
+  public static void copyTo(short[][][] src, ShortNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 4-dimensions array of shorts into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-4 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ShortNdArray dst, short[][][][] array) {
+  public static void copyTo(short[][][][] src, ShortNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 5-dimensions array of shorts into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-5 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ShortNdArray dst, short[][][][][] array) {
+  public static void copyTo(short[][][][][] src, ShortNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 6-dimensions array of shorts into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-6 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(ShortNdArray dst, short[][][][][][] array) {
+  public static void copyTo(short[][][][][][] src, ShortNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
   /**
    * Copy a single-dimension array of booleans into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-1 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(BooleanNdArray dst, boolean[] array) {
-    NdArrays.vectorOf(array).copyTo(dst);
+  public static void copyTo(boolean[] src, BooleanNdArray dst) {
+    NdArrays.vectorOf(src).copyTo(dst);
   }
 
   /**
    * Copy a 2-dimensions array of booleans into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-2 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(BooleanNdArray dst, boolean[][] array) {
+  public static void copyTo(boolean[][] src, BooleanNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 3-dimensions array of booleans into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-3 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(BooleanNdArray dst, boolean[][][] array) {
+  public static void copyTo(boolean[][][] src, BooleanNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 4-dimensions array of booleans into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-4 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(BooleanNdArray dst, boolean[][][][] array) {
+  public static void copyTo(boolean[][][][] src, BooleanNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 5-dimensions array of booleans into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-5 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(BooleanNdArray dst, boolean[][][][][] array) {
+  public static void copyTo(boolean[][][][][] src, BooleanNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 6-dimensions array of booleans into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-6 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
    *                                  with the source array
    */
-  public static void copyTo(BooleanNdArray dst, boolean[][][][][][] array) {
+  public static void copyTo(boolean[][][][][][] src, BooleanNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
   /**
    * Copy a single-dimension array of objects into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-1 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
    *                                  with the source array
    */
-  public static <T> void copyTo(NdArray<T> dst, T[] array) {
-    NdArrays.vectorOfObjects(array).copyTo(dst);
+  public static <T> void copyTo(T[] src, NdArray<T> dst) {
+    NdArrays.vectorOfObjects(src).copyTo(dst);
   }
 
   /**
    * Copy a 2-dimensions array of objects into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-2 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
    *                                  with the source array
    */
-  public static <T> void copyTo(NdArray<T> dst, T[][] array) {
+  public static <T> void copyTo(T[][] src, NdArray<T> dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(array[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 3-dimensions array of objects into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-3 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
    *                                  with the source array
    */
-  public static <T> void copyTo(NdArray<T> dst, T[][][] array) {
+  public static <T> void copyTo(T[][][] src, NdArray<T> dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(array[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 4-dimensions array of objects into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-4 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
    *                                  with the source array
    */
-  public static <T> void copyTo(NdArray<T> dst, T[][][][] array) {
+  public static <T> void copyTo(T[][][][] src, NdArray<T> dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(array[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 5-dimensions array of objects into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-5 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
    *                                  with the source array
    */
-  public static <T> void copyTo(NdArray<T> dst, T[][][][][] array) {
+  public static <T> void copyTo(T[][][][][] src, NdArray<T> dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
   /**
    * Copy a 6-dimensions array of objects into the {@code dst} {@link NdArray}
    *
+   * @param src source array
    * @param dst destination rank-6 array
-   * @param array source array
    * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
    *                                  with the source array
    */
-  public static <T> void copyTo(NdArray<T> dst, T[][][][][][] array) {
+  public static <T> void copyTo(T[][][][][][] src, NdArray<T> dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(array[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+    );
+  }
+
+
+  /**
+   * Copy a {@link NdArray} to a single-dimension array of ints
+   *
+   * @param src source rank-1 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-1
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(IntNdArray src, int[] dst) {
+    if (src.rank() != 1) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    if (src.size() > dst.length) {
+      throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
+    }
+    src.read(DataBuffers.of(dst, false, false));
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 2-dimensions array of ints
+   *
+   * @param src source rank-2 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-2
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(IntNdArray src, int[][] dst) {
+    if (src.rank() != 2) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(0).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 3-dimensions array of ints
+   *
+   * @param src source rank-3 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-3
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(IntNdArray src, int[][][] dst) {
+    if (src.rank() != 3) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(1).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 4-dimensions array of ints
+   *
+   * @param src source rank-4 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-4
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(IntNdArray src, int[][][][] dst) {
+    if (src.rank() != 4) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(2).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 5-dimensions array of ints
+   *
+   * @param src source rank-5 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-5
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(IntNdArray src, int[][][][][] dst) {
+    if (src.rank() != 5) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(3).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 6-dimensions array of ints
+   *
+   * @param src source rank-6 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-6
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(IntNdArray src, int[][][][][][] dst) {
+    if (src.rank() != 6) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(4).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a single-dimension array of longs
+   *
+   * @param src source rank-1 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-1
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(LongNdArray src, long[] dst) {
+    if (src.rank() != 1) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    if (src.size() > dst.length) {
+      throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
+    }
+    src.read(DataBuffers.of(dst, false, false));
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 2-dimensions array of longs
+   *
+   * @param src source rank-2 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-2
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(LongNdArray src, long[][] dst) {
+    if (src.rank() != 2) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(0).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 3-dimensions array of longs
+   *
+   * @param src source rank-3 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-3
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(LongNdArray src, long[][][] dst) {
+    if (src.rank() != 3) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(1).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 4-dimensions array of longs
+   *
+   * @param src source rank-4 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-4
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(LongNdArray src, long[][][][] dst) {
+    if (src.rank() != 4) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(2).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 5-dimensions array of longs
+   *
+   * @param src source rank-5 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-5
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(LongNdArray src, long[][][][][] dst) {
+    if (src.rank() != 5) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(3).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 6-dimensions array of longs
+   *
+   * @param src source rank-6 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-6
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(LongNdArray src, long[][][][][][] dst) {
+    if (src.rank() != 6) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(4).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a single-dimension array of floats
+   *
+   * @param src source rank-1 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-1
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(FloatNdArray src, float[] dst) {
+    if (src.rank() != 1) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    if (src.size() > dst.length) {
+      throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
+    }
+    src.read(DataBuffers.of(dst, false, false));
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 2-dimensions array of floats
+   *
+   * @param src source rank-2 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-2
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(FloatNdArray src, float[][] dst) {
+    if (src.rank() != 2) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(0).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 3-dimensions array of floats
+   *
+   * @param src source rank-3 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-3
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(FloatNdArray src, float[][][] dst) {
+    if (src.rank() != 3) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(1).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 4-dimensions array of floats
+   *
+   * @param src source rank-4 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-4
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(FloatNdArray src, float[][][][] dst) {
+    if (src.rank() != 4) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(2).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 5-dimensions array of floats
+   *
+   * @param src source rank-5 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-5
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(FloatNdArray src, float[][][][][] dst) {
+    if (src.rank() != 5) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(3).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 6-dimensions array of floats
+   *
+   * @param src source rank-6 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-6
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(FloatNdArray src, float[][][][][][] dst) {
+    if (src.rank() != 6) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(4).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a single-dimension array of doubles
+   *
+   * @param src source rank-1 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-1
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(DoubleNdArray src, double[] dst) {
+    if (src.rank() != 1) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    if (src.size() > dst.length) {
+      throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
+    }
+    src.read(DataBuffers.of(dst, false, false));
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 2-dimensions array of doubles
+   *
+   * @param src source rank-2 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-2
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(DoubleNdArray src, double[][] dst) {
+    if (src.rank() != 2) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(0).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 3-dimensions array of doubles
+   *
+   * @param src source rank-3 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-3
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(DoubleNdArray src, double[][][] dst) {
+    if (src.rank() != 3) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(1).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 4-dimensions array of doubles
+   *
+   * @param src source rank-4 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-4
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(DoubleNdArray src, double[][][][] dst) {
+    if (src.rank() != 4) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(2).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 5-dimensions array of doubles
+   *
+   * @param src source rank-5 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-5
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(DoubleNdArray src, double[][][][][] dst) {
+    if (src.rank() != 5) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(3).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 6-dimensions array of doubles
+   *
+   * @param src source rank-6 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-6
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(DoubleNdArray src, double[][][][][][] dst) {
+    if (src.rank() != 6) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(4).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a single-dimension array of bytes
+   *
+   * @param src source rank-1 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-1
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ByteNdArray src, byte[] dst) {
+    if (src.rank() != 1) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    if (src.size() > dst.length) {
+      throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
+    }
+    src.read(DataBuffers.of(dst, false, false));
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 2-dimensions array of bytes
+   *
+   * @param src source rank-2 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-2
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ByteNdArray src, byte[][] dst) {
+    if (src.rank() != 2) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(0).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 3-dimensions array of bytes
+   *
+   * @param src source rank-3 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-3
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ByteNdArray src, byte[][][] dst) {
+    if (src.rank() != 3) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(1).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 4-dimensions array of bytes
+   *
+   * @param src source rank-4 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-4
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ByteNdArray src, byte[][][][] dst) {
+    if (src.rank() != 4) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(2).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 5-dimensions array of bytes
+   *
+   * @param src source rank-5 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-5
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ByteNdArray src, byte[][][][][] dst) {
+    if (src.rank() != 5) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(3).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 6-dimensions array of bytes
+   *
+   * @param src source rank-6 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-6
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ByteNdArray src, byte[][][][][][] dst) {
+    if (src.rank() != 6) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(4).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a single-dimension array of shorts
+   *
+   * @param src source rank-1 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-1
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ShortNdArray src, short[] dst) {
+    if (src.rank() != 1) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    if (src.size() > dst.length) {
+      throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
+    }
+    src.read(DataBuffers.of(dst, false, false));
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 2-dimensions array of shorts
+   *
+   * @param src source rank-2 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-2
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ShortNdArray src, short[][] dst) {
+    if (src.rank() != 2) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(0).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 3-dimensions array of shorts
+   *
+   * @param src source rank-3 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-3
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ShortNdArray src, short[][][] dst) {
+    if (src.rank() != 3) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(1).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 4-dimensions array of shorts
+   *
+   * @param src source rank-4 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-4
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ShortNdArray src, short[][][][] dst) {
+    if (src.rank() != 4) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(2).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 5-dimensions array of shorts
+   *
+   * @param src source rank-5 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-5
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ShortNdArray src, short[][][][][] dst) {
+    if (src.rank() != 5) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(3).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 6-dimensions array of shorts
+   *
+   * @param src source rank-6 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-6
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(ShortNdArray src, short[][][][][][] dst) {
+    if (src.rank() != 6) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(4).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a single-dimension array of booleans.
+   *
+   * @param src source rank-1 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-1
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(BooleanNdArray src, boolean[] dst) {
+    if (src.rank() != 1) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    if (src.size() > dst.length) {
+      throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
+    }
+    src.read(DataBuffers.of(dst, false, false));
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 2-dimensions array of booleans
+   *
+   * @param src source rank-2 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-2
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(BooleanNdArray src, boolean[][] dst) {
+    if (src.rank() != 2) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(0).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 3-dimensions array of booleans
+   *
+   * @param src source rank-3 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-3
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(BooleanNdArray src, boolean[][][] dst) {
+    if (src.rank() != 3) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(1).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 4-dimensions array of booleans
+   *
+   * @param src source rank-4 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-4
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(BooleanNdArray src, boolean[][][][] dst) {
+    if (src.rank() != 4) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(2).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 5-dimensions array of booleans
+   *
+   * @param src source rank-5 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-5
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(BooleanNdArray src, boolean[][][][][] dst) {
+    if (src.rank() != 5) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(3).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 6-dimensions array of booleans
+   *
+   * @param src source rank-6 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-6
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static void copyFrom(BooleanNdArray src, boolean[][][][][][] dst) {
+    if (src.rank() != 6) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(4).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a single-dimension array of objects
+   *
+   * @param src source rank-1 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-1
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static <T> void copyFrom(NdArray<T> src, T[] dst) {
+    if (src.rank() != 1) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    if (src.size() > dst.length) {
+      throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
+    }
+    src.read(DataBuffers.of(dst, false, false));
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 2-dimensions array of objects
+   *
+   * @param src source rank-2 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-2
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static <T> void copyFrom(NdArray<T> src, T[][] dst) {
+    if (src.rank() != 2) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(0).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 3-dimensions array of objects
+   *
+   * @param src source rank-3 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-3
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static <T> void copyFrom(NdArray<T> src, T[][][] dst) {
+    if (src.rank() != 3) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(1).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 4-dimensions array of objects
+   *
+   * @param src source rank-4 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-4
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static <T> void copyFrom(NdArray<T> src, T[][][][] dst) {
+    if (src.rank() != 4) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(2).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 5-dimensions array of objects
+   *
+   * @param src source rank-5 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-5
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static <T> void copyFrom(NdArray<T> src, T[][][][][] dst) {
+    if (src.rank() != 5) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(3).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+    );
+  }
+
+  /**
+   * Copy a {@link NdArray} to a 6-dimensions array of objects
+   *
+   * @param src source rank-6 array
+   * @param dst destination array
+   * @throws IllegalArgumentException if {@code src} is not of rank-6
+   * @throws ArrayIndexOutOfBoundsException if not all elements of {@code src} can fit it the destination array
+   */
+  public static <T> void copyFrom(NdArray<T> src, T[][][][][][] dst) {
+    if (src.rank() != 6) {
+      throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
+    }
+    src.elements(4).forEachIndexed((idx, e) ->
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -2203,5 +3759,21 @@ public final class StdArrays {
       componentType = componentType.getComponentType();
     }
     return (Class<T>)componentType;
+  }
+
+  private static int[] computeArrayDims(NdArray<?> ndArray, int expectedRank) {
+    Shape shape = ndArray.shape();
+    if (shape.numDimensions() != expectedRank) {
+      throw new IllegalArgumentException("NdArray must be of rank " + expectedRank);
+    }
+    int[] arrayShape = new int[expectedRank];
+    for (int i = 0; i < expectedRank; ++i) {
+      long dimSize = shape.size(i);
+      if (dimSize > Integer.MAX_VALUE) {
+        throw new IllegalArgumentException("Dimension " + i + " is too large to fit in a standard array (" + shape.size(i) + ")");
+      }
+      arrayShape[i] = (int)dimSize;
+    }
+    return arrayShape;
   }
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
@@ -11,7 +11,7 @@ import org.tensorflow.ndarray.buffer.DataBuffers;
 public final class StdArrays {
 
   /**
-   * Copy a single-dimension array of ints in a new {@link IntNdArray}
+   * Copy an array of ints in a new {@link IntNdArray}
    *
    * @param array source array
    * @return the {@code IntNdArray} copy
@@ -23,7 +23,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of ints in a new {@link IntNdArray}
+   * Copy a 2-dimensional array of ints in a new {@link IntNdArray}
    *
    * @param array source array
    * @return the {@code IntNdArray} copy
@@ -35,7 +35,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of ints in a new {@link IntNdArray}
+   * Copy a 3-dimensional array of ints in a new {@link IntNdArray}
    *
    * @param array source array
    * @return the {@code IntNdArray} copy
@@ -47,7 +47,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of ints in a new {@link IntNdArray}
+   * Copy a 4-dimensional array of ints in a new {@link IntNdArray}
    *
    * @param array source array
    * @return the {@code IntNdArray} copy
@@ -59,7 +59,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of ints in a new {@link IntNdArray}
+   * Copy a 5-dimensional array of ints in a new {@link IntNdArray}
    *
    * @param array source array
    * @return the {@code IntNdArray} copy
@@ -71,7 +71,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of ints in a new {@link IntNdArray}
+   * Copy a 6-dimensional array of ints in a new {@link IntNdArray}
    *
    * @param array source array
    * @return the {@code IntNdArray} copy
@@ -83,7 +83,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of longs in a new {@link LongNdArray}
+   * Copy an array of longs in a new {@link LongNdArray}
    *
    * @param array source array
    * @return the {@code LongNdArray} copy
@@ -95,7 +95,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of longs in a new {@link LongNdArray}
+   * Copy a 2-dimensional array of longs in a new {@link LongNdArray}
    *
    * @param array source array
    * @return the {@code LongNdArray} copy
@@ -107,7 +107,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of longs in a new {@link LongNdArray}
+   * Copy a 3-dimensional array of longs in a new {@link LongNdArray}
    *
    * @param array source array
    * @return the {@code LongNdArray} copy
@@ -119,7 +119,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of longs in a new {@link LongNdArray}
+   * Copy a 4-dimensional array of longs in a new {@link LongNdArray}
    *
    * @param array source array
    * @return the {@code LongNdArray} copy
@@ -131,7 +131,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of longs in a new {@link LongNdArray}
+   * Copy a 5-dimensional array of longs in a new {@link LongNdArray}
    *
    * @param array source array
    * @return the {@code LongNdArray} copy
@@ -143,7 +143,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of longs in a new {@link LongNdArray}
+   * Copy a 6-dimensional array of longs in a new {@link LongNdArray}
    *
    * @param array source array
    * @return the {@code LongNdArray} copy
@@ -155,7 +155,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of floats in a new {@link FloatNdArray}
+   * Copy an array of floats in a new {@link FloatNdArray}
    *
    * @param array source array
    * @return the {@code FloatNdArray} copy
@@ -167,7 +167,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of floats in a new {@link FloatNdArray}
+   * Copy a 2-dimensional array of floats in a new {@link FloatNdArray}
    *
    * @param array source array
    * @return the {@code FloatNdArray} copy
@@ -179,7 +179,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of floats in a new {@link FloatNdArray}
+   * Copy a 3-dimensional array of floats in a new {@link FloatNdArray}
    *
    * @param array source array
    * @return the {@code FloatNdArray} copy
@@ -191,7 +191,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of floats in a new {@link FloatNdArray}
+   * Copy a 4-dimensional array of floats in a new {@link FloatNdArray}
    *
    * @param array source array
    * @return the {@code FloatNdArray} copy
@@ -203,7 +203,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of floats in a new {@link FloatNdArray}
+   * Copy a 5-dimensional array of floats in a new {@link FloatNdArray}
    *
    * @param array source array
    * @return the {@code FloatNdArray} copy
@@ -215,7 +215,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of floats in a new {@link FloatNdArray}
+   * Copy a 6-dimensional array of floats in a new {@link FloatNdArray}
    *
    * @param array source array
    * @return the {@code FloatNdArray} copy
@@ -227,7 +227,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of doubles in a new {@link DoubleNdArray}
+   * Copy an array of doubles in a new {@link DoubleNdArray}
    *
    * @param array source array
    * @return the {@code DoubleNdArray} copy
@@ -239,7 +239,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of doubles in a new {@link DoubleNdArray}
+   * Copy a 2-dimensional array of doubles in a new {@link DoubleNdArray}
    *
    * @param array source array
    * @return the {@code DoubleNdArray} copy
@@ -251,7 +251,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of doubles in a new {@link DoubleNdArray}
+   * Copy a 3-dimensional array of doubles in a new {@link DoubleNdArray}
    *
    * @param array source array
    * @return the {@code DoubleNdArray} copy
@@ -263,7 +263,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of doubles in a new {@link DoubleNdArray}
+   * Copy a 4-dimensional array of doubles in a new {@link DoubleNdArray}
    *
    * @param array source array
    * @return the {@code DoubleNdArray} copy
@@ -275,7 +275,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of doubles in a new {@link DoubleNdArray}
+   * Copy a 5-dimensional array of doubles in a new {@link DoubleNdArray}
    *
    * @param array source array
    * @return the {@code DoubleNdArray} copy
@@ -287,7 +287,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of doubles in a new {@link DoubleNdArray}
+   * Copy a 6-dimensional array of doubles in a new {@link DoubleNdArray}
    *
    * @param array source array
    * @return the {@code DoubleNdArray} copy
@@ -299,7 +299,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of bytes in a new {@link ByteNdArray}
+   * Copy an array of bytes in a new {@link ByteNdArray}
    *
    * @param array source array
    * @return the {@code ByteNdArray} copy
@@ -311,7 +311,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of bytes in a new {@link ByteNdArray}
+   * Copy a 2-dimensional array of bytes in a new {@link ByteNdArray}
    *
    * @param array source array
    * @return the {@code ByteNdArray} copy
@@ -323,7 +323,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of bytes in a new {@link ByteNdArray}
+   * Copy a 3-dimensional array of bytes in a new {@link ByteNdArray}
    *
    * @param array source array
    * @return the {@code ByteNdArray} copy
@@ -335,7 +335,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of bytes in a new {@link ByteNdArray}
+   * Copy a 4-dimensional array of bytes in a new {@link ByteNdArray}
    *
    * @param array source array
    * @return the {@code ByteNdArray} copy
@@ -347,7 +347,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of bytes in a new {@link ByteNdArray}
+   * Copy a 5-dimensional array of bytes in a new {@link ByteNdArray}
    *
    * @param array source array
    * @return the {@code ByteNdArray} copy
@@ -359,7 +359,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of bytes in a new {@link ByteNdArray}
+   * Copy a 6-dimensional array of bytes in a new {@link ByteNdArray}
    *
    * @param array source array
    * @return the {@code ByteNdArray} copy
@@ -371,7 +371,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of shorts in a new {@link ShortNdArray}
+   * Copy an array of shorts in a new {@link ShortNdArray}
    *
    * @param array source array
    * @return the {@code ShortNdArray} copy
@@ -383,7 +383,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of shorts in a new {@link ShortNdArray}
+   * Copy a 2-dimensional array of shorts in a new {@link ShortNdArray}
    *
    * @param array source array
    * @return the {@code ShortNdArray} copy
@@ -395,7 +395,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of shorts in a new {@link ShortNdArray}
+   * Copy a 3-dimensional array of shorts in a new {@link ShortNdArray}
    *
    * @param array source array
    * @return the {@code ShortNdArray} copy
@@ -407,7 +407,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of shorts in a new {@link ShortNdArray}
+   * Copy a 4-dimensional array of shorts in a new {@link ShortNdArray}
    *
    * @param array source array
    * @return the {@code ShortNdArray} copy
@@ -419,7 +419,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of shorts in a new {@link ShortNdArray}
+   * Copy a 5-dimensional array of shorts in a new {@link ShortNdArray}
    *
    * @param array source array
    * @return the {@code ShortNdArray} copy
@@ -431,7 +431,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of shorts in a new {@link ShortNdArray}
+   * Copy a 6-dimensional array of shorts in a new {@link ShortNdArray}
    *
    * @param array source array
    * @return the {@code ShortNdArray} copy
@@ -443,7 +443,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of booleans in a new {@link BooleanNdArray}
+   * Copy an array of booleans in a new {@link BooleanNdArray}
    *
    * @param array source array
    * @return the {@code BooleanNdArray} copy
@@ -455,7 +455,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of booleans in a new {@link BooleanNdArray}
+   * Copy a 2-dimensional array of booleans in a new {@link BooleanNdArray}
    *
    * @param array source array
    * @return the {@code BooleanNdArray} copy
@@ -467,7 +467,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of booleans in a new {@link BooleanNdArray}
+   * Copy a 3-dimensional array of booleans in a new {@link BooleanNdArray}
    *
    * @param array source array
    * @return the {@code BooleanNdArray} copy
@@ -479,7 +479,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of booleans in a new {@link BooleanNdArray}
+   * Copy a 4-dimensional array of booleans in a new {@link BooleanNdArray}
    *
    * @param array source array
    * @return the {@code BooleanNdArray} copy
@@ -491,7 +491,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of booleans in a new {@link BooleanNdArray}
+   * Copy a 5-dimensional array of booleans in a new {@link BooleanNdArray}
    *
    * @param array source array
    * @return the {@code BooleanNdArray} copy
@@ -503,7 +503,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of booleans in a new {@link BooleanNdArray}
+   * Copy a 6-dimensional array of booleans in a new {@link BooleanNdArray}
    *
    * @param array source array
    * @return the {@code BooleanNdArray} copy
@@ -515,7 +515,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of objects in a new {@link NdArray}
+   * Copy an array of objects in a new {@link NdArray}
    *
    * @param array source array
    * @return the {@code NdArray} copy
@@ -528,7 +528,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of objects in a new {@link NdArray}
+   * Copy a 2-dimensional array of objects in a new {@link NdArray}
    *
    * @param array source array
    * @return the {@code NdArray} copy
@@ -541,7 +541,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of objects in a new {@link NdArray}
+   * Copy a 3-dimensional array of objects in a new {@link NdArray}
    *
    * @param array source array
    * @return the {@code NdArray} copy
@@ -554,7 +554,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of objects in a new {@link NdArray}
+   * Copy a 4-dimensional array of objects in a new {@link NdArray}
    *
    * @param array source array
    * @return the {@code NdArray} copy
@@ -567,7 +567,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of objects in a new {@link NdArray}
+   * Copy a 5-dimensional array of objects in a new {@link NdArray}
    *
    * @param array source array
    * @return the {@code NdArray} copy
@@ -580,7 +580,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of objects in a new {@link NdArray}
+   * Copy a 6-dimensional array of objects in a new {@link NdArray}
    *
    * @param array source array
    * @return the {@code NdArray} copy
@@ -1321,7 +1321,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of ints into the {@code dst} {@link NdArray}
+   * Copy an array of ints into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-1 array
@@ -1333,7 +1333,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of ints into the {@code dst} {@link NdArray}
+   * Copy a 2-dimensional array of ints into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-2 array
@@ -1347,7 +1347,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of ints into the {@code dst} {@link NdArray}
+   * Copy a 3-dimensional array of ints into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-3 array
@@ -1361,7 +1361,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of ints into the {@code dst} {@link NdArray}
+   * Copy a 4-dimensional array of ints into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-4 array
@@ -1375,7 +1375,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of ints into the {@code dst} {@link NdArray}
+   * Copy a 5-dimensional array of ints into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-5 array
@@ -1389,7 +1389,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of ints into the {@code dst} {@link NdArray}
+   * Copy a 6-dimensional array of ints into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-6 array
@@ -1403,7 +1403,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of longs into the {@code dst} {@link NdArray}
+   * Copy an array of longs into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-1 array
@@ -1415,7 +1415,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of longs into the {@code dst} {@link NdArray}
+   * Copy a 2-dimensional array of longs into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-2 array
@@ -1429,7 +1429,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of longs into the {@code dst} {@link NdArray}
+   * Copy a 3-dimensional array of longs into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-3 array
@@ -1443,7 +1443,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of longs into the {@code dst} {@link NdArray}
+   * Copy a 4-dimensional array of longs into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-4 array
@@ -1457,7 +1457,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of longs into the {@code dst} {@link NdArray}
+   * Copy a 5-dimensional array of longs into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-5 array
@@ -1471,7 +1471,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of longs into the {@code dst} {@link NdArray}
+   * Copy a 6-dimensional array of longs into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-6 array
@@ -1485,7 +1485,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of floats into the {@code dst} {@link NdArray}
+   * Copy an array of floats into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-1 array
@@ -1497,7 +1497,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of floats into the {@code dst} {@link NdArray}
+   * Copy a 2-dimensional array of floats into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-2 array
@@ -1511,7 +1511,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of floats into the {@code dst} {@link NdArray}
+   * Copy a 3-dimensional array of floats into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-3 array
@@ -1525,7 +1525,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of floats into the {@code dst} {@link NdArray}
+   * Copy a 4-dimensional array of floats into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-4 array
@@ -1539,7 +1539,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of floats into the {@code dst} {@link NdArray}
+   * Copy a 5-dimensional array of floats into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-5 array
@@ -1553,7 +1553,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of floats into the {@code dst} {@link NdArray}
+   * Copy a 6-dimensional array of floats into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-6 array
@@ -1567,7 +1567,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of doubles into the {@code dst} {@link NdArray}
+   * Copy an array of doubles into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-1 array
@@ -1579,7 +1579,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of doubles into the {@code dst} {@link NdArray}
+   * Copy a 2-dimensional array of doubles into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-2 array
@@ -1593,7 +1593,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of doubles into the {@code dst} {@link NdArray}
+   * Copy a 3-dimensional array of doubles into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-3 array
@@ -1607,7 +1607,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of doubles into the {@code dst} {@link NdArray}
+   * Copy a 4-dimensional array of doubles into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-4 array
@@ -1621,7 +1621,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of doubles into the {@code dst} {@link NdArray}
+   * Copy a 5-dimensional array of doubles into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-5 array
@@ -1635,7 +1635,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of doubles into the {@code dst} {@link NdArray}
+   * Copy a 6-dimensional array of doubles into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-6 array
@@ -1649,7 +1649,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of bytes into the {@code dst} {@link NdArray}
+   * Copy an array of bytes into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-1 array
@@ -1661,7 +1661,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of bytes into the {@code dst} {@link NdArray}
+   * Copy a 2-dimensional array of bytes into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-2 array
@@ -1675,7 +1675,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of bytes into the {@code dst} {@link NdArray}
+   * Copy a 3-dimensional array of bytes into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-3 array
@@ -1689,7 +1689,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of bytes into the {@code dst} {@link NdArray}
+   * Copy a 4-dimensional array of bytes into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-4 array
@@ -1703,7 +1703,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of bytes into the {@code dst} {@link NdArray}
+   * Copy a 5-dimensional array of bytes into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-5 array
@@ -1717,7 +1717,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of bytes into the {@code dst} {@link NdArray}
+   * Copy a 6-dimensional array of bytes into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-6 array
@@ -1731,7 +1731,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of shorts into the {@code dst} {@link NdArray}
+   * Copy an array of shorts into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-1 array
@@ -1743,7 +1743,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of shorts into the {@code dst} {@link NdArray}
+   * Copy a 2-dimensional array of shorts into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-2 array
@@ -1757,7 +1757,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of shorts into the {@code dst} {@link NdArray}
+   * Copy a 3-dimensional array of shorts into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-3 array
@@ -1771,7 +1771,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of shorts into the {@code dst} {@link NdArray}
+   * Copy a 4-dimensional array of shorts into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-4 array
@@ -1785,7 +1785,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of shorts into the {@code dst} {@link NdArray}
+   * Copy a 5-dimensional array of shorts into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-5 array
@@ -1799,7 +1799,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of shorts into the {@code dst} {@link NdArray}
+   * Copy a 6-dimensional array of shorts into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-6 array
@@ -1813,7 +1813,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of booleans into the {@code dst} {@link NdArray}
+   * Copy an array of booleans into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-1 array
@@ -1825,7 +1825,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of booleans into the {@code dst} {@link NdArray}
+   * Copy a 2-dimensional array of booleans into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-2 array
@@ -1839,7 +1839,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of booleans into the {@code dst} {@link NdArray}
+   * Copy a 3-dimensional array of booleans into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-3 array
@@ -1853,7 +1853,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of booleans into the {@code dst} {@link NdArray}
+   * Copy a 4-dimensional array of booleans into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-4 array
@@ -1867,7 +1867,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of booleans into the {@code dst} {@link NdArray}
+   * Copy a 5-dimensional array of booleans into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-5 array
@@ -1881,7 +1881,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of booleans into the {@code dst} {@link NdArray}
+   * Copy a 6-dimensional array of booleans into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-6 array
@@ -1895,7 +1895,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a single-dimension array of objects into the {@code dst} {@link NdArray}
+   * Copy an array of objects into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-1 array
@@ -1907,7 +1907,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 2-dimensions array of objects into the {@code dst} {@link NdArray}
+   * Copy a 2-dimensional array of objects into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-2 array
@@ -1921,7 +1921,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 3-dimensions array of objects into the {@code dst} {@link NdArray}
+   * Copy a 3-dimensional array of objects into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-3 array
@@ -1935,7 +1935,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 4-dimensions array of objects into the {@code dst} {@link NdArray}
+   * Copy a 4-dimensional array of objects into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-4 array
@@ -1949,7 +1949,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 5-dimensions array of objects into the {@code dst} {@link NdArray}
+   * Copy a 5-dimensional array of objects into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-5 array
@@ -1963,7 +1963,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a 6-dimensions array of objects into the {@code dst} {@link NdArray}
+   * Copy a 6-dimensional array of objects into the {@code dst} {@link NdArray}
    *
    * @param src source array
    * @param dst destination rank-6 array
@@ -1978,7 +1978,7 @@ public final class StdArrays {
 
 
   /**
-   * Copy a {@link NdArray} to a single-dimension array of ints
+   * Copy a {@link NdArray} to an array of ints
    *
    * @param src source rank-1 array
    * @param dst destination array
@@ -1996,7 +1996,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 2-dimensions array of ints
+   * Copy a {@link NdArray} to a 2-dimensional array of ints
    *
    * @param src source rank-2 array
    * @param dst destination array
@@ -2013,7 +2013,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 3-dimensions array of ints
+   * Copy a {@link NdArray} to a 3-dimensional array of ints
    *
    * @param src source rank-3 array
    * @param dst destination array
@@ -2030,7 +2030,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 4-dimensions array of ints
+   * Copy a {@link NdArray} to a 4-dimensional array of ints
    *
    * @param src source rank-4 array
    * @param dst destination array
@@ -2047,7 +2047,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 5-dimensions array of ints
+   * Copy a {@link NdArray} to a 5-dimensional array of ints
    *
    * @param src source rank-5 array
    * @param dst destination array
@@ -2064,7 +2064,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 6-dimensions array of ints
+   * Copy a {@link NdArray} to a 6-dimensional array of ints
    *
    * @param src source rank-6 array
    * @param dst destination array
@@ -2081,7 +2081,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a single-dimension array of longs
+   * Copy a {@link NdArray} to an array of longs
    *
    * @param src source rank-1 array
    * @param dst destination array
@@ -2099,7 +2099,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 2-dimensions array of longs
+   * Copy a {@link NdArray} to a 2-dimensional array of longs
    *
    * @param src source rank-2 array
    * @param dst destination array
@@ -2116,7 +2116,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 3-dimensions array of longs
+   * Copy a {@link NdArray} to a 3-dimensional array of longs
    *
    * @param src source rank-3 array
    * @param dst destination array
@@ -2133,7 +2133,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 4-dimensions array of longs
+   * Copy a {@link NdArray} to a 4-dimensional array of longs
    *
    * @param src source rank-4 array
    * @param dst destination array
@@ -2150,7 +2150,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 5-dimensions array of longs
+   * Copy a {@link NdArray} to a 5-dimensional array of longs
    *
    * @param src source rank-5 array
    * @param dst destination array
@@ -2167,7 +2167,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 6-dimensions array of longs
+   * Copy a {@link NdArray} to a 6-dimensional array of longs
    *
    * @param src source rank-6 array
    * @param dst destination array
@@ -2184,7 +2184,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a single-dimension array of floats
+   * Copy a {@link NdArray} to an array of floats
    *
    * @param src source rank-1 array
    * @param dst destination array
@@ -2202,7 +2202,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 2-dimensions array of floats
+   * Copy a {@link NdArray} to a 2-dimensional array of floats
    *
    * @param src source rank-2 array
    * @param dst destination array
@@ -2219,7 +2219,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 3-dimensions array of floats
+   * Copy a {@link NdArray} to a 3-dimensional array of floats
    *
    * @param src source rank-3 array
    * @param dst destination array
@@ -2236,7 +2236,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 4-dimensions array of floats
+   * Copy a {@link NdArray} to a 4-dimensional array of floats
    *
    * @param src source rank-4 array
    * @param dst destination array
@@ -2253,7 +2253,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 5-dimensions array of floats
+   * Copy a {@link NdArray} to a 5-dimensional array of floats
    *
    * @param src source rank-5 array
    * @param dst destination array
@@ -2270,7 +2270,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 6-dimensions array of floats
+   * Copy a {@link NdArray} to a 6-dimensional array of floats
    *
    * @param src source rank-6 array
    * @param dst destination array
@@ -2287,7 +2287,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a single-dimension array of doubles
+   * Copy a {@link NdArray} to an array of doubles
    *
    * @param src source rank-1 array
    * @param dst destination array
@@ -2305,7 +2305,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 2-dimensions array of doubles
+   * Copy a {@link NdArray} to a 2-dimensional array of doubles
    *
    * @param src source rank-2 array
    * @param dst destination array
@@ -2322,7 +2322,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 3-dimensions array of doubles
+   * Copy a {@link NdArray} to a 3-dimensional array of doubles
    *
    * @param src source rank-3 array
    * @param dst destination array
@@ -2339,7 +2339,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 4-dimensions array of doubles
+   * Copy a {@link NdArray} to a 4-dimensional array of doubles
    *
    * @param src source rank-4 array
    * @param dst destination array
@@ -2356,7 +2356,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 5-dimensions array of doubles
+   * Copy a {@link NdArray} to a 5-dimensional array of doubles
    *
    * @param src source rank-5 array
    * @param dst destination array
@@ -2373,7 +2373,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 6-dimensions array of doubles
+   * Copy a {@link NdArray} to a 6-dimensional array of doubles
    *
    * @param src source rank-6 array
    * @param dst destination array
@@ -2390,7 +2390,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a single-dimension array of bytes
+   * Copy a {@link NdArray} to an array of bytes
    *
    * @param src source rank-1 array
    * @param dst destination array
@@ -2408,7 +2408,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 2-dimensions array of bytes
+   * Copy a {@link NdArray} to a 2-dimensional array of bytes
    *
    * @param src source rank-2 array
    * @param dst destination array
@@ -2425,7 +2425,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 3-dimensions array of bytes
+   * Copy a {@link NdArray} to a 3-dimensional array of bytes
    *
    * @param src source rank-3 array
    * @param dst destination array
@@ -2442,7 +2442,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 4-dimensions array of bytes
+   * Copy a {@link NdArray} to a 4-dimensional array of bytes
    *
    * @param src source rank-4 array
    * @param dst destination array
@@ -2459,7 +2459,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 5-dimensions array of bytes
+   * Copy a {@link NdArray} to a 5-dimensional array of bytes
    *
    * @param src source rank-5 array
    * @param dst destination array
@@ -2476,7 +2476,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 6-dimensions array of bytes
+   * Copy a {@link NdArray} to a 6-dimensional array of bytes
    *
    * @param src source rank-6 array
    * @param dst destination array
@@ -2493,7 +2493,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a single-dimension array of shorts
+   * Copy a {@link NdArray} to an array of shorts
    *
    * @param src source rank-1 array
    * @param dst destination array
@@ -2511,7 +2511,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 2-dimensions array of shorts
+   * Copy a {@link NdArray} to a 2-dimensional array of shorts
    *
    * @param src source rank-2 array
    * @param dst destination array
@@ -2528,7 +2528,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 3-dimensions array of shorts
+   * Copy a {@link NdArray} to a 3-dimensional array of shorts
    *
    * @param src source rank-3 array
    * @param dst destination array
@@ -2545,7 +2545,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 4-dimensions array of shorts
+   * Copy a {@link NdArray} to a 4-dimensional array of shorts
    *
    * @param src source rank-4 array
    * @param dst destination array
@@ -2562,7 +2562,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 5-dimensions array of shorts
+   * Copy a {@link NdArray} to a 5-dimensional array of shorts
    *
    * @param src source rank-5 array
    * @param dst destination array
@@ -2579,7 +2579,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 6-dimensions array of shorts
+   * Copy a {@link NdArray} to a 6-dimensional array of shorts
    *
    * @param src source rank-6 array
    * @param dst destination array
@@ -2596,7 +2596,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a single-dimension array of booleans.
+   * Copy a {@link NdArray} to an array of booleans.
    *
    * @param src source rank-1 array
    * @param dst destination array
@@ -2614,7 +2614,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 2-dimensions array of booleans
+   * Copy a {@link NdArray} to a 2-dimensional array of booleans
    *
    * @param src source rank-2 array
    * @param dst destination array
@@ -2631,7 +2631,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 3-dimensions array of booleans
+   * Copy a {@link NdArray} to a 3-dimensional array of booleans
    *
    * @param src source rank-3 array
    * @param dst destination array
@@ -2648,7 +2648,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 4-dimensions array of booleans
+   * Copy a {@link NdArray} to a 4-dimensional array of booleans
    *
    * @param src source rank-4 array
    * @param dst destination array
@@ -2665,7 +2665,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 5-dimensions array of booleans
+   * Copy a {@link NdArray} to a 5-dimensional array of booleans
    *
    * @param src source rank-5 array
    * @param dst destination array
@@ -2682,7 +2682,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 6-dimensions array of booleans
+   * Copy a {@link NdArray} to a 6-dimensional array of booleans
    *
    * @param src source rank-6 array
    * @param dst destination array
@@ -2699,7 +2699,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a single-dimension array of objects
+   * Copy a {@link NdArray} to an array of objects
    *
    * @param src source rank-1 array
    * @param dst destination array
@@ -2717,7 +2717,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 2-dimensions array of objects
+   * Copy a {@link NdArray} to a 2-dimensional array of objects
    *
    * @param src source rank-2 array
    * @param dst destination array
@@ -2734,7 +2734,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 3-dimensions array of objects
+   * Copy a {@link NdArray} to a 3-dimensional array of objects
    *
    * @param src source rank-3 array
    * @param dst destination array
@@ -2751,7 +2751,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 4-dimensions array of objects
+   * Copy a {@link NdArray} to a 4-dimensional array of objects
    *
    * @param src source rank-4 array
    * @param dst destination array
@@ -2768,7 +2768,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 5-dimensions array of objects
+   * Copy a {@link NdArray} to a 5-dimensional array of objects
    *
    * @param src source rank-5 array
    * @param dst destination array
@@ -2785,7 +2785,7 @@ public final class StdArrays {
   }
 
   /**
-   * Copy a {@link NdArray} to a 6-dimensions array of objects
+   * Copy a {@link NdArray} to a 6-dimensional array of objects
    *
    * @param src source rank-6 array
    * @param dst destination array
@@ -2802,7 +2802,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a single-dimension int array.
+   * Compute the shape of an int array.
    *
    * @param array 1D array
    * @return shape of the array
@@ -2812,7 +2812,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions int array.
+   * Compute the shape of a 2-dimensional int array.
    *
    * @param array 2D array
    * @return shape of the array
@@ -2822,7 +2822,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions int array.
+   * Compute the shape of a 3-dimensional int array.
    *
    * @param array 3D array
    * @return shape of the array
@@ -2832,7 +2832,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 4-dimensions int array.
+   * Compute the shape of a 4-dimensional int array.
    *
    * @param array 4D array
    * @return shape of the array
@@ -2842,7 +2842,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 5-dimensions int array.
+   * Compute the shape of a 5-dimensional int array.
    *
    * @param array 5D array
    * @return shape of the array
@@ -2852,7 +2852,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 6-dimensions int array.
+   * Compute the shape of a 6-dimensional int array.
    *
    * @param array 6D array
    * @return shape of the array
@@ -2862,7 +2862,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a single-dimension long array.
+   * Compute the shape of a long array.
    *
    * @param array 1D array
    * @return shape of the array
@@ -2872,7 +2872,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions long array.
+   * Compute the shape of a 2-dimensional long array.
    *
    * @param array 2D array
    * @return shape of the array
@@ -2882,7 +2882,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions long array.
+   * Compute the shape of a 3-dimensional long array.
    *
    * @param array 3D array
    * @return shape of the array
@@ -2892,7 +2892,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 4-dimensions long array.
+   * Compute the shape of a 4-dimensional long array.
    *
    * @param array 4D array
    * @return shape of the array
@@ -2902,7 +2902,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 5-dimensions long array.
+   * Compute the shape of a 5-dimensional long array.
    *
    * @param array 5D array
    * @return shape of the array
@@ -2912,7 +2912,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 6-dimensions long array.
+   * Compute the shape of a 6-dimensional long array.
    *
    * @param array 6D array
    * @return shape of the array
@@ -2922,7 +2922,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a single-dimension float array.
+   * Compute the shape of a float array.
    *
    * @param array 1D array
    * @return shape of the array
@@ -2932,7 +2932,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions float array.
+   * Compute the shape of a 2-dimensional float array.
    *
    * @param array 2D array
    * @return shape of the array
@@ -2942,7 +2942,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions float array.
+   * Compute the shape of a 3-dimensional float array.
    *
    * @param array 3D array
    * @return shape of the array
@@ -2952,7 +2952,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 4-dimensions float array.
+   * Compute the shape of a 4-dimensional float array.
    *
    * @param array 4D array
    * @return shape of the array
@@ -2962,7 +2962,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 5-dimensions float array.
+   * Compute the shape of a 5-dimensional float array.
    *
    * @param array 5D array
    * @return shape of the array
@@ -2972,7 +2972,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 6-dimensions float array.
+   * Compute the shape of a 6-dimensional float array.
    *
    * @param array 6D array
    * @return shape of the array
@@ -2982,7 +2982,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a single-dimension double array.
+   * Compute the shape of a double array.
    *
    * @param array 1D array
    * @return shape of the array
@@ -2992,7 +2992,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions double array.
+   * Compute the shape of a 2-dimensional double array.
    *
    * @param array 2D array
    * @return shape of the array
@@ -3002,7 +3002,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions double array.
+   * Compute the shape of a 3-dimensional double array.
    *
    * @param array 3D array
    * @return shape of the array
@@ -3012,7 +3012,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 4-dimensions double array.
+   * Compute the shape of a 4-dimensional double array.
    *
    * @param array 4D array
    * @return shape of the array
@@ -3022,7 +3022,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 5-dimensions double array.
+   * Compute the shape of a 5-dimensional double array.
    *
    * @param array 5D array
    * @return shape of the array
@@ -3032,7 +3032,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 6-dimensions double array.
+   * Compute the shape of a 6-dimensional double array.
    *
    * @param array 6D array
    * @return shape of the array
@@ -3042,7 +3042,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a single-dimension byte array.
+   * Compute the shape of a byte array.
    *
    * @param array 1D array
    * @return shape of the array
@@ -3052,7 +3052,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions byte array.
+   * Compute the shape of a 2-dimensional byte array.
    *
    * @param array 2D array
    * @return shape of the array
@@ -3062,7 +3062,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions byte array.
+   * Compute the shape of a 3-dimensional byte array.
    *
    * @param array 3D array
    * @return shape of the array
@@ -3072,7 +3072,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 4-dimensions byte array.
+   * Compute the shape of a 4-dimensional byte array.
    *
    * @param array 4D array
    * @return shape of the array
@@ -3082,7 +3082,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 5-dimensions byte array.
+   * Compute the shape of a 5-dimensional byte array.
    *
    * @param array 5D array
    * @return shape of the array
@@ -3092,7 +3092,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 6-dimensions byte array.
+   * Compute the shape of a 6-dimensional byte array.
    *
    * @param array 6D array
    * @return shape of the array
@@ -3102,7 +3102,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a single-dimension short array.
+   * Compute the shape of a short array.
    *
    * @param array 1D array
    * @return shape of the array
@@ -3112,7 +3112,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions short array.
+   * Compute the shape of a 2-dimensional short array.
    *
    * @param array 2D array
    * @return shape of the array
@@ -3122,7 +3122,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions short array.
+   * Compute the shape of a 3-dimensional short array.
    *
    * @param array 3D array
    * @return shape of the array
@@ -3132,7 +3132,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 4-dimensions short array.
+   * Compute the shape of a 4-dimensional short array.
    *
    * @param array 4D array
    * @return shape of the array
@@ -3142,7 +3142,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 5-dimensions short array.
+   * Compute the shape of a 5-dimensional short array.
    *
    * @param array 5D array
    * @return shape of the array
@@ -3152,7 +3152,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 6-dimensions short array.
+   * Compute the shape of a 6-dimensional short array.
    *
    * @param array 6D array
    * @return shape of the array
@@ -3162,7 +3162,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a single-dimension boolean array.
+   * Compute the shape of a boolean array.
    *
    * @param array 1D array
    * @return shape of the array
@@ -3172,7 +3172,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions boolean array.
+   * Compute the shape of a 2-dimensional boolean array.
    *
    * @param array 2D array
    * @return shape of the array
@@ -3182,7 +3182,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions boolean array.
+   * Compute the shape of a 3-dimensional boolean array.
    *
    * @param array 3D array
    * @return shape of the array
@@ -3192,7 +3192,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 4-dimensions boolean array.
+   * Compute the shape of a 4-dimensional boolean array.
    *
    * @param array 4D array
    * @return shape of the array
@@ -3202,7 +3202,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 5-dimensions boolean array.
+   * Compute the shape of a 5-dimensional boolean array.
    *
    * @param array 5D array
    * @return shape of the array
@@ -3212,7 +3212,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 6-dimensions boolean array.
+   * Compute the shape of a 6-dimensional boolean array.
    *
    * @param array 6D array
    * @return shape of the array
@@ -3222,7 +3222,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a single-dimension object array.
+   * Compute the shape of an object array.
    *
    * @param array 1D array
    * @return shape of the array
@@ -3232,7 +3232,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions object array.
+   * Compute the shape of a 2-dimensional object array.
    *
    * @param array 2D array
    * @return shape of the array
@@ -3242,7 +3242,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 3-dimensions object array.
+   * Compute the shape of a 3-dimensional object array.
    *
    * @param array 3D array
    * @return shape of the array
@@ -3252,7 +3252,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 4-dimensions object array.
+   * Compute the shape of a 4-dimensional object array.
    *
    * @param array 4D array
    * @return shape of the array
@@ -3262,7 +3262,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 5-dimensions object array.
+   * Compute the shape of a 5-dimensional object array.
    *
    * @param array 5D array
    * @return shape of the array
@@ -3272,7 +3272,7 @@ public final class StdArrays {
   }
 
   /**
-   * Compute the shape of a 6-dimensions object array.
+   * Compute the shape of a 6-dimensional object array.
    *
    * @param array 6D array
    * @return shape of the array

--- a/ndarray/src/test/java/org/tensorflow/ndarray/NdArrayTestBase.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/NdArrayTestBase.java
@@ -322,11 +322,11 @@ public abstract class NdArrayTestBase<T> {
         { { valueOf(0L), valueOf(1L) }, { valueOf(2L), valueOf(0L) } }
     });
 
-    StdArrays.copyTo(array1, values[0]);
-    StdArrays.copyTo(array2, values[0]);
-    StdArrays.copyTo(array3, values[0]);
+    StdArrays.copyTo(values[0], array1);
+    StdArrays.copyTo(values[0], array2);
+    StdArrays.copyTo(values[0], array3);
     array3.setObject(valueOf(0L), 0, 1);
-    StdArrays.copyTo(array4, values);
+    StdArrays.copyTo(values, array4);
 
     assertEquals(array1, array2);
     assertEquals(array1.hashCode(), array2.hashCode());

--- a/ndarray/src/test/java/org/tensorflow/ndarray/StdArraysTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/StdArraysTest.java
@@ -2,6 +2,7 @@ package org.tensorflow.ndarray;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
@@ -9,27 +10,56 @@ import org.junit.jupiter.api.Test;
 public class StdArraysTest {
 
   @Test
-  public void initVector() {
+  public void vectors() {
     IntNdArray vector = NdArrays.ofInts(Shape.of(2));
 
-    StdArrays.copyTo(vector, new int[] {1, 2});
+    StdArrays.copyTo(new int[] {1, 2}, vector);
     assertEquals(1, vector.getInt(0));
     assertEquals(2, vector.getInt(1));
 
     try {
-      StdArrays.copyTo(vector, new int[] {1, 2, 3});
+      StdArrays.copyTo(new int[] {1, 2, 3}, vector);
       fail();
     } catch (IllegalArgumentException e) {
       // as expected
     }
     try {
-      StdArrays.copyTo(NdArrays.ofInts(Shape.of(4)), new int[] {1, 2});
+      StdArrays.copyTo(new int[] {1, 2}, NdArrays.ofInts(Shape.of(4)));
       fail();
     } catch (IllegalArgumentException e) {
       // as expected
     }
     try {
-      StdArrays.copyTo(NdArrays.ofInts(Shape.of(2, 2)), new int[] {1, 2});
+      StdArrays.copyTo(new int[] {1, 2}, NdArrays.ofInts(Shape.of(2, 2)));
+      fail();
+    } catch (IllegalArgumentException e) {
+      // as expected
+    }
+
+    int[] array = StdArrays.array1dCopyOf(vector);
+    assertEquals(1, array[0]);
+    assertEquals(2, array[1]);
+
+    array = new int[3];
+    StdArrays.copyFrom(vector, array);
+    assertEquals(1, array[0]);
+    assertEquals(2, array[1]);
+    assertEquals(0, array[2]);
+
+    try {
+      StdArrays.copyFrom(vector, new int[1]);
+      fail();
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // as expected
+    }
+    try {
+      StdArrays.copyFrom(vector, new int[1][2]);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // as expected
+    }
+    try {
+      StdArrays.copyFrom(vector, new int[2][2][2]);
       fail();
     } catch (IllegalArgumentException e) {
       // as expected
@@ -37,45 +67,110 @@ public class StdArraysTest {
   }
 
   @Test
-  public void initMatrix() {
+  public void matrices() {
     IntNdArray matrix = NdArrays.ofInts(Shape.of(2, 2));
 
-    StdArrays.copyTo(matrix, new int[][] {
+    StdArrays.copyTo(new int[][] {
         {1, 2},
         {3, 4}
-    });
+    }, matrix);
     assertEquals(1, matrix.getInt(0, 0));
     assertEquals(2, matrix.getInt(0, 1));
     assertEquals(3, matrix.getInt(1, 0));
     assertEquals(4, matrix.getInt(1, 1));
     try {
-      StdArrays.copyTo(matrix, new int[][] {{1, 2, 3}, {4, 5, 6}});
+      StdArrays.copyTo(new int[][] {{1, 2, 3}, {4, 5, 6}}, matrix);
       fail();
     } catch (IllegalArgumentException e) {
       // as expected
     }
     try {
-      StdArrays.copyTo(NdArrays.ofInts(Shape.of(3, 3)), new int[][] {{1, 2}, {3, 4}});
+      StdArrays.copyTo(new int[][] {{1, 2}, {3, 4}}, NdArrays.ofInts(Shape.of(3, 3)));
       fail();
     } catch (IllegalArgumentException e) {
       // as expected
     }
     try {
-      StdArrays.copyTo(NdArrays.ofInts(Shape.of(2, 2, 1)), new int[][] {{1, 2}, {3, 4}});
+      StdArrays.copyTo(new int[][] {{1, 2}, {3, 4}}, NdArrays.ofInts(Shape.of(2, 2, 1)));
       fail();
     } catch (IllegalArgumentException e) {
       // as expected
     }
+
+    int[][] array = StdArrays.array2dCopyOf(matrix);
+    assertEquals(1, array[0][0]);
+    assertEquals(2, array[0][1]);
+    assertEquals(3, array[1][0]);
+    assertEquals(4, array[1][1]);
+
+    array = new int[3][3];
+    StdArrays.copyFrom(matrix, array);
+    assertArrayEquals(new int[] { 1, 2, 0 }, array[0]);
+    assertArrayEquals(new int[] { 3, 4, 0 }, array[1]);
+    assertArrayEquals(new int[] { 0, 0, 0 }, array[2]);
+
+    try {
+      StdArrays.copyFrom(matrix, new int[1][2]);
+      fail();
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // as expected
+    }
+    try {
+      StdArrays.copyFrom(matrix, new int[2][1]);
+      fail();
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // as expected
+    }
+    try {
+      StdArrays.copyFrom(matrix, new int[2]);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // as expected
+    }
+    try {
+      StdArrays.copyFrom(matrix, new int[1][2][2]);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // as expected
+    }
+    try {
+      StdArrays.copyFrom(matrix, new int[2][2][2]);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // as expected
+    }
+  }
+
+  @Test
+  public void objectMatrix() {
+    NdArray<String> matrix = StdArrays.ndCopyOf(new String[][] {{"ab", "bc"}, {"cd", "de"}});
+    assertEquals(NdArrays.vectorOfObjects("ab", "bc"), matrix.get(0));
+    assertEquals(NdArrays.vectorOfObjects("cd", "de"), matrix.get(1));
+
+    String[][] array = StdArrays.array2dCopyOf(matrix, String.class);
+    assertEquals("ab", array[0][0]);
+    assertEquals("bc", array[0][1]);
+    assertEquals("cd", array[1][0]);
+    assertEquals("de", array[1][1]);
+
+    array = new String[2][3];
+    StdArrays.copyFrom(matrix, array);
+    assertEquals("ab", array[0][0]);
+    assertEquals("bc", array[0][1]);
+    assertNull(array[0][2]);
+    assertEquals("cd", array[1][0]);
+    assertEquals("de", array[1][1]);
+    assertNull(array[1][2]);
   }
 
   @Test
   public void cannotInitDenseMatrixWithRaggedArray() {
     IntNdArray matrix = NdArrays.ofInts(Shape.of(2, 2));
     try {
-      StdArrays.copyTo(matrix, new int[][]{
+      StdArrays.copyTo(new int[][]{
           {1, 2},
           {3}
-      });
+      }, matrix);
       fail();
     } catch (IllegalArgumentException e) {
       // as expected
@@ -112,12 +207,5 @@ public class StdArraysTest {
   public void shapeOfEmptyArray() {
     Shape shape = StdArrays.shapeOf(new int[2][2][3]);
     assertArrayEquals(new long[] {2, 2, 3}, shape.asArray());
-  }
-
-  @Test
-  public void createArrayFromObjectMatrix() {
-    NdArray<String> ndArray = StdArrays.ndCopyOf(new String[][] {{"a", "b"}, {"c", "d"}});
-    assertEquals(NdArrays.vectorOfObjects("a", "b"), ndArray.get(0));
-    assertEquals(NdArrays.vectorOfObjects("c", "d"), ndArray.get(1));
   }
 }

--- a/ndarray/src/test/java/org/tensorflow/ndarray/benchmark/NdArrayBenchmark.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/benchmark/NdArrayBenchmark.java
@@ -62,8 +62,8 @@ public class NdArrayBenchmark {
 		for (int y = 0, pixelIdx = 0; y < image.getHeight(); ++y) {
 			for (int x = 0; x < image.getWidth(); ++x, ++pixelIdx) {
 				imageData.getPixel(x, y, pixel);
-				StdArrays.copyTo(pixels.get(pixelIdx), pixel);
-				StdArrays.copyTo(channels.slice(all(), at(pixelIdx)), pixel);
+				StdArrays.copyTo(pixel, pixels.get(pixelIdx));
+				StdArrays.copyTo(pixel, channels.slice(all(), at(pixelIdx)));
 			}
 		}
 		batches = NdArrays.ofFloats(Shape.of(BATCH_SIZE, 3, numPixels));

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Constant.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Constant.java
@@ -122,7 +122,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt32> tensorOf(Scope scope, int[][] data) {
-    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -137,7 +138,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt32> tensorOf(Scope scope, int[][][] data) {
-    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -152,7 +154,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt32> tensorOf(Scope scope, int[][][][] data) {
-    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -167,7 +170,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt32> tensorOf(Scope scope, int[][][][][] data) {
-    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -182,7 +186,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt32> tensorOf(Scope scope, int[][][][][][] data) {
-    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt32> value = TInt32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -271,7 +276,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat32> tensorOf(Scope scope, float[][] data) {
-    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -286,7 +292,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat32> tensorOf(Scope scope, float[][][] data) {
-    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -301,7 +308,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat32> tensorOf(Scope scope, float[][][][] data) {
-    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -316,7 +324,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat32> tensorOf(Scope scope, float[][][][][] data) {
-    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -331,7 +340,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat32> tensorOf(Scope scope, float[][][][][][] data) {
-    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat32> value = TFloat32.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -420,7 +430,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat64> tensorOf(Scope scope, double[][] data) {
-    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -435,7 +446,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat64> tensorOf(Scope scope, double[][][] data) {
-    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -450,7 +462,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat64> tensorOf(Scope scope, double[][][][] data) {
-    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -465,7 +478,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat64> tensorOf(Scope scope, double[][][][][] data) {
-    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -480,7 +494,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TFloat64> tensorOf(Scope scope, double[][][][][][] data) {
-    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TFloat64> value = TFloat64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(
+        data, t))) {
       return create(scope, value);
     }
   }
@@ -554,7 +569,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt64> tensorOf(Scope scope, long[][] data) {
-    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -584,7 +600,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt64> tensorOf(Scope scope, long[][][] data) {
-    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -599,7 +616,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt64> tensorOf(Scope scope, long[][][][] data) {
-    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -614,7 +632,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt64> tensorOf(Scope scope, long[][][][][] data) {
-    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -629,7 +648,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TInt64> tensorOf(Scope scope, long[][][][][][] data) {
-    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TInt64> value = TInt64.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -718,7 +738,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TBool> tensorOf(Scope scope, boolean[][] data) {
-    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -733,7 +754,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TBool> tensorOf(Scope scope, boolean[][][] data) {
-    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -748,7 +770,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TBool> tensorOf(Scope scope, boolean[][][][] data) {
-    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -763,7 +786,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TBool> tensorOf(Scope scope, boolean[][][][][] data) {
-    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -778,7 +802,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TBool> tensorOf(Scope scope, boolean[][][][][][] data) {
-    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(t, data))) {
+    try (Tensor<TBool> value = TBool.tensorOf(StdArrays.shapeOf(data), t -> StdArrays.copyTo(data,
+        t))) {
       return create(scope, value);
     }
   }
@@ -867,7 +892,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TUint8> tensorOf(Scope scope, byte[][] data) {
-    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(d, data))) {
+    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(data,
+        d))) {
       return create(scope, value);
     }
   }
@@ -882,7 +908,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TUint8> tensorOf(Scope scope, byte[][][] data) {
-    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(d, data))) {
+    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(data,
+        d))) {
       return create(scope, value);
     }
   }
@@ -897,7 +924,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TUint8> tensorOf(Scope scope, byte[][][][] data) {
-    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(d, data))) {
+    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(data,
+        d))) {
       return create(scope, value);
     }
   }
@@ -912,7 +940,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TUint8> tensorOf(Scope scope, byte[][][][][] data) {
-    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(d, data))) {
+    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(data,
+        d))) {
       return create(scope, value);
     }
   }
@@ -927,7 +956,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   @Endpoint
   public static Constant<TUint8> tensorOf(Scope scope, byte[][][][][][] data) {
-    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(d, data))) {
+    try (Tensor<TUint8> value = TUint8.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(data,
+        d))) {
       return create(scope, value);
     }
   }
@@ -1081,7 +1111,7 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   public static Constant<TString> tensorOf(Scope scope, String[][] data) {
     NdArray<String> src = NdArrays.ofObjects(String.class, StdArrays.shapeOf(data));
-    StdArrays.copyTo(src, data);
+    StdArrays.copyTo(data, src);
     try (Tensor<TString> value = TString.tensorOf(src)) {
       return create(scope, value);
     }
@@ -1096,7 +1126,7 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   public static Constant<TString> tensorOf(Scope scope, String[][][] data) {
     NdArray<String> src = NdArrays.ofObjects(String.class, StdArrays.shapeOf(data));
-    StdArrays.copyTo(src, data);
+    StdArrays.copyTo(data, src);
     try (Tensor<TString> value = TString.tensorOf(src)) {
       return create(scope, value);
     }
@@ -1111,7 +1141,7 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   public static Constant<TString> tensorOf(Scope scope, String[][][][] data) {
     NdArray<String> src = NdArrays.ofObjects(String.class, StdArrays.shapeOf(data));
-    StdArrays.copyTo(src, data);
+    StdArrays.copyTo(data, src);
     try (Tensor<TString> value = TString.tensorOf(src)) {
       return create(scope, value);
     }
@@ -1126,7 +1156,7 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   public static Constant<TString> tensorOf(Scope scope, String[][][][][] data) {
     NdArray<String> src = NdArrays.ofObjects(String.class, StdArrays.shapeOf(data));
-    StdArrays.copyTo(src, data);
+    StdArrays.copyTo(data, src);
     try (Tensor<TString> value = TString.tensorOf(src)) {
       return create(scope, value);
     }
@@ -1141,7 +1171,7 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
    */
   public static Constant<TString> tensorOf(Scope scope, String[][][][][][] data) {
     NdArray<String> src = NdArrays.ofObjects(String.class, StdArrays.shapeOf(data));
-    StdArrays.copyTo(src, data);
+    StdArrays.copyTo(data, src);
     try (Tensor<TString> value = TString.tensorOf(src)) {
       return create(scope, value);
     }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
@@ -72,7 +72,7 @@ public interface TBfloat16 extends FloatNdArray, TNumber {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(data, values));
+    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
@@ -65,7 +65,7 @@ public interface TBool extends BooleanNdArray, TType {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(data, values));
+    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
@@ -69,7 +69,7 @@ public interface TFloat16 extends FloatNdArray, TNumber {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(data, values));
+    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
@@ -59,7 +59,7 @@ public interface TFloat32 extends FloatNdArray, TNumber {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(data, values));
+    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
@@ -59,7 +59,7 @@ public interface TFloat64 extends DoubleNdArray, TNumber {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(data, values));
+    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
@@ -59,7 +59,7 @@ public interface TInt32 extends IntNdArray, TNumber {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(data, values));
+    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
@@ -59,7 +59,7 @@ public interface TInt64 extends LongNdArray, TNumber {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(data, values));
+    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
@@ -59,7 +59,7 @@ public interface TUint8 extends ByteNdArray, TNumber {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(data, values));
+    return Tensor.of(DTYPE, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/benchmark/TensorBenchmark.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/benchmark/TensorBenchmark.java
@@ -65,7 +65,7 @@ public class TensorBenchmark {
             }
         }
     };
-    TInt32.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(d, data));
+    TInt32.tensorOf(StdArrays.shapeOf(data), d -> StdArrays.copyTo(data, d));
   }
 
   @Benchmark


### PR DESCRIPTION
This PR is in linked with what was observed and discussed in https://github.com/tensorflow/java/issues/85. While it is possible to transform a standard array of n-dimension to a `NdArray`, the other way around is not possible, or at least not simple enough.

I'm adding here two new signatures for converting back `NdArray` instances to standard arrays:
`StdArrays.array*dCopyOf(NdArray<T>)` and `StdArrays.copyFrom(T[], NdArray<T>)`, for all their primitive types and when `*` is replaced by the number of dimensions. For example:

```java
IntNdArray matrix = StdArrays.ndCopyOf(new int[][] { { 1, 2, 3 }, { 4, 5, 6 } });
int[][] array = StdArrays.array2dCopyOf(matrix);
assertEquals(2, array.length);
assertEquals(3, array[0].length);
assertArrayEquals(new int[]{ 1, 2, 3 }, array[0]);
```

Note that while `array*dCopyOf` returns an array with the exact same dimensions as the original `NdArray`, `copyFrom` is more permissive and allow larger arrays to be used, as long as the number of dimensions matches. For example:

```java
IntNdArray matrix = StdArrays.ndCopyOf(new int[][] { { 1, 2, 3 }, { 4, 5, 6 } });
int[][] array = new int[3][4];
StdArrays.copyFrom(matrix, array);
assertArrayEquals(new int[]{ 1, 2, 3, 0 }, array[0]);
assertArrayEquals(new int[]{ 4, 5, 6, 0 }, array[1]);
assertArrayEquals(new int[]{ 0, 0, 0, 0 }, array[2]);
```