### PR TITLE
Update manual ops for new codegen

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -3433,7 +3433,7 @@ public final class Ops {
    * @return a constant tensor initialized with ones
    * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with ones.
    */
-  public <T extends TType, U extends TNumber> Ones<T> ones(Operand<U> dims, Class<T> type) {
+  public <T extends TType> Ones<T> ones(Operand<? extends TNumber> dims, Class<T> type) {
     return Ones.create(scope, dims, type);
   }
 
@@ -7674,7 +7674,7 @@ public final class Ops {
    * @return a constant tensor initialized with zeros
    * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with zeros.
    */
-  public <T extends TType, U extends TNumber> Zeros<T> zeros(Operand<U> dims, Class<T> type) {
+  public <T extends TType> Zeros<T> zeros(Operand<? extends TNumber> dims, Class<T> type) {
     return Zeros.create(scope, dims, type);
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Ones.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Ones.java
@@ -49,7 +49,7 @@ public final class Ones<T extends TType> implements Op, Operand<T> {
    * @throws IllegalArgumentException if the tensor type or shape cannot be initialized with ones.
    */
   @Endpoint
-  public static <T extends TType, U extends TNumber> Ones<T> create(Scope scope, Operand<U> dims, Class<T> type) {
+  public static <T extends TType> Ones<T> create(Scope scope, Operand<? extends TNumber> dims, Class<T> type) {
     Scope onesScope = scope.withSubScope("Ones");
     if (type == TString.class) {
       throw new IllegalArgumentException("Can't create Ones of String DataType");

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Zeros.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Zeros.java
@@ -50,7 +50,7 @@ public final class Zeros<T extends TType> implements Op, Operand<T> {
    */
   @Endpoint
   @SuppressWarnings("unchecked")
-  public static <T extends TType, U extends TNumber> Zeros<T> create(Scope scope, Operand<U> dims, Class<T> type) {
+  public static <T extends TType> Zeros<T> create(Scope scope, Operand<? extends TNumber> dims, Class<T> type) {
     Scope zerosScope = scope.withSubScope("Zeros");
     Operand<T> zero;
     if (type == TString.class) {


### PR DESCRIPTION
Embarrassingly simple PR that really should have been done as part of #193.  All it does is remove the extra generics from `Ones` and `Zeros`.