### PR TITLE
Exclude core-generator from the compilation classpath

### DIFF
--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -39,12 +39,6 @@
     </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>
-      <artifactId>tensorflow-core-generator</artifactId>
-      <version>${project.version}</version>
-      <optional>true</optional> <!-- for compilation only -->
-    </dependency>
-    <dependency>
-      <groupId>org.tensorflow</groupId>
       <artifactId>ndarray</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -144,6 +138,13 @@
               <annotationProcessors>
                 <annotationProcessor>org.tensorflow.processor.operator.OperatorProcessor</annotationProcessor>
               </annotationProcessors>
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>org.tensorflow</groupId>
+                  <artifactId>tensorflow-core-generator</artifactId>
+                  <version>${project.version}</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
               <!-- Important: Cannot be ${project.basedir}/src/gen/java or wherever the ops are -->
               <generatedSourcesDirectory>${project.basedir}/src/gen/annotations</generatedSourcesDirectory>
             </configuration>


### PR DESCRIPTION
As discussed in [this previous PR](https://github.com/tensorflow/java/pull/83), transitive dependencies coming from the `tensorflow-core-generator` artifact can cause confusion for the developer working in `tensorflow-core-api`, as many classes not available at runtime seem available.

Adding the `tensorflow-core-generator` dependency to the Maven compile plugin directly resolves this issue.

CC\ @hthu , @Craigacp 