### PR TITLE
Expose input and output types from Signature

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
@@ -36,9 +36,9 @@ public class Signature  {
 
   public static class TensorDescription {
     public final DataType dataType;
-    public final long[] shape;
+    public final Shape shape;
 
-    public TensorDescription(DataType dataType, long[] shape) {
+    public TensorDescription(DataType dataType, Shape shape) {
       this.dataType = dataType;
       this.shape = shape;
     }
@@ -189,7 +189,10 @@ public class Signature  {
   private Map<String, TensorDescription> buildTensorDescriptionMap(Map<String, TensorInfo> dataMapIn) {
     Map<String, TensorDescription> dataTypeMap = new HashMap<>();
     dataMapIn.forEach((a, b) -> {
-      dataTypeMap.put(a, new TensorDescription(b.getDtype(), b.getTensorShape().getDimList().stream().mapToLong(d -> d.getSize()).toArray()));
+      long[] tensorDims = b.getTensorShape().getDimList().stream().mapToLong(d -> d.getSize()).toArray();
+      Shape tensorShape = Shape.of(tensorDims);
+      dataTypeMap.put(a, new TensorDescription(b.getDtype(),
+                                               tensorShape));
     });
     return dataTypeMap;
   }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
@@ -15,9 +15,11 @@
  */
 package org.tensorflow;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.tensorflow.ndarray.Shape;
+import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.proto.framework.SignatureDef;
 import org.tensorflow.proto.framework.TensorInfo;
 import org.tensorflow.proto.framework.TensorShapeProto;
@@ -172,6 +174,28 @@ public class Signature  {
       printTensorInfo(signatureDef.getOutputsMap(), strBuilder);
     }
     return strBuilder.toString();
+  }
+
+  /**
+   * Returns the names of the inputs in this signature mapped to their expected data type
+   */
+  public Map<String, DataType> getInputs() {
+    Map<String, DataType> dataTypeMap = new HashMap<>();
+    signatureDef.getInputsMap().forEach((a,b) -> {
+      dataTypeMap.put(a, b.getDtype());
+    });
+    return dataTypeMap;
+  }
+
+  /**
+   * Returns the names of the outputs in this signature mapped to their expected data type
+   */
+  public Map<String, DataType> getOutputs() {
+    Map<String, DataType> dataTypeMap = new HashMap<>();
+    signatureDef.getOutputsMap().forEach((a,b) -> {
+      dataTypeMap.put(a, b.getDtype());
+    });
+    return dataTypeMap;
   }
 
   Signature(String key, SignatureDef signatureDef) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
@@ -34,6 +34,16 @@ public class Signature  {
   /** The default signature key, when not provided */
   public static final String DEFAULT_KEY = "serving_default";
 
+  public static class TensorDescription {
+    public final DataType dataType;
+    public final long[] shape;
+
+    public TensorDescription(DataType dataType, long[] shape) {
+      this.dataType = dataType;
+      this.shape = shape;
+    }
+  }
+
   /**
    * Builds a new function signature.
    */
@@ -176,26 +186,27 @@ public class Signature  {
     return strBuilder.toString();
   }
 
-  /**
-   * Returns the names of the inputs in this signature mapped to their expected data type
-   */
-  public Map<String, DataType> getInputs() {
-    Map<String, DataType> dataTypeMap = new HashMap<>();
-    signatureDef.getInputsMap().forEach((a,b) -> {
-      dataTypeMap.put(a, b.getDtype());
+  private Map<String, TensorDescription> buildTensorDescriptionMap(Map<String, TensorInfo> dataMapIn) {
+    Map<String, TensorDescription> dataTypeMap = new HashMap<>();
+    dataMapIn.forEach((a, b) -> {
+      dataTypeMap.put(a, new TensorDescription(b.getDtype(), b.getTensorShape().getDimList().stream().mapToLong(d -> d.getSize()).toArray()));
     });
     return dataTypeMap;
   }
 
   /**
-   * Returns the names of the outputs in this signature mapped to their expected data type
+   * Returns the names of the inputs in this signature mapped to their expected data type and shape
+   * @return
    */
-  public Map<String, DataType> getOutputs() {
-    Map<String, DataType> dataTypeMap = new HashMap<>();
-    signatureDef.getOutputsMap().forEach((a,b) -> {
-      dataTypeMap.put(a, b.getDtype());
-    });
-    return dataTypeMap;
+  public Map<String, TensorDescription> getInputs() {
+    return buildTensorDescriptionMap(signatureDef.getInputsMap());
+  }
+
+  /**
+   * Returns the names of the outputs in this signature mapped to their expected data type and shape
+   */
+  public Map<String, TensorDescription> getOutputs() {
+    return buildTensorDescriptionMap(signatureDef.getOutputsMap());
   }
 
   Signature(String key, SignatureDef signatureDef) {

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SignatureTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SignatureTest.java
@@ -14,11 +14,14 @@ limitations under the License.
 ==============================================================================*/
 package org.tensorflow;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.junit.jupiter.api.Test;
+import org.tensorflow.Signature.TensorDescription;
 import org.tensorflow.op.Ops;
+import org.tensorflow.proto.framework.DataType;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SignatureTest {
 
@@ -41,6 +44,29 @@ public class SignatureTest {
       assertThrows(IllegalArgumentException.class, () -> builder.input("x", tf.constant(10)));
       assertThrows(IllegalArgumentException.class, () -> builder.output("y", tf.constant(20.0f)));
     }
+  }
+
+  @Test
+  public void getInputsAndOutputs() {
+    Ops tf = Ops.create();
+    Signature builder = Signature.builder()
+          .input("x",  tf.constant(10.0f))
+          .output("y", tf.constant(new float[][] {{10.0f, 30.0f}}))
+          .output("z", tf.constant(20.0f)).build();
+
+    Map<String, TensorDescription> inputs = builder.getInputs();
+    assertEquals(inputs.size(), 1);
+
+    Map<String, TensorDescription> outputs = builder.getOutputs();
+    assertEquals(outputs.size(), 2);
+
+    assertEquals(outputs.get("y").dataType, DataType.DT_FLOAT);
+    assertEquals(outputs.get("z").dataType, DataType.DT_FLOAT);
+    assertArrayEquals(outputs.get("y").shape, new long [] {1,2});
+    assertArrayEquals(outputs.get("z").shape, new long [] {});
+
+    Signature emptySignature = Signature.builder().build();
+    assertEquals(emptySignature.getInputs().size(), 0);
   }
 
   @Test

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SignatureTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SignatureTest.java
@@ -62,8 +62,8 @@ public class SignatureTest {
 
     assertEquals(outputs.get("y").dataType, DataType.DT_FLOAT);
     assertEquals(outputs.get("z").dataType, DataType.DT_FLOAT);
-    assertArrayEquals(outputs.get("y").shape, new long [] {1,2});
-    assertArrayEquals(outputs.get("z").shape, new long [] {});
+    assertArrayEquals(outputs.get("y").shape.asArray(), new long [] {1,2});
+    assertArrayEquals(outputs.get("z").shape.asArray(), new long [] {});
 
     Signature emptySignature = Signature.builder().build();
     assertEquals(emptySignature.getInputs().size(), 0);


### PR DESCRIPTION
Currently you can get the names of the inputs and outputs from a Signature, but there is no publicly accessible method that allows you to get the return types other than toString().

I was unable to get the tests building on my machine, but hopefully this change is small enough that it won't be an issue.