### PR TITLE
Nicer error messages for mode-forbidden ops

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
@@ -56,10 +56,6 @@ import org.tensorflow.proto.framework.DataType;
 final class EagerOperationBuilder implements OperationBuilder {
 
   EagerOperationBuilder(EagerSession session, String type, String name) {
-    if (!session.isOpEnabled(type)) {
-      throw new IllegalArgumentException("Op " + type + " is not valid in eager mode.");
-    }
-
     this.session = session;
     this.type = type;
     this.name = name;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
@@ -56,8 +56,9 @@ import org.tensorflow.proto.framework.DataType;
 final class EagerOperationBuilder implements OperationBuilder {
 
   EagerOperationBuilder(EagerSession session, String type, String name) {
-    if(!session.isOpEnabled(type))
+    if (!session.isOpEnabled(type)) {
       throw new IllegalArgumentException("Op " + type + " is not valid in eager mode.");
+    }
 
     this.session = session;
     this.type = type;
@@ -78,7 +79,7 @@ final class EagerOperationBuilder implements OperationBuilder {
 
   @Override
   public EagerOperationBuilder addInput(Output<?> input) {
-    addInput(opHandle, (TFE_TensorHandle)input.getUnsafeNativeHandle());
+    addInput(opHandle, (TFE_TensorHandle) input.getUnsafeNativeHandle());
     return this;
   }
 
@@ -86,7 +87,7 @@ final class EagerOperationBuilder implements OperationBuilder {
   public EagerOperationBuilder addInputList(Output<?>[] inputs) {
     TFE_TensorHandle[] inputHandles = new TFE_TensorHandle[inputs.length];
     for (int i = 0; i < inputs.length; ++i) {
-      inputHandles[i] = (TFE_TensorHandle)inputs[i].getUnsafeNativeHandle();
+      inputHandles[i] = (TFE_TensorHandle) inputs[i].getUnsafeNativeHandle();
     }
     addInputList(opHandle, inputHandles);
     return this;
@@ -229,7 +230,9 @@ final class EagerOperationBuilder implements OperationBuilder {
   private final String type;
   private final String name;
 
-  /** This value should be >= to the maximum number of outputs in any op */
+  /**
+   * This value should be >= to the maximum number of outputs in any op
+   */
   private static final int MAX_OUTPUTS_PER_OP = 1000;
 
   private static void requireOp(TFE_Op handle) {
@@ -361,7 +364,7 @@ final class EagerOperationBuilder implements OperationBuilder {
 
   private static void setAttrBool(TFE_Op opHandle, String name, boolean value) {
     requireOp(opHandle);
-    TFE_OpSetAttrBool(opHandle, name, (byte)(value ? 1 : 0));
+    TFE_OpSetAttrBool(opHandle, name, (byte) (value ? 1 : 0));
   }
 
   private static void setAttrBoolList(TFE_Op opHandle, String name, boolean[] values) {
@@ -413,7 +416,7 @@ final class EagerOperationBuilder implements OperationBuilder {
       }
       TF_Status status = TF_Status.newStatus();
       TFE_OpSetAttrShapeList(opHandle, new BytePointer(name), shapesPointers, new IntPointer(numDims),
-                            numDims.length, status);
+          numDims.length, status);
     }
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
@@ -56,6 +56,9 @@ import org.tensorflow.proto.framework.DataType;
 final class EagerOperationBuilder implements OperationBuilder {
 
   EagerOperationBuilder(EagerSession session, String type, String name) {
+    if(!session.isOpEnabled(type))
+      throw new IllegalArgumentException("Op " + type + " is not valid in eager mode.");
+
     this.session = session;
     this.type = type;
     this.name = name;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
@@ -274,6 +274,9 @@ public final class EagerSession implements ExecutionEnvironment, AutoCloseable {
   @Override
   public OperationBuilder opBuilder(String type, String name) {
     checkSession();
+    if (!isOpEnabled(type)) {
+      throw new IllegalArgumentException("Op " + type + " is not valid in eager mode.");
+    }
     return new EagerOperationBuilder(this, type, name);
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
@@ -27,6 +27,9 @@ import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.internal.c_api.TFE_Context;
 import org.tensorflow.internal.c_api.TFE_ContextOptions;
 import org.tensorflow.internal.c_api.TF_Status;
+import org.tensorflow.op.core.Assign;
+import org.tensorflow.op.core.Placeholder;
+import org.tensorflow.op.core.Variable;
 import org.tensorflow.proto.framework.ConfigProto;
 
 /**
@@ -277,6 +280,18 @@ public final class EagerSession implements ExecutionEnvironment, AutoCloseable {
   @Override
   public Types environmentType() {
     return Types.EAGER;
+  }
+
+  @Override
+  public boolean isOpEnabled(String opType) {
+    switch (opType) {
+      case Variable.OP_NAME:
+      case Placeholder.OP_NAME:
+      case Assign.OP_NAME:
+        return false;
+      default:
+        return true;
+    }
   }
 
   TFE_Context nativeHandle() {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/ExecutionEnvironment.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/ExecutionEnvironment.java
@@ -35,6 +35,15 @@ public interface ExecutionEnvironment {
   OperationBuilder opBuilder(String type, String name);
 
   /**
+   * Returns true if the given operation is valid in this execution environment.
+   * @param opType The op to check.
+   * @return Whether the given operation is valid in this execution environment.
+   */
+  default boolean isOpEnabled(String opType){
+    return true;
+  }
+
+  /**
    * Get the type of this environment (from the `Environments` enumeration.
    *
    * @return An `Environments` value indicating the type of execution environment.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
@@ -147,6 +147,9 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
    */
   @Override
   public GraphOperationBuilder opBuilder(String type, String name) {
+    if (!isOpEnabled(type)) {
+      throw new IllegalArgumentException("Op " + type + " is not valid in graph mode.");
+    }
     return new GraphOperationBuilder(this, type, name);
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
@@ -54,12 +54,15 @@ import org.tensorflow.internal.c_api.TF_Tensor;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.proto.framework.DataType;
 
-/** An {@link OperationBuilder} for adding {@link GraphOperation}s to a {@link Graph}. */
+/**
+ * An {@link OperationBuilder} for adding {@link GraphOperation}s to a {@link Graph}.
+ */
 public final class GraphOperationBuilder implements OperationBuilder {
 
   GraphOperationBuilder(Graph graph, String type, String name) {
-    if(!graph.isOpEnabled(type))
+    if (!graph.isOpEnabled(type)) {
       throw new IllegalArgumentException("Op " + type + " is not valid in graph mode.");
+    }
 
     this.graph = graph;
     Graph.Reference r = graph.ref();
@@ -106,7 +109,7 @@ public final class GraphOperationBuilder implements OperationBuilder {
   public GraphOperationBuilder addInput(Output<?> input) {
     Graph.Reference r = graph.ref();
     try {
-      addInput(unsafeNativeHandle, (TF_Operation)input.getUnsafeNativeHandle(), input.index());
+      addInput(unsafeNativeHandle, (TF_Operation) input.getUnsafeNativeHandle(), input.index());
     } finally {
       r.close();
     }
@@ -120,7 +123,7 @@ public final class GraphOperationBuilder implements OperationBuilder {
       TF_Operation[] opHandles = new TF_Operation[inputs.length];
       int[] indices = new int[inputs.length];
       for (int i = 0; i < inputs.length; ++i) {
-        opHandles[i] = (TF_Operation)inputs[i].getUnsafeNativeHandle();
+        opHandles[i] = (TF_Operation) inputs[i].getUnsafeNativeHandle();
         indices[i] = inputs[i].index();
       }
       addInputList(unsafeNativeHandle, opHandles, indices);
@@ -447,7 +450,7 @@ public final class GraphOperationBuilder implements OperationBuilder {
 
   private static void setAttrBool(TF_OperationDescription handle, String name, boolean value) {
     requireHandle(handle);
-    TF_SetAttrBool(handle, name, (byte)(value ? 1 : 0));
+    TF_SetAttrBool(handle, name, (byte) (value ? 1 : 0));
   }
 
   private static void setAttrBoolList(TF_OperationDescription handle, String name, boolean[] value) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
@@ -58,6 +58,9 @@ import org.tensorflow.proto.framework.DataType;
 public final class GraphOperationBuilder implements OperationBuilder {
 
   GraphOperationBuilder(Graph graph, String type, String name) {
+    if(!graph.isOpEnabled(type))
+      throw new IllegalArgumentException("Op " + type + " is not valid in graph mode.");
+
     this.graph = graph;
     Graph.Reference r = graph.ref();
     try {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
@@ -60,10 +60,6 @@ import org.tensorflow.proto.framework.DataType;
 public final class GraphOperationBuilder implements OperationBuilder {
 
   GraphOperationBuilder(Graph graph, String type, String name) {
-    if (!graph.isOpEnabled(type)) {
-      throw new IllegalArgumentException("Op " + type + " is not valid in graph mode.");
-    }
-
     this.graph = graph;
     Graph.Reference r = graph.ref();
     try {


### PR DESCRIPTION
Adds a way to forbid ops in `ExecutionEnviroment`s, uses it to forbid Placeholder, Variable, and Assign in eager mode.  As far as I know there's no way to detect ahead of time whether an op is forbidden, so this list will have to be added to as people run into mode-specific ops.  These three are likely to be the most common though.

Fixes #155 and fixes #154.