### PR TITLE
Fix Javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,18 @@
 
   <profiles>
     <!--
+    Developer profile
+        Enable javadoc generation so the developer is aware of any mistake that might prevent
+        ultimately the deployment of the artifacts
+    -->
+    <profile>
+      <id>dev</id>
+      <properties>
+        <maven.javadoc.skip>false</maven.javadoc.skip>
+      </properties>
+    </profile>
+
+    <!--
     Deploying profile
         Build the Javadoc when deploying
     -->

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/CategoricalCrossentropy.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/CategoricalCrossentropy.java
@@ -155,8 +155,8 @@ public class CategoricalCrossentropy extends Loss {
    * @param tf the TensorFlow Ops
    * @param fromLogits Whether to interpret predictions as a tensor of logit values
    * @param labelSmoothing Float in <code>[0, 1]</code>. When <code>&gt; 0</code>, label values are smoothed, meaning the
-   *    confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2<code> means that we will use a
-   *    value of </code>0.1<code> for label </code>0<code> and </code>0.9<code> for label </code>1<code>
+   *    confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2</code> means that we will use a
+   *    value of <code>0.1</code> for label <code>0</code> and <code>0.9</code> for label <code>1</code>
    */
   public CategoricalCrossentropy(Ops tf, boolean fromLogits, float labelSmoothing) {
     this(tf, null, fromLogits, labelSmoothing, REDUCTION_DEFAULT, DEFAULT_AXIS);
@@ -170,8 +170,8 @@ public class CategoricalCrossentropy extends Loss {
    * @param name the name of this loss
    * @param fromLogits Whether to interpret predictions as a tensor of logit values
    * @param labelSmoothing Float in <code>[0, 1]</code>. When <code>&gt; 0</code>, label values are smoothed, meaning the
-   *    confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2<code> means that we will use a
-   *    value of </code>0.1<code> for label </code>0<code> and </code>0.9<code> for label </code>1<code>
+   *    confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2</code> means that we will use a
+   *    value of <code>0.1</code> for label <code>0</code> and <code>0.9</code> for label <code>1</code>
    */
   public CategoricalCrossentropy(Ops tf, String name, boolean fromLogits, float labelSmoothing) {
     this(tf, name, fromLogits, labelSmoothing, REDUCTION_DEFAULT, DEFAULT_AXIS);
@@ -184,8 +184,8 @@ public class CategoricalCrossentropy extends Loss {
    * @param tf the TensorFlow Ops
    * @param fromLogits Whether to interpret predictions as a tensor of logit values
    * @param labelSmoothing Float in <code>[0, 1]</code>. When <code>&gt; 0</code>, label values are smoothed, meaning the
-   *    confidence on label values are relaxed. e.g. <code>x=0.2<code> means that we will use a
-   *    value of </code>0.1<code> for label </code>0<code> and </code>0.9<code> for label </code>1<code>
+   *    confidence on label values are relaxed. e.g. <code>x=0.2</code> means that we will use a
+   *    value of <code>0.1</code> for label <code>0</code> and <code>0.9</code> for label <code>1</code>
    * @param reduction Type of Reduction to apply to loss.
    */
   public CategoricalCrossentropy(
@@ -200,8 +200,8 @@ public class CategoricalCrossentropy extends Loss {
    * @param name the name of this loss
    * @param fromLogits Whether to interpret predictions as a tensor of logit values
    * @param labelSmoothing Float in <code>[0, 1]</code>. When <code>&gt; 0</code>, label values are smoothed, meaning the
-   *    confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2<code> means that we will use a
-   *    value of </code>0.1<code> for label </code>0<code> and </code>0.9<code> for label </code>1<code>
+   *    confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2</code> means that we will use a
+   *    value of <code>0.1</code> for label <code>0</code> and <code>0.9</code> for label <code>1</code>
    * @param reduction Type of Reduction to apply to loss.
    * @param axis The channels axis. <code>axis=-1</code> corresponds to data format `Channels Last'
    *     and <code>axis=1</code> corresponds to data format 'Channels First'.

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/Hinge.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/Hinge.java
@@ -25,7 +25,7 @@ import static org.tensorflow.framework.utils.CastHelper.cast;
  *
  * <p><code>loss = maximum(1 - labels * predictions, 0)</code></p>.
  *
- * <p><code>labels/code> values are expected to be -1 or 1.
+ * <p><code>labels</code> values are expected to be -1 or 1.
  * If binary (0 or 1) labels are provided, they will be converted to -1 or 1.</p>
  *
  * <p>Standalone usage:

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/Losses.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/Losses.java
@@ -218,8 +218,8 @@ public class Losses {
    * @param predictions the predictions
    * @param fromLogits Whether to interpret predictions as a tensor of logit values
    * @param labelSmoothing Float in <code>[0, 1]</code>. When <code>&gt; 0</code>, label values are smoothed, meaning the
-   *     confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2<code> means that we will use a
-   *     value of </code>0.1<code> for label </code>0<code> and </code>0.9<code> for label </code>1<code>
+   *     confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2</code> means that we will use a
+   *     value of <code>0.1</code> for label <code>0</code> and <code>0.9</code> for label <code>1</code>
    * @param axis the
    * @param <T> the data type of the predictions and labels
    * @return the categorical crossentropy loss.

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/impl/LossesHelper.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/impl/LossesHelper.java
@@ -43,10 +43,10 @@ public class LossesHelper {
    *
    * <ol type="1">
    *   <li>Squeezes last dim of <code>predictions</code> or <code>labels</code> if their rank
-   *       differs by 1 (using {@link #removeSqueezableDimensions}).
+   *       differs by 1 (using {@link #removeSqueezableDimensions}).</li>
    *   <li>Squeezes or expands last dim of <code>sampleWeight</code> if its rank differs by 1 from
    *       the new rank of <code>predictions</code>. If <code>sampleWeight</code> is scalar, it is
-   *       kept scalar./li>
+   *       kept scalar.</li>
    * </ol>
    *
    * @param tf the TensorFlow Ops
@@ -80,7 +80,7 @@ public class LossesHelper {
    *     </code>.
    * @param sampleWeights Optional sample weight(s) <code>Operand</code> whose dimensions match<code>
    *     prediction</code>.
-   * @return LossTuple of <code>prediction<s/code>, <code>labels</code> and <code>sampleWeight</code>.
+   * @return LossTuple of <code>predictions</code>, <code>labels</code> and <code>sampleWeight</code>.
    *     Each of them possibly has the last dimension squeezed, <code>sampleWeight</code> could be
    *     extended by one dimension. If <code>sampleWeight</code> is null, only the possibly shape modified <code>predictions</code> and <code>labels</code> are
    *     returned.
@@ -290,7 +290,7 @@ public class LossesHelper {
    * Computes a safe mean of the losses.
    *
    * @param tf the TensorFlow Ops
-   * @param losses </code>Operand</code> whose elements contain individual loss measurements.
+   * @param losses <code>Operand</code> whose elements contain individual loss measurements.
    * @param numElements The number of measurable elements in <code>losses</code>.
    * @param <T> the data type of the losses
    * @return A scalar representing the mean of <code>losses</code>. If <code>numElements</code> is


### PR DESCRIPTION
@JimClarke5 , FYI, I had to fix a few errors in the new Javadoc merged with #129 or it was preventing the deployment to OSSRH, as you can see in [this build](https://github.com/tensorflow/java/runs/1413747395?check_suite_focus=true).

Javadoc generation by maven was only enabled during deployment because it takes time to generate and I wanted to prevent our native builds on GitHub Actions to timeout because of this when it is not required, since we are so close of the 6 hours limit. But now, I'll reactivate it at least when using the `-Pdev` profile so the developers can be aware beforehand of these errors.

I'll merge right away this PR since I've already redeploy the artifacts locally based on these changes.

Thanks,
Karl