### PR TITLE
Change eager mode control inputs from exception to no-op, reflecting eager semantics.

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
@@ -90,8 +90,8 @@ final class EagerOperationBuilder implements OperationBuilder {
 
   @Override
   public OperationBuilder addControlInput(Operation control) {
-    throw new UnsupportedOperationException(
-        "Control inputs are not supported in an eager execution environment");
+    // No-op.  Any operations passed to this method will already be evaluated (b/c eager evaluation).
+    return this;
   }
 
   @Override

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/EagerOperationBuilderTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/EagerOperationBuilderTest.java
@@ -61,12 +61,7 @@ public class EagerOperationBuilderTest {
               .addInput(tf.constant(true).asOutput())
               .addInputList(new Output<?>[] {tf.constant(-1).asOutput()})
               .build();
-      try {
-        opBuilder(session, "Const", "var").addControlInput(asrt);
-        fail();
-      } catch (UnsupportedOperationException e) {
-        // expected
-      }
+      opBuilder(session, "Const", "var").addControlInput(asrt);
     }
   }
 


### PR DESCRIPTION
Simple PR to fix #157.  Makes adding control inputs in eager mode a no-op instead of an exception, for the reasons described in the issue (since it's eager mode, any control deps being added will already have been computed).