### PR TITLE
[TypeRefact] Added `Shaped` interface shared across different containers

### DIFF
--- a/ndarray/src/main/java/org/tensorflow/ndarray/NdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/NdArray.java
@@ -55,29 +55,7 @@ import org.tensorflow.ndarray.index.Index;
  *
  * @param <T> the type of values to be mapped
  */
-public interface NdArray<T> {
-
-  /**
-   * @return the shape of this N-dimensional array
-   */
-  Shape shape();
-
-  /**
-   * @return the rank of this N-dimensional array
-   */
-  default int rank() {
-    return shape().numDimensions();
-  }
-
-  /**
-   * Computes and returns the total size of this N-dimensional array, in number of values.
-   *
-   * <p>For example, given a 3x3x2 matrix, the return value will be 18.
-   * @return total size of this nd array
-   */
-  default long size() {
-    return shape().size();
-  }
+public interface NdArray<T> extends Shaped {
 
   /**
    * Returns a sequence of all elements at a given dimension.

--- a/ndarray/src/main/java/org/tensorflow/ndarray/NdArrays.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/NdArrays.java
@@ -65,7 +65,7 @@ public final class NdArrays {
     if (values == null) {
       throw new IllegalArgumentException("Values cannot be null");
     }
-    return wrap(DataBuffers.of(values, false, false), Shape.of(values.length));
+    return wrap(Shape.of(values.length), DataBuffers.of(values, false, false));
   }
 
   /**
@@ -81,19 +81,19 @@ public final class NdArrays {
     if (shape == null) {
       throw new IllegalArgumentException("Shape cannot be null");
     }
-    return wrap(DataBuffers.ofBytes(shape.size()), shape);
+    return wrap(shape, DataBuffers.ofBytes(shape.size()));
   }
 
   /**
    * Wraps a buffer in a byte N-dimensional array of a given shape.
    *
-   * @param buffer buffer to wrap
    * @param shape shape of the array
+   * @param buffer buffer to wrap
    * @return new byte N-dimensional array
    * @throws IllegalArgumentException if shape is null, has unknown dimensions or has size bigger
    *                                  in the buffer size
    */
-  public static ByteNdArray wrap(ByteDataBuffer buffer, Shape shape) {
+  public static ByteNdArray wrap(Shape shape, ByteDataBuffer buffer) {
     return ByteDenseNdArray.create(buffer, shape);
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/Shaped.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/Shaped.java
@@ -1,0 +1,51 @@
+/*
+ Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ =======================================================================
+ */
+package org.tensorflow.ndarray;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.tensorflow.ndarray.buffer.DataBuffer;
+import org.tensorflow.ndarray.index.Index;
+
+/**
+ * Any data container with a given {@link Shape}.
+ */
+public interface Shaped {
+
+  /**
+   * @return the shape of this container
+   */
+  Shape shape();
+
+  /**
+   * @return the rank of this container
+   */
+  default int rank() {
+    return shape().numDimensions();
+  }
+
+  /**
+   * Computes and returns the total size of this container, in number of values.
+   *
+   * <p>For example, given a 3x3x2 matrix, the return value will be 18.
+   *
+   * @return number of values in this element
+   */
+  default long size() {
+    return shape().size();
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_BarrierIncompleteSize.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_BarrierIncompleteSize.pbtxt
@@ -1,3 +1,7 @@
 op {
   graph_op_name: "BarrierIncompleteSize"
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_BarrierReadySize.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_BarrierReadySize.pbtxt
@@ -1,3 +1,7 @@
 op {
   graph_op_name: "BarrierReadySize"
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_LookupTableSizeV2.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_LookupTableSizeV2.pbtxt
@@ -3,4 +3,8 @@ op {
   endpoint {
     name: "LookupTableSize"
   }
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_MapIncompleteSize.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_MapIncompleteSize.pbtxt
@@ -1,3 +1,7 @@
 op {
   graph_op_name: "MapIncompleteSize"
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_MapSize.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_MapSize.pbtxt
@@ -1,3 +1,7 @@
 op {
   graph_op_name: "MapSize"
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_OrderedMapIncompleteSize.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_OrderedMapIncompleteSize.pbtxt
@@ -1,3 +1,7 @@
 op {
   graph_op_name: "OrderedMapIncompleteSize"
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_OrderedMapSize.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_OrderedMapSize.pbtxt
@@ -1,3 +1,7 @@
 op {
   graph_op_name: "OrderedMapSize"
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_QueueSizeV2.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_QueueSizeV2.pbtxt
@@ -3,4 +3,8 @@ op {
   endpoint {
     name: "io.QueueSize"
   }
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_SetSize.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_SetSize.pbtxt
@@ -1,3 +1,7 @@
 op {
   graph_op_name: "SetSize"
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_StageSize.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_StageSize.pbtxt
@@ -1,3 +1,7 @@
 op {
   graph_op_name: "StageSize"
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_TensorArraySizeV3.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/bazel/api_def/api_def_TensorArraySizeV3.pbtxt
@@ -3,4 +3,8 @@ op {
   endpoint {
     name: "TensorArraySize"
   }
+  out_arg {
+    name: "size"
+    rename_to: "output"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/BarrierIncompleteSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/BarrierIncompleteSize.java
@@ -53,23 +53,23 @@ public final class BarrierIncompleteSize extends RawOp implements Operand<TInt32
    * The number of incomplete elements (i.e. those with some of their value
    * components not set) in the barrier.
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "BarrierIncompleteSize";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private BarrierIncompleteSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/BarrierReadySize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/BarrierReadySize.java
@@ -53,23 +53,23 @@ public final class BarrierReadySize extends RawOp implements Operand<TInt32> {
    * The number of complete elements (i.e. those with all of their value
    * components set) in the barrier.
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "BarrierReadySize";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private BarrierReadySize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/LookupTableSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/LookupTableSize.java
@@ -51,23 +51,23 @@ public final class LookupTableSize extends RawOp implements Operand<TInt64> {
   /**
    * Scalar that contains number of elements in the table.
    */
-  public Output<TInt64> size() {
-    return size;
+  public Output<TInt64> output() {
+    return output;
   }
   
   @Override
   public Output<TInt64> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "LookupTableSizeV2";
   
-  private Output<TInt64> size;
+  private Output<TInt64> output;
   
   private LookupTableSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/MapIncompleteSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/MapIncompleteSize.java
@@ -147,23 +147,23 @@ public final class MapIncompleteSize extends RawOp implements Operand<TInt32> {
   
   /**
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "MapIncompleteSize";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private MapIncompleteSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/MapSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/MapSize.java
@@ -147,23 +147,23 @@ public final class MapSize extends RawOp implements Operand<TInt32> {
   
   /**
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "MapSize";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private MapSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/OrderedMapIncompleteSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/OrderedMapIncompleteSize.java
@@ -147,23 +147,23 @@ public final class OrderedMapIncompleteSize extends RawOp implements Operand<TIn
   
   /**
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "OrderedMapIncompleteSize";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private OrderedMapIncompleteSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/OrderedMapSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/OrderedMapSize.java
@@ -147,23 +147,23 @@ public final class OrderedMapSize extends RawOp implements Operand<TInt32> {
   
   /**
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "OrderedMapSize";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private OrderedMapSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/SetSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/SetSize.java
@@ -100,23 +100,23 @@ public final class SetSize extends RawOp implements Operand<TInt32> {
    * `n-1` dimensions as `set`. Each value is the number of unique elements in
    * the corresponding `[0...n-1]` dimension of `set`.
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "SetSize";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private SetSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/StageSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/StageSize.java
@@ -147,23 +147,23 @@ public final class StageSize extends RawOp implements Operand<TInt32> {
   
   /**
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "StageSize";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private StageSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/TensorArraySize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/core/TensorArraySize.java
@@ -54,23 +54,23 @@ public final class TensorArraySize extends RawOp implements Operand<TInt32> {
   /**
    * The current size of the TensorArray.
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "TensorArraySizeV3";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private TensorArraySize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/io/QueueSize.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/io/QueueSize.java
@@ -51,23 +51,23 @@ public final class QueueSize extends RawOp implements Operand<TInt32> {
   /**
    * The number of elements in the given queue.
    */
-  public Output<TInt32> size() {
-    return size;
+  public Output<TInt32> output() {
+    return output;
   }
   
   @Override
   public Output<TInt32> asOutput() {
-    return size;
+    return output;
   }
   
   /** The name of this op, as known by TensorFlow core engine */
   public static final String OP_NAME = "QueueSizeV2";
   
-  private Output<TInt32> size;
+  private Output<TInt32> output;
   
   private QueueSize(Operation operation) {
     super(operation);
     int outputIdx = 0;
-    size = operation.output(outputIdx++);
+    output = operation.output(outputIdx++);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Operand.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Operand.java
@@ -15,6 +15,8 @@ limitations under the License.
 
 package org.tensorflow;
 
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.Shaped;
 import org.tensorflow.op.Op;
 import org.tensorflow.types.family.TType;
 
@@ -39,7 +41,7 @@ import org.tensorflow.types.family.TType;
  * tf.concat(split, tf.constant(0));
  * }</pre>
  */
-public interface Operand<T extends TType> extends Op {
+public interface Operand<T extends TType> extends Op, Shaped {
 
   /**
    * Returns the symbolic handle of the tensor.
@@ -75,5 +77,10 @@ public interface Operand<T extends TType> extends Op {
    */
   default T data() {
     return asOutput().tensor().data();
+  }
+
+  @Override
+  default Shape shape() {
+    return asOutput().shape();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Operand.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Operand.java
@@ -79,6 +79,9 @@ public interface Operand<T extends TType> extends Op, Shaped {
     return asOutput().tensor().data();
   }
 
+  /**
+   * Returns the (possibly partially known) shape of the tensor referred to by the {@link Output} of this operand.
+   */
   @Override
   default Shape shape() {
     return asOutput().shape();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
@@ -80,6 +80,9 @@ public final class Output<T extends TType> implements Operand<T> {
     return (Tensor<T>) operation.tensor(index);
   }
 
+  /**
+   * Returns the (possibly partially known) shape of the tensor referred to by this output.
+   */
   @Override
   public Shape shape() {
     return operation.shape(index);

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
@@ -18,6 +18,7 @@ package org.tensorflow;
 import java.util.Objects;
 import org.bytedeco.javacpp.Pointer;
 import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.Shaped;
 import org.tensorflow.types.family.TType;
 
 /**
@@ -34,11 +35,6 @@ public final class Output<T extends TType> implements Operand<T> {
   /** Returns the index into the outputs of the Operation. */
   public int index() {
     return index;
-  }
-
-  /** Returns the (possibly partially known) shape of the tensor referred to by this Output. */
-  public Shape shape() {
-    return operation.shape(index);
   }
 
   /** Returns the DataType of the tensor referred to by this Output. */
@@ -82,6 +78,11 @@ public final class Output<T extends TType> implements Operand<T> {
   @SuppressWarnings("unchecked")
   public Tensor<T> tensor() {
     return (Tensor<T>) operation.tensor(index);
+  }
+
+  @Override
+  public Shape shape() {
+    return operation.shape(index);
   }
 
   @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
@@ -233,6 +233,7 @@ public final class Tensor<T extends TType> implements Shaped, AutoCloseable {
     return numBytes;
   }
 
+  /** Returns the shape of this tensor. */
   @Override
   public Shape shape() {
     return shape;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
@@ -26,6 +26,7 @@ import org.tensorflow.internal.buffer.TensorBuffers;
 import org.tensorflow.internal.c_api.TF_Tensor;
 import org.tensorflow.ndarray.NdArray;
 import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.Shaped;
 import org.tensorflow.ndarray.buffer.ByteDataBuffer;
 import org.tensorflow.types.family.TType;
 
@@ -44,7 +45,7 @@ import org.tensorflow.types.family.TType;
  * }
  * }</pre>
  */
-public final class Tensor<T extends TType> implements AutoCloseable {
+public final class Tensor<T extends TType> implements Shaped, AutoCloseable {
 
   /**
    * Allocates a tensor of a given datatype and shape.
@@ -232,12 +233,7 @@ public final class Tensor<T extends TType> implements AutoCloseable {
     return numBytes;
   }
 
-  /**
-   * Returns the <a href="https://www.tensorflow.org/resources/dims_types.html#shape">shape</a> of
-   * the Tensor, i.e., the sizes of each dimension.
-   *
-   * @return shape of this tensor
-   */
+  @Override
   public Shape shape() {
     return shape;
   }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SigmoidCrossEntropyWithLogits.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SigmoidCrossEntropyWithLogits.java
@@ -67,7 +67,7 @@ public class SigmoidCrossEntropyWithLogits {
       throw new IllegalArgumentException(
           String.format(
               "logits and labels must have the same shape (%s vs %s)",
-              labels.shape().toString(), logits.shape()));
+              labels.shape(), logits.shape()));
     }
     scope = scope.withSubScope("SigmoidCrossEntropyWithLogits");
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SigmoidCrossEntropyWithLogits.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SigmoidCrossEntropyWithLogits.java
@@ -63,11 +63,11 @@ public class SigmoidCrossEntropyWithLogits {
   @Endpoint(name = "sigmoidCrossEntropyWithLogits")
   public static <T extends TNumber> Operand<T> sigmoidCrossEntropyWithLogits(
       Scope scope, Operand<T> labels, Operand<T> logits) {
-    if (!isCompatible(labels.asOutput().shape(), logits.asOutput().shape())) {
+    if (!isCompatible(labels.shape(), logits.shape())) {
       throw new IllegalArgumentException(
           String.format(
               "logits and labels must have the same shape (%s vs %s)",
-              labels.asOutput().shape().toString(), logits.asOutput().shape()));
+              labels.shape().toString(), logits.shape()));
     }
     scope = scope.withSubScope("SigmoidCrossEntropyWithLogits");
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SoftmaxCrossEntropyWithLogits.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SoftmaxCrossEntropyWithLogits.java
@@ -73,9 +73,9 @@ public class SoftmaxCrossEntropyWithLogits {
   public static <T extends TNumber, U extends TNumber> Operand<T> softmaxCrossEntropyWithLogits(
       Scope scope, Operand<U> labels, Operand<T> logits, int axis) {
     scope = scope.withSubScope("SoftmaxCrossEntropyWithLogits");
-    axis = axis % logits.asOutput().shape().numDimensions();
+    axis = axis % logits.shape().numDimensions();
     if (axis < 0) {
-      axis += logits.asOutput().shape().numDimensions();
+      axis += logits.shape().numDimensions();
     }
 
 
@@ -96,15 +96,15 @@ public class SoftmaxCrossEntropyWithLogits {
     }
 
     Operand<TInt64> inputRank = Cast.create(scope, Rank.create(scope, logits), TInt64.DTYPE);
-    Shape shape = logits.asOutput().shape();
+    Shape shape = logits.shape();
 
     // Move the dim to the end if dim is not the last dimension.
-    if (axis != -1 && axis != logits.asOutput().shape().numDimensions() - 1) {
+    if (axis != -1 && axis != logits.shape().numDimensions() - 1) {
       logits = moveDimToEnd(scope, logits, axis, inputRank);
       labels = moveDimToEnd(scope, labels, axis, inputRank);
     }
 
-    Shape inputShape = logits.asOutput().shape();
+    Shape inputShape = logits.shape();
     logits = flattenOuterDims(scope, logits);
     labels = flattenOuterDims(scope, labels);
 
@@ -149,7 +149,7 @@ public class SoftmaxCrossEntropyWithLogits {
   private static <T extends TNumber> Operand<T> flattenOuterDims(Scope scope, Operand<T> logits) {
     Operand<TInt64> one = Constant.scalarOf(scope, 1L);
 
-    Shape shape = logits.asOutput().shape();
+    Shape shape = logits.shape();
     int ndims = shape.numDimensions();
     if (!shape.hasUnknownDimension()) {
       long product = 1L;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SparseSoftmaxCrossEntropyWithLogits.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SparseSoftmaxCrossEntropyWithLogits.java
@@ -98,7 +98,7 @@ public class SparseSoftmaxCrossEntropyWithLogits {
       throw new IllegalArgumentException(
           String.format(
               "Rank mismatch: Rank of labels (received %s) should equal rank of logits minus 1 (received %s).",
-              labelsStaticShape.toString(), logitsShape.toString()));
+              labelsStaticShape, logitsShape));
     }
 
     if (staticShapesFullyDefined && !labelsStaticShape.equals(logitsShortened)) {
@@ -107,7 +107,7 @@ public class SparseSoftmaxCrossEntropyWithLogits {
               "Shape mismatch: The shape of labels (received %s) "
                   + "should equal the shape of logits except for the last "
                   + "dimension (received %s).",
-              labelsStaticShape.toString(), logitsShape.toString()));
+              labelsStaticShape, logitsShape));
     }
     // Check if no reshapes are required.
     if (logitsShape.numDimensions() == 2) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SparseSoftmaxCrossEntropyWithLogits.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/nn/SparseSoftmaxCrossEntropyWithLogits.java
@@ -80,10 +80,10 @@ public class SparseSoftmaxCrossEntropyWithLogits {
     if (convertToFloat32) {
       preciseLogits = Cast.create(scope, logits, TFloat32.DTYPE);
     }
-    Shape labelsStaticShape = labels.asOutput().shape();
+    Shape labelsStaticShape = labels.shape();
     org.tensorflow.op.core.Shape<TInt32> labelsShape =
         org.tensorflow.op.core.Shape.create(scope, labels);
-    Shape logitsShape = logits.asOutput().shape();
+    Shape logitsShape = logits.shape();
     Shape logitsShortened = logitsShape.take(logitsShape.numDimensions() - 1);
 
     boolean staticShapesFullyDefined =

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/activations/Softmax.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/activations/Softmax.java
@@ -73,7 +73,7 @@ public class Softmax<T extends TFloating> extends Activation<T> {
    */
   @Override
   public Operand<T> call(Operand<T> input) {
-    Shape shape = input.asOutput().shape();
+    Shape shape = input.shape();
     int numDimensions = shape.numDimensions();
     if (numDimensions == 2) {
       return tf.nn.softmax(input);

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/data/impl/TensorSliceDataset.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/data/impl/TensorSliceDataset.java
@@ -31,7 +31,7 @@ public class TensorSliceDataset extends Dataset {
   }
 
   private static List<Shape> outputShapes(List<Operand<?>> components) {
-    return components.stream().map(c -> c.asOutput().shape().tail()).collect(Collectors.toList());
+    return components.stream().map(c -> c.shape().tail()).collect(Collectors.toList());
   }
 
   private static Operand<?> makeVariant(

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/Losses.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/Losses.java
@@ -535,7 +535,7 @@ public class Losses {
       predictions = tf.clipByValue(predictions, epsilonConst, oneMinusEpsilonConst);
       predictions = tf.math.log(predictions);
     }
-    Shape predictionsShape = predictions.asOutput().shape();
+    Shape predictionsShape = predictions.shape();
     int predictionsRank = predictionsShape.numDimensions();
     axis %= predictionsRank;
     if (axis < 0) {
@@ -549,7 +549,7 @@ public class Losses {
     Operand<TInt64> iLabels = cast(tf, labels, TInt64.DTYPE);
 
     // Try to adjust the shape so that rank of labels = rank of logits - 1.
-    Shape labelsShape = labels.asOutput().shape();
+    Shape labelsShape = labels.shape();
     int labelsRank = labelsShape.numDimensions();
 
     boolean updateShape = labelsRank != predictionsRank - 1;
@@ -635,7 +635,7 @@ public class Losses {
       Ops tf, Operand<T> labels, float labelSmoothing) {
     DataType<T> dataType = labels.asOutput().dataType();
     Operand<T> smoothing = cast(tf, tf.constant(labelSmoothing), dataType);
-    Shape labelsShape = labels.asOutput().shape();
+    Shape labelsShape = labels.shape();
     int numDims = labelsShape.numDimensions();
     Operand<T> numClasses = cast(tf, tf.constant(labelsShape.size(numDims - 1)), dataType);
     Operand<T> oneMinusSmoothing = cast(tf, tf.constant(1.f - labelSmoothing), dataType);

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/impl/LossesHelper.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/impl/LossesHelper.java
@@ -88,13 +88,13 @@ public class LossesHelper {
   public static <T extends TNumber> LossTuple<T> squeezeOrExpandDimensions(
       Ops tf, Operand<T> labels, Operand<T> predictions, Operand<T> sampleWeights) {
 
-    Shape predictionsShape = predictions.asOutput().shape();
+    Shape predictionsShape = predictions.shape();
     long predictionsRank = predictionsShape.numDimensions();
 
     // Default case when no modifications are made.
     LossTuple<T> lossTuple = new LossTuple<>(labels, predictions, sampleWeights);
     if (labels != null) {
-      Shape labelsShape = labels.asOutput().shape();
+      Shape labelsShape = labels.shape();
       long labelsRank = labelsShape.numDimensions();
       if (labelsRank != Shape.UNKNOWN_SIZE && predictionsRank != Shape.UNKNOWN_SIZE) {
         // Use static rank for 'label' and 'prediction'.
@@ -108,7 +108,7 @@ public class LossesHelper {
     if (sampleWeights == null) { // nothing more to do.
       return lossTuple;
     }
-    Shape weightsShape = sampleWeights.asOutput().shape();
+    Shape weightsShape = sampleWeights.shape();
     long weightsRank = weightsShape.numDimensions();
     if (weightsRank == 0) { // scalar
       return new LossTuple<>(lossTuple.getLabels(), lossTuple.getTarget(), sampleWeights);
@@ -200,9 +200,9 @@ public class LossesHelper {
       Ops tf, Operand<T> labels, Operand<T> predictions, int expectedRankDiff) {
 
     tf = tf.withSubScope("removeSqueezableDimensions");
-    Shape predictionsShape = predictions.asOutput().shape();
+    Shape predictionsShape = predictions.shape();
     int predictionsRank = predictionsShape.numDimensions();
-    Shape labelsShape = labels.asOutput().shape();
+    Shape labelsShape = labels.shape();
     int labelsRank = labelsShape.numDimensions();
 
     if (predictionsRank != Shape.UNKNOWN_SIZE || labelsRank != Shape.UNKNOWN_SIZE) {
@@ -280,7 +280,7 @@ public class LossesHelper {
       loss =
           tf.reduceSum(weightedLoss, allAxes(tf, weightedLoss), ReduceSum.keepDims(Boolean.FALSE));
       if (reduction == Reduction.AUTO || reduction == Reduction.SUM_OVER_BATCH_SIZE) {
-        loss = safeMean(tf, loss, weightedLoss.asOutput().shape().size());
+        loss = safeMean(tf, loss, weightedLoss.shape().size());
       }
     }
     return loss;
@@ -312,7 +312,7 @@ public class LossesHelper {
    * @return a Constant that represents all the axes of the operand.
    */
   public static <T extends TNumber> Operand<TInt32> allAxes(Ops tf, Operand<T> op) {
-    int rank = op.asOutput().shape().numDimensions();
+    int rank = op.shape().numDimensions();
     if (rank != Shape.UNKNOWN_SIZE) {
       int[] axes = new int[rank];
       for (int i = 0; i < rank; i++) {
@@ -385,9 +385,9 @@ public class LossesHelper {
   public static <T extends TNumber> Operand<T> valueCheck(
       Ops tf, String prefix, Operand<T> values, Operand<T> allowedValues) {
     Operand<T> flatValues =
-        tf.reshape(values, tf.constant(Shape.of(values.asOutput().shape().size())));
+        tf.reshape(values, tf.constant(Shape.of(values.shape().size())));
     SetDiff1d<T, TInt32> diff = tf.setDiff1d(flatValues, allowedValues, TInt32.DTYPE);
-    long diffSize = diff.out().asOutput().shape().size();
+    long diffSize = diff.out().shape().size();
 
     if (diffSize != Shape.UNKNOWN_SIZE) {
       if (diffSize != 0) { // at least 1 value in the diff did not match the allowed values.

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/AdaDeltaTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/AdaDeltaTest.java
@@ -118,16 +118,16 @@ public class AdaDeltaTest {
           Variable<TFloat32>[] slotUpdates = new Variable[2];
 
           slots[0] = adaDelta.getSlot(var0.asOutput(), ACCUMULATOR).get();
-          assertEquals(slots[0].asOutput().shape(), var0.asOutput().shape());
+          assertEquals(slots[0].shape(), var0.shape());
 
           slotUpdates[0] = adaDelta.getSlot(var0.asOutput(), ACCUMULATOR_UPDATE).get();
-          assertEquals(slotUpdates[0].asOutput().shape(), var0.asOutput().shape());
+          assertEquals(slotUpdates[0].shape(), var0.shape());
 
           slots[1] = adaDelta.getSlot(var1.asOutput(), ACCUMULATOR).get();
-          assertEquals(slots[1].asOutput().shape(), var1.asOutput().shape());
+          assertEquals(slots[1].shape(), var1.shape());
 
           slotUpdates[1] = adaDelta.getSlot(var1.asOutput(), ACCUMULATOR_UPDATE).get();
-          assertEquals(slotUpdates[1].asOutput().shape(), var1.asOutput().shape());
+          assertEquals(slotUpdates[1].shape(), var1.shape());
 
           /* initialize the local variables */
           session.run(var0Initializer);

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/AdaGradTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/AdaGradTest.java
@@ -99,10 +99,10 @@ public class AdaGradTest {
 
       Variable<TFloat32>[] accumulatorSlots = new Variable[2];
       accumulatorSlots[0] = instance.getSlot(var0.asOutput(), ACCUMULATOR).get();
-      assertEquals(accumulatorSlots[0].asOutput().shape(), var0.asOutput().shape());
+      assertEquals(accumulatorSlots[0].shape(), var0.shape());
 
       accumulatorSlots[1] = instance.getSlot(var1.asOutput(), ACCUMULATOR).get();
-      assertEquals(accumulatorSlots[1].asOutput().shape(), var1.asOutput().shape());
+      assertEquals(accumulatorSlots[1].shape(), var1.shape());
 
       /* initialize the local variables */
       session.run(var0Initializer);

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/AdamTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/AdamTest.java
@@ -111,16 +111,16 @@ public class AdamTest {
       Variable<TFloat32>[] secondMomentSlots = new Variable[2];
 
       firstMomentSlots[0] = instance.getSlot(var0.asOutput(), FIRST_MOMENT).get();
-      assertEquals(firstMomentSlots[0].asOutput().shape(), var0.asOutput().shape());
+      assertEquals(firstMomentSlots[0].shape(), var0.shape());
 
       secondMomentSlots[0] = instance.getSlot(var0.asOutput(), SECOND_MOMENT).get();
-      assertEquals(secondMomentSlots[0].asOutput().shape(), var0.asOutput().shape());
+      assertEquals(secondMomentSlots[0].shape(), var0.shape());
 
       firstMomentSlots[1] = instance.getSlot(var1.asOutput(), FIRST_MOMENT).get();
-      assertEquals(firstMomentSlots[1].asOutput().shape(), var1.asOutput().shape());
+      assertEquals(firstMomentSlots[1].shape(), var1.shape());
 
       secondMomentSlots[1] = instance.getSlot(var1.asOutput(), SECOND_MOMENT).get();
-      assertEquals(secondMomentSlots[1].asOutput().shape(), var1.asOutput().shape());
+      assertEquals(secondMomentSlots[1].shape(), var1.shape());
 
       /* initialize the accumulators */
       session.run(tf.init());

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/AdamaxTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/AdamaxTest.java
@@ -127,16 +127,16 @@ public class AdamaxTest {
       Variable<TFloat32>[] secondMomentSlots = new Variable[2];
 
       firstMomentSlots[0] = instance.getSlot(var0.asOutput(), FIRST_MOMENT).get();
-      assertEquals(firstMomentSlots[0].asOutput().shape(), var0.asOutput().shape());
+      assertEquals(firstMomentSlots[0].shape(), var0.shape());
 
       secondMomentSlots[0] = instance.getSlot(var0.asOutput(), SECOND_MOMENT).get();
-      assertEquals(secondMomentSlots[0].asOutput().shape(), var0.asOutput().shape());
+      assertEquals(secondMomentSlots[0].shape(), var0.shape());
 
       firstMomentSlots[1] = instance.getSlot(var1.asOutput(), FIRST_MOMENT).get();
-      assertEquals(firstMomentSlots[1].asOutput().shape(), var1.asOutput().shape());
+      assertEquals(firstMomentSlots[1].shape(), var1.shape());
 
       secondMomentSlots[1] = instance.getSlot(var1.asOutput(), SECOND_MOMENT).get();
-      assertEquals(secondMomentSlots[1].asOutput().shape(), var1.asOutput().shape());
+      assertEquals(secondMomentSlots[1].shape(), var1.shape());
 
       /* initialize the accumulators */
       session.run(tf.init());

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/MomentumTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/MomentumTest.java
@@ -148,9 +148,9 @@ public class MomentumTest {
       Op update = instance.applyGradients(gradsAndVars, "SGDTest");
 
       Variable<TFloat32> momentumSlot0 = instance.getSlot(var0.asOutput(), MOMENTUM).get();
-      assertEquals(momentumSlot0.asOutput().shape(), var0.asOutput().shape());
+      assertEquals(momentumSlot0.shape(), var0.shape());
       Variable<TFloat32> momentumSlot1 = instance.getSlot(var1.asOutput(), MOMENTUM).get();
-      assertEquals(momentumSlot1.asOutput().shape(), var1.asOutput().shape());
+      assertEquals(momentumSlot1.shape(), var1.shape());
 
       /* initialize the local variables */
       session.run(var0Initializer);

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/NadamTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/NadamTest.java
@@ -124,16 +124,16 @@ public class NadamTest {
       Variable<TFloat32>[] secondMomentSlots = new Variable[2];
 
       firstMomentSlots[0] = instance.getSlot(var0.asOutput(), Nadam.FIRST_MOMENT).get();
-      assertEquals(firstMomentSlots[0].asOutput().shape(), var0.asOutput().shape());
+      assertEquals(firstMomentSlots[0].shape(), var0.shape());
 
       secondMomentSlots[0] = instance.getSlot(var0.asOutput(), Nadam.SECOND_MOMENT).get();
-      assertEquals(secondMomentSlots[0].asOutput().shape(), var0.asOutput().shape());
+      assertEquals(secondMomentSlots[0].shape(), var0.shape());
 
       firstMomentSlots[1] = instance.getSlot(var1.asOutput(), Nadam.FIRST_MOMENT).get();
-      assertEquals(firstMomentSlots[1].asOutput().shape(), var1.asOutput().shape());
+      assertEquals(firstMomentSlots[1].shape(), var1.shape());
 
       secondMomentSlots[1] = instance.getSlot(var1.asOutput(), Nadam.SECOND_MOMENT).get();
-      assertEquals(secondMomentSlots[1].asOutput().shape(), var1.asOutput().shape());
+      assertEquals(secondMomentSlots[1].shape(), var1.shape());
 
       /* initialize the local variables */
       session.run(var0Initializer);

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/utils/GraphTestSession.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/utils/GraphTestSession.java
@@ -1021,7 +1021,7 @@ public class GraphTestSession extends TestSession {
   /** {@inheritDoc} */
   @Override
   public <T extends TType> void print(PrintWriter writer, Output<T> input) {
-    boolean isScalar = input.asOutput().shape().size() == 1;
+    boolean isScalar = input.shape().size() == 1;
 
     DataType<T> dtype = input.dataType();
     if (dtype == TFloat32.DTYPE) {


### PR DESCRIPTION
PR related to #139.

It extracts the shape-related operators of the `NdArray` interface into a separate interface (`Shaped`) that is shared across the client for each container with a given shape. 

I had to rename the output of a few operators as it was conflicting with the `size()` method of `Shaped`, which is now inherited by `Operand`.

CC\ @deansher 