### PR TITLE
Add ones op

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -128,6 +128,7 @@ import org.tensorflow.op.core.MutexLock;
 import org.tensorflow.op.core.NextIteration;
 import org.tensorflow.op.core.NoOp;
 import org.tensorflow.op.core.OneHot;
+import org.tensorflow.op.core.Ones;
 import org.tensorflow.op.core.OnesLike;
 import org.tensorflow.op.core.OrderedMapClear;
 import org.tensorflow.op.core.OrderedMapIncompleteSize;
@@ -3424,6 +3425,19 @@ public final class Ops {
   public <U extends TType, T extends TNumber> OneHot<U> oneHot(Operand<T> indices,
       Operand<TInt32> depth, Operand<U> onValue, Operand<U> offValue, OneHot.Options... options) {
     return OneHot.create(scope, indices, depth, onValue, offValue, options);
+  }
+
+  /**
+   * Creates a one valued tensor given its type and shape.
+   *
+   * @param scope is a scope used to add the underlying operation
+   * @param dims a 1-D operand that represents the shape of the output tensor
+   * @param type the output tensor datatype. Can not be TString.
+   * @return a constant tensor initialized with zeros
+   * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with ones.
+   */
+  public <T extends TType, U extends TNumber> Ones<T> ones(Operand<U> dims, DataType<T> type) {
+    return Ones.create(scope, dims, type);
   }
 
   /**
@@ -7726,7 +7740,7 @@ public final class Ops {
   }
 
   /**
-   * Returns an API that uses the provided DeviceSpec for an op.
+   * Returns an API that places the created operations on the device(s) matching the provided spec.
    *
    * @see {@link Scope#withDevice(DeviceSpec)}
    */

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -3433,7 +3433,7 @@ public final class Ops {
    * @param scope is a scope used to add the underlying operation
    * @param dims a 1-D operand that represents the shape of the output tensor
    * @param type the output tensor datatype. Can not be TString.
-   * @return a constant tensor initialized with zeros
+   * @return a constant tensor initialized with ones
    * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with ones.
    */
   public <T extends TType, U extends TNumber> Ones<T> ones(Operand<U> dims, DataType<T> type) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Ones.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Ones.java
@@ -46,17 +46,17 @@ public final class Ones<T extends TType> implements Op, Operand<T> {
    * @param scope is a scope used to add the underlying operation
    * @param dims a 1-D operand that represents the shape of the output tensor
    * @param type the output tensor datatype. Can not be TString.
-   * @return a constant tensor initialized with zeros
+   * @return a constant tensor initialized with ones
    * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with ones.
    */
   @Endpoint
   public static <T extends TType, U extends TNumber> Ones<T> create(Scope scope, Operand<U> dims, DataType<T> type) {
-    Scope zerosScope = scope.withSubScope("Ones");
+    Scope onesScope = scope.withSubScope("Ones");
     if (type == TString.DTYPE) {
       throw new IllegalArgumentException("Can't create Ones of String DataType");
     }
-    Operand<T> one = Cast.create(zerosScope.withName("One"), Constant.scalarOf(zerosScope, 1), type);
-    return new Ones<>(Fill.create(zerosScope.withName("Fill"), dims, one));
+    Operand<T> one = Cast.create(onesScope.withName("One"), Constant.scalarOf(onesScope, 1), type);
+    return new Ones<>(Fill.create(onesScope.withName("Fill"), dims, one));
   }
 
   @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Ones.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Ones.java
@@ -1,0 +1,77 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+package org.tensorflow.op.core;
+
+import org.tensorflow.DataType;
+import org.tensorflow.Operand;
+import org.tensorflow.Operation;
+import org.tensorflow.Output;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Scope;
+import org.tensorflow.op.annotation.Endpoint;
+import org.tensorflow.op.annotation.Operator;
+import org.tensorflow.op.dtypes.Cast;
+import org.tensorflow.types.TString;
+import org.tensorflow.types.family.TNumber;
+import org.tensorflow.types.family.TType;
+
+/**
+ * An operator creating a constant initialized with ones of the shape given by `dims`.
+ * 
+ * <p>For example, the following expression
+ * <pre>{@code tf.ones(tf.constant(shape), TFloat32.DTYPE)</pre>
+ * is the equivalent of
+ * <pre>{@code tf.fill(tf.constant(shape), tf.constant(1.0f))</pre>
+ *
+ * @param <T> constant type
+ */
+@Operator
+public final class Ones<T extends TType> implements Op, Operand<T> {
+
+  /**
+   * Creates a one valued tensor given its type and shape.
+   *
+   * @param scope is a scope used to add the underlying operation
+   * @param dims a 1-D operand that represents the shape of the output tensor
+   * @param type the output tensor datatype. Can not be TString.
+   * @return a constant tensor initialized with zeros
+   * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with ones.
+   */
+  @Endpoint
+  public static <T extends TType, U extends TNumber> Ones<T> create(Scope scope, Operand<U> dims, DataType<T> type) {
+    Scope zerosScope = scope.withSubScope("Ones");
+    if (type == TString.DTYPE) {
+      throw new IllegalArgumentException("Can't create Ones of String DataType");
+    }
+    Operand<T> one = Cast.create(zerosScope.withName("One"), Constant.scalarOf(zerosScope, 1), type);
+    return new Ones<>(Fill.create(zerosScope.withName("Fill"), dims, one));
+  }
+
+  @Override
+  public Operation op() {
+    return fill.op();
+  }
+
+  @Override
+  public Output<T> asOutput() {
+    return fill.asOutput();
+  }
+
+  private final Fill<T> fill;
+
+  private Ones(Fill<T> fill) {
+    this.fill = fill;
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Ones.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Ones.java
@@ -1,4 +1,4 @@
-/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,9 +31,9 @@ import org.tensorflow.types.family.TType;
  * An operator creating a constant initialized with ones of the shape given by `dims`.
  * 
  * <p>For example, the following expression
- * <pre>{@code tf.ones(tf.constant(shape), TFloat32.DTYPE)</pre>
+ * <pre>{@code tf.ones(tf.constant(shape), TFloat32.DTYPE)}</pre>
  * is the equivalent of
- * <pre>{@code tf.fill(tf.constant(shape), tf.constant(1.0f))</pre>
+ * <pre>{@code tf.fill(tf.constant(shape), tf.constant(1.0f))}</pre>
  *
  * @param <T> constant type
  */


### PR DESCRIPTION
Simple PR to add a ones op to match Python TF and numpy APIs.  Copies from Zeros and operates in the same way (`fill` + `constant`).