### PR TITLE
Clairify tensorOf lifetime requirements

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -1867,7 +1867,8 @@ public final class Ops {
   }
 
   /**
-   * Create a constant by making an immutable copy of {@code tensor}.
+   * Create a constant by making an immutable copy of {@code tensor}. {@code tensor} may be closed afterwards without
+   *  issue.
    *
    *  <p>Note: this endpoint cannot be simply called {@code constant} since it will conflict with
    *  other endpoints accepting an NdArray in parameter {e.g. {@link #tensorOf(Scope, FloatNdArray)}}.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Constant.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Constant.java
@@ -1278,7 +1278,8 @@ public final class Constant<T extends TType> extends RawOp implements Operand<T>
   }
 
   /**
-   * Create a constant by making an immutable copy of {@code tensor}.
+   * Create a constant by making an immutable copy of {@code tensor}. {@code tensor} may be closed afterwards without
+   * issue.
    *
    * <p>Note: this endpoint cannot be simply called {@code constant} since it will conflict with
    * other endpoints accepting an NdArray in parameter {e.g. {@link #tensorOf(Scope, FloatNdArray)}}.


### PR DESCRIPTION
Very simple PR that adds a note that the tensor can be closed afterwards to `tensorOf`.  This is not obvious since it depends on the native behavior (I've tested it in graph and eager mode and it works).