### PR TITLE
add more cuda compute capabilities

### DIFF
--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -24,7 +24,7 @@ fi
 
 if [[ "${EXTENSION:-}" == *gpu* ]]; then
     export BUILD_FLAGS="$BUILD_FLAGS --config=cuda"
-    export TF_CUDA_COMPUTE_CAPABILITIES=3.5,sm_52,sm_60,sm_61,7.0,7.5
+    export TF_CUDA_COMPUTE_CAPABILITIES=sm_35,sm_37,sm_52,sm_60,sm_61,7.0
     if [[ -z ${TF_CUDA_PATHS:-} ]] && [[ -d ${CUDA_PATH:-} ]]; then
         # Work around some issue with Bazel preventing it from detecting CUDA on Windows
         export TF_CUDA_PATHS="$CUDA_PATH"

--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -24,6 +24,7 @@ fi
 
 if [[ "${EXTENSION:-}" == *gpu* ]]; then
     export BUILD_FLAGS="$BUILD_FLAGS --config=cuda"
+    export TF_CUDA_COMPUTE_CAPABILITIES=3.5,sm_52,sm_60,sm_61,7.0,7.5
     if [[ -z ${TF_CUDA_PATHS:-} ]] && [[ -d ${CUDA_PATH:-} ]]; then
         # Work around some issue with Bazel preventing it from detecting CUDA on Windows
         export TF_CUDA_PATHS="$CUDA_PATH"


### PR DESCRIPTION
should fix #104 

I'm not sure if this is the proper way to fix. It should be configured through [configure.py](https://github.com/tensorflow/tensorflow/blob/master/configure.py#L1003) during built from source.

I added these versions to match what `tensorflow-gpu` pip packages support, but will increase build time.

cc @karllessard @saudet 