### PR TITLE
Creation of tensorflow-keras module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,10 +100,23 @@
     </dependencies>
   </dependencyManagement>
 
-  <!-- Two profiles are used:
-       ossrh - deploys to ossrh/maven central
-       bintray - deploys to bintray/jcenter. -->
   <profiles>
+    <!--
+    Profile dev
+        The 'dev' profile is used for local development or PR compilation check only.
+        Here, we enable the `tensorflow-keras` module only under this profile, until
+        it is mature enough for being deployed and distributed for the end users.
+    -->
+    <profile>
+      <id>dev</id>
+      <modules>
+        <module>tensorflow-keras</module>
+      </modules>
+    </profile>
+    <!--
+    Profile ossrh
+        Deploys to ossrh/maven central
+    -->
     <profile>
       <id>ossrh</id>
       <distributionManagement>
@@ -118,6 +131,10 @@
         </repository>
       </distributionManagement>
     </profile>
+    <!--
+    Profile bintray
+        Deploys to bintray/jcenter
+    -->
     <profile>
       <id>bintray</id>
       <distributionManagement>

--- a/tensorflow-keras/pom.xml
+++ b/tensorflow-keras/pom.xml
@@ -1,0 +1,66 @@
+<!--
+  Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  =======================================================================
+  -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.tensorflow</groupId>
+    <artifactId>tensorflow-java</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>tensorflow-keras</artifactId>
+  <packaging>jar</packaging>
+
+  <name>TensorFlow Keras Library</name>
+  <description>Java implementation of the TensorFlow Keras API</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <argLine>-Xmx2G -XX:MaxPermSize=256m</argLine>
+          <skipTests>false</skipTests>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+

--- a/tensorflow-keras/src/main/java/org/tensorflow/keras/package-info.java
+++ b/tensorflow-keras/src/main/java/org/tensorflow/keras/package-info.java
@@ -1,0 +1,1 @@
+package org.tensorflow.keras;

--- a/tensorflow-keras/src/test/java/org/tensorflow/keras/package-info.java
+++ b/tensorflow-keras/src/test/java/org/tensorflow/keras/package-info.java
@@ -1,0 +1,1 @@
+package org.tensorflow.keras;


### PR DESCRIPTION
This PR simply creates an empty module called `tensorflow-keras` so that developer working on this API can start to submit their code. 

This module is now activated only in dev profile (`mvn install -Pdev`) until it gets mature enough to be deployed and distributed. The full CI build will currently skip it.

CC\ @dhruvrajan, @JimClarke5 