### PR TITLE
Fix validateTags() bug

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -429,7 +429,7 @@ public class SavedModelBundle implements AutoCloseable {
   }
 
   private static void validateTags(String[] tags) {
-    if (tags == null || tags.length == 0 || Arrays.stream(tags).anyMatch(t -> t == null || t.isEmpty())) {
+    if (tags == null || Arrays.stream(tags).anyMatch(t -> t == null || t.isEmpty())) {
       throw new IllegalArgumentException("Invalid tags: " + Arrays.toString(tags));
     }
   }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SavedModelBundleTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SavedModelBundleTest.java
@@ -262,10 +262,7 @@ public class SavedModelBundleTest {
   @Test
   public void cannotExportOrImportInvalidTags() {
     assertThrows(IllegalArgumentException.class, () ->
-        SavedModelBundle.loader("/").withTags()
-    );
-    assertThrows(IllegalArgumentException.class, () ->
-        SavedModelBundle.loader("/").withTags(new String[]{})
+        SavedModelBundle.loader("/").withTags(null)
     );
     assertThrows(IllegalArgumentException.class, () ->
         SavedModelBundle.loader("/").withTags(new String[]{"tag", null})
@@ -274,10 +271,7 @@ public class SavedModelBundleTest {
         SavedModelBundle.loader("/").withTags(new String[]{"tag", ""})
     );
     assertThrows(IllegalArgumentException.class, () ->
-        SavedModelBundle.exporter("/").withTags()
-    );
-    assertThrows(IllegalArgumentException.class, () ->
-        SavedModelBundle.exporter("/").withTags(new String[]{})
+        SavedModelBundle.exporter("/").withTags(null)
     );
     assertThrows(IllegalArgumentException.class, () ->
         SavedModelBundle.exporter("/").withTags(new String[]{"tag", null})


### PR DESCRIPTION
empty string array is a valid tag. TF 1.x model does not have any tags