### PR TITLE
Fix decoding of string length

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/StringTensorBuffer.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/StringTensorBuffer.java
@@ -105,7 +105,8 @@ public class StringTensorBuffer extends AbstractDataBuffer<byte[]> {
     int length = 0;
     do {
       b = data.getByte(offset++);
-      length |= (b & 0x7F) << pos++;
+      length |= (b & 0x7F) << pos;
+      pos += 7;
     } while ((b & 0x80) != 0);
 
     // Read string of the given length

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TStringTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TStringTest.java
@@ -41,7 +41,19 @@ public class TStringTest {
     assertEquals("Pretty vacant", data.getObject());
   }
 
-  @Test
+    @Test
+    public void createrScalarLongerThan127() {
+        Tensor<TString> tensor = TString.scalarOf("Long String 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 !");
+        assertNotNull(tensor);
+
+        TString data = tensor.data();
+        assertNotNull(data);
+        assertEquals(Shape.scalar(), data.shape());
+        assertEquals("Long String 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 !", data.getObject());
+    }
+
+
+    @Test
   public void createVector() {
     Tensor<TString> tensor = TString.vectorOf("Pretty", "vacant");
     assertNotNull(tensor);


### PR DESCRIPTION
When turning tensors with length > 127 into java Strings, they were truncated.

Patch contains an added test case with an example.