### PR TITLE
Build the `tensorflow_cc` target instead of just `tensorflow`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   linux-x86_64:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: ubuntu-latest
-    container: nvidia/cuda:10.1-cudnn7-devel-centos7
+    container: centos:7
     strategy:
       matrix:
         ext: ["", -mkl, -gpu, -mkl-gpu]
@@ -39,6 +39,17 @@ jobs:
           echo Downloading Bazel
           curl -L https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-linux-x86_64.sh -o bazel.sh --retry 10
           bash bazel.sh
+          echo Installing CUDA
+          curl -L https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel7-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm -o $HOME/cuda.rpm
+          curl -L https://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.1-linux-x64-v7.6.5.32.tgz -o $HOME/cudnn.tgz
+          curl -L https://developer.download.nvidia.com/compute/redist/nccl/v2.4/nccl_2.4.8-1+cuda10.1_x86_64.txz -o $HOME/nccl.txz
+          rpm -i $HOME/cuda.rpm
+          cd /var/cuda-repo-10-1-local-10.1.243-418.87.00/; rpm -i --nodeps cuda*.rpm libc*.rpm
+          ln -sf /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/libcuda.so
+          ln -sf /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/libnvidia-ml.so
+          tar hxvf $HOME/cudnn.tgz -C /usr/local/
+          tar hxvf $HOME/nccl.txz --strip-components=1 -C /usr/local/cuda/
+          mv /usr/local/cuda/lib/* /usr/local/cuda/lib64/
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Build project
@@ -110,7 +121,7 @@ jobs:
           curl.exe -L https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-windows-x86_64.exe -o C:/bazel/bazel.exe --retry 10
           echo Installing CUDA
           curl.exe -L http://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_windows.exe -o cuda.exe
-          curl.exe -L https://developer.download.nvidia.com/compute/redist/cudnn/v7.6.4/cudnn-10.1-windows7-x64-v7.6.4.38.zip -o cudnn.zip
+          curl.exe -L https://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.1-windows7-x64-v7.6.5.32.zip -o cudnn.zip
           cuda.exe -s
           mkdir cuda
           unzip.exe cudnn.zip

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/internal/c_api/global/tensorflow.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/internal/c_api/global/tensorflow.java
@@ -11,6 +11,57 @@ import org.bytedeco.javacpp.annotation.*;
 public class tensorflow extends org.tensorflow.internal.c_api.presets.tensorflow {
     static { Loader.load(); }
 
+// Parsed from tensorflow/core/util/port.h
+
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// #ifndef TENSORFLOW_CORE_UTIL_PORT_H_
+// #define TENSORFLOW_CORE_UTIL_PORT_H_
+
+// Returns true if GOOGLE_CUDA is defined.
+@Namespace("tensorflow") public static native @Cast("bool") boolean IsGoogleCudaEnabled();
+
+// Returns true if TENSORFLOW_USE_ROCM is defined. (i.e. TF is built with ROCm)
+@Namespace("tensorflow") public static native @Cast("bool") boolean IsBuiltWithROCm();
+
+// Returns true if TENSORFLOW_USE_XLA is defined. (i.e. TF is built with XLA)
+@Namespace("tensorflow") public static native @Cast("bool") boolean IsBuiltWithXLA();
+
+// Returns true if TENSORFLOW_USE_NVCC is defined. (i.e. TF is built with nvcc)
+@Namespace("tensorflow") public static native @Cast("bool") boolean IsBuiltWithNvcc();
+
+// Returns true if either
+//
+//   GOOGLE_CUDA is defined, and the given CUDA version supports
+//   half-precision matrix multiplications and convolution operations.
+//
+//     OR
+//
+//   TENSORFLOW_USE_ROCM is defined
+//
+@Namespace("tensorflow") public static native @Cast("bool") boolean GpuSupportsHalfMatMulAndConv();
+
+// Returns true if INTEL_MKL is defined
+@Namespace("tensorflow") public static native @Cast("bool") boolean IsMklEnabled();
+
+  // end namespace tensorflow
+
+// #endif  // TENSORFLOW_CORE_UTIL_PORT_H_
+
+
 // Parsed from tensorflow/c/tf_attrtype.h
 
 /* Copyright 2019 The TensorFlow Authors. All Rights Reserved.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/c_api/presets/tensorflow.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/c_api/presets/tensorflow.java
@@ -38,6 +38,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
             value = {"linux", "macosx", "windows"},
             compiler = "cpp11",
             include = {
+                "tensorflow/core/util/port.h",
                 "tensorflow/c/tf_attrtype.h",
                 "tensorflow/c/tf_datatype.h",
                 "tensorflow/c/tf_status.h",
@@ -48,7 +49,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
                 "tensorflow/c/ops.h",
                 "tensorflow/c/eager/c_api.h"
             },
-            link = "tensorflow@.2",
+            link = "tensorflow_cc@.2",
             preload = {"iomp5", "mklml", "mklml_intel", "tensorflow_framework@.2"},
             preloadresource = "/org/bytedeco/mkldnn/",
             resource = {"LICENSE", "THIRD_PARTY_TF_JNI_LICENSES"}


### PR DESCRIPTION
Fixes #82 

All tests pass on full builds:
https://github.com/saudet/tensorflow-java/actions/runs/250665886
Does not increase total build time when compared with current ones like:
https://github.com/tensorflow/java/actions/runs/215892440

Also:
 * Install CUDA via RPM files since NVIDIA broke their Docker containers
 * Build for 3.5 and 7.0 and keep PTX code (fixes #104)
 * Add "tensorflow/core/util/port.h" to the functions exposed via JavaCPP 

/cc @roywei