### PR TITLE
Initialization imprvements

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -2755,7 +2755,7 @@ public final class Ops {
    *
    *  <p>Registered initializers are then grouped as a single unit of computation by adding
    *  and executing an {@link org.tensorflow.op.core.Init#create(Scope) init} operation from a graph
-   *  session.  No-ops if the session is eager.
+   *  session.  This is a no-op if executed in an eager session.
    *
    * @param scope
    * @param initializer

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -347,9 +347,9 @@ public final class Ops {
 
   public final SignalOps signal;
 
-  public final QuantizationOps quantization;
-
   public final TrainOps train;
+
+  public final QuantizationOps quantization;
 
   private final Scope scope;
 
@@ -372,8 +372,8 @@ public final class Ops {
     math = new MathOps(this);
     audio = new AudioOps(this);
     signal = new SignalOps(this);
-    quantization = new QuantizationOps(this);
     train = new TrainOps(this);
+    quantization = new QuantizationOps(this);
   }
 
   /**
@@ -2755,11 +2755,10 @@ public final class Ops {
    *
    *  <p>Registered initializers are then grouped as a single unit of computation by adding
    *  and executing an {@link org.tensorflow.op.core.Init#create(Scope) init} operation from a graph
-   *  session.
+   *  session.  No-ops if the session is eager.
    *
    * @param scope
    * @param initializer
-   * @throws IllegalArgumentException if the execution environment in scope is not a graph
    * @see org.tensorflow.op.core.Init#create(Scope) init
    */
   public void initAdd(Op initializer) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -294,6 +294,16 @@ public final class Session implements AutoCloseable {
     }
 
     /**
+     * Make {@link #run} execute the graph's initializers.
+     *
+     * @return this session runner
+     */
+    public Runner doInitialization(){
+      graph.initializers().forEach(this::addTarget);
+      return this;
+    }
+
+    /**
      * Set options (typically for debugging) for this run.
      *
      * <p>The options are presented as a <a

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -294,16 +294,6 @@ public final class Session implements AutoCloseable {
     }
 
     /**
-     * Make {@link #run} execute the graph's initializers.
-     *
-     * @return this session runner
-     */
-    public Runner doInitialization(){
-      graph.initializers().forEach(this::addTarget);
-      return this;
-    }
-
-    /**
      * Set options (typically for debugging) for this run.
      *
      * <p>The options are presented as a <a

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -490,6 +490,19 @@ public final class Session implements AutoCloseable {
     runner().addTarget(op.op()).run();
   }
 
+
+  /**
+   * Execute the graph's initializers.
+   *
+   * <p>This method is equivalent to {@code session.runner().addTarget(Ops.create(session.graph()).init()).run()}.
+   *
+   */
+  public void runInit(){
+    Runner runner = runner();
+    graph.initializers().forEach(runner::addTarget);
+    runner.run();
+  }
+
   /**
    * Saves the actual state of the variables of this session's graph.
    *

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -494,7 +494,7 @@ public final class Session implements AutoCloseable {
   /**
    * Execute the graph's initializers.
    *
-   * <p>This method is equivalent to {@code session.runner().addTarget(Ops.create(session.graph()).init()).run()}.
+   * <p>This method is equivalent to {@code session.run(Ops.create(session.graph).init())}.
    *
    */
   public void runInit(){

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
@@ -89,16 +89,18 @@ public final class Init extends RawOp {
    *
    * <p>Registered initializers are then grouped as a single unit of computation by adding
    * and executing an {@link org.tensorflow.op.core.Init#create(Scope) init} operation from a graph
-   * session.
+   * session.  No-ops if the session is eager.
    *
    * @param scope
    * @param initializer
-   * @throws IllegalArgumentException if the execution environment in scope is not a graph
    * @see org.tensorflow.op.core.Init#create(Scope) init
    */
   @Endpoint(name = "initAdd")
   public static void add(Scope scope, Op initializer) {
     ExecutionEnvironment exEnv = scope.env();
+    if(exEnv.isEager()){
+      return;
+    }
     if (!(exEnv instanceof Graph)) {
       throw new IllegalArgumentException("initAdd is only supported on Graph sessions.");
     }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
@@ -102,7 +102,7 @@ public final class Init extends RawOp {
       return;
     }
     if (!(exEnv instanceof Graph)) {
-      throw new IllegalArgumentException("initAdd is only supported on Graph sessions.");
+      throw new IllegalArgumentException("initAdd is only supported on Graph or eager sessions.");
     }
     Graph graph = (Graph) exEnv;
     graph.addInitializer(initializer);

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
@@ -98,14 +98,10 @@ public final class Init extends RawOp {
   @Endpoint(name = "initAdd")
   public static void add(Scope scope, Op initializer) {
     ExecutionEnvironment exEnv = scope.env();
-    if(exEnv.isEager()){
-      return;
+
+    if(exEnv.isGraph()) {
+      ((Graph) exEnv).addInitializer(initializer);
     }
-    if (!(exEnv instanceof Graph)) {
-      throw new IllegalArgumentException("initAdd is only supported on Graph or eager sessions.");
-    }
-    Graph graph = (Graph) exEnv;
-    graph.addInitializer(initializer);
   }
 
   private Init(Operation operation) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
@@ -99,7 +99,7 @@ public final class Init extends RawOp {
   public static void add(Scope scope, Op initializer) {
     ExecutionEnvironment exEnv = scope.env();
 
-    if(exEnv.isGraph()) {
+    if (exEnv.isGraph()) {
       ((Graph) exEnv).addInitializer(initializer);
     }
   }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Init.java
@@ -89,7 +89,7 @@ public final class Init extends RawOp {
    *
    * <p>Registered initializers are then grouped as a single unit of computation by adding
    * and executing an {@link org.tensorflow.op.core.Init#create(Scope) init} operation from a graph
-   * session.  No-ops if the session is eager.
+   * session.  This is a no-op if executed in an eager session.
    *
    * @param scope
    * @param initializer


### PR DESCRIPTION
Makes three simple improvements to initialization:
 * Makes `Ops.initAdd` no-op in eager mode, since the op has already been ran.
 * Adds a `runInit()` method to `Session` that runs the graph's initializers.
 * Adds a `doInitialization()` method to `Session.Runner` to add the initializers as targets.
 
There's no changes that conflict w/ the type refactor, so I'll just wait till it's merged and rebase onto master.