### PR TITLE
Better cross-environment error messages

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperation.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperation.java
@@ -69,6 +69,11 @@ class EagerOperation extends AbstractOperation {
   }
 
   @Override
+  public EagerSession env() {
+    return session;
+  }
+
+  @Override
   public int numOutputs() {
     return outputHandles.length;
   }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
@@ -75,6 +75,7 @@ final class EagerOperationBuilder implements OperationBuilder {
 
   @Override
   public EagerOperationBuilder addInput(Output<?> input) {
+    session.checkInput(input);
     addInput(opHandle, (TFE_TensorHandle) input.getUnsafeNativeHandle());
     return this;
   }
@@ -83,6 +84,7 @@ final class EagerOperationBuilder implements OperationBuilder {
   public EagerOperationBuilder addInputList(Output<?>[] inputs) {
     TFE_TensorHandle[] inputHandles = new TFE_TensorHandle[inputs.length];
     for (int i = 0; i < inputs.length; ++i) {
+      session.checkInput(inputs[i]);
       inputHandles[i] = (TFE_TensorHandle) inputs[i].getUnsafeNativeHandle();
     }
     addInputList(opHandle, inputHandles);

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
@@ -27,6 +27,7 @@ import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.internal.c_api.TFE_Context;
 import org.tensorflow.internal.c_api.TFE_ContextOptions;
 import org.tensorflow.internal.c_api.TF_Status;
+import org.tensorflow.op.Op;
 import org.tensorflow.op.core.Assign;
 import org.tensorflow.op.core.Placeholder;
 import org.tensorflow.op.core.Variable;
@@ -294,6 +295,13 @@ public final class EagerSession implements ExecutionEnvironment, AutoCloseable {
         return false;
       default:
         return true;
+    }
+  }
+
+  @Override
+  public void checkInput(Op input) {
+    if (!input.env().isEager()) {
+      throw new IllegalArgumentException("Can't use graph operation " + input + " in eager mode.");
     }
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/ExecutionEnvironment.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/ExecutionEnvironment.java
@@ -15,7 +15,11 @@ limitations under the License.
 
 package org.tensorflow;
 
-/** Defines an environment for creating and executing TensorFlow {@link Operation}s. */
+import org.tensorflow.op.Op;
+
+/**
+ * Defines an environment for creating and executing TensorFlow {@link Operation}s.
+ */
 public interface ExecutionEnvironment {
 
   enum Types {
@@ -36,12 +40,22 @@ public interface ExecutionEnvironment {
 
   /**
    * Returns true if the given operation is valid in this execution environment.
+   *
    * @param opType The op to check.
    * @return Whether the given operation is valid in this execution environment.
    */
-  default boolean isOpEnabled(String opType){
+  default boolean isOpEnabled(String opType) {
     return true;
   }
+
+  /**
+   * Checks that {@code input} is valid to use as an input in this execution environment. Throws {@link
+   * IllegalArgumentException} if not.
+   *
+   * @param input The op to check
+   * @throws IllegalArgumentException if input can't be used as an input in this execution environment.
+   */
+  void checkInput(Op input);
 
   /**
    * Get the type of this environment (from the `Environments` enumeration.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
@@ -158,6 +158,17 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
     return Types.GRAPH;
   }
 
+  @Override
+  public void checkInput(Op input) {
+    if (input.env().isEager()) {
+      throw new IllegalArgumentException(
+          "Input " + input + " was from an eager session, can't use in a graph.  Use tf.constantOf(input.asTensor())");
+    }
+    if (input.env() != this) {
+      throw new IllegalArgumentException("Input " + input + " was from a different graph, can't use.");
+    }
+  }
+
   /**
    * Import a representation of a TensorFlow graph.
    *

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperation.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperation.java
@@ -74,6 +74,13 @@ public final class GraphOperation extends AbstractOperation {
   }
 
   @Override
+  public Graph env() {
+    try (Graph.Reference r = graph.ref()) {
+      return graph;
+    }
+  }
+
+  @Override
   public int numOutputs() {
     Graph.Reference r = graph.ref();
     try {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
@@ -92,6 +92,11 @@ public final class GraphOperationBuilder implements OperationBuilder {
       throw new IllegalArgumentException(
           "Only GraphOperation instances can be used as control inputs");
     }
+
+    if (control.env() != graph) {
+      throw new IllegalArgumentException("Control input " + control + " was from a different graph, can't use.");
+    }
+
     Graph.Reference r = graph.ref();
     try {
       addControlInput(unsafeNativeHandle, ((GraphOperation) control).getUnsafeNativeHandle());
@@ -103,6 +108,7 @@ public final class GraphOperationBuilder implements OperationBuilder {
 
   @Override
   public GraphOperationBuilder addInput(Output<?> input) {
+    graph.checkInput(input);
     Graph.Reference r = graph.ref();
     try {
       addInput(unsafeNativeHandle, (TF_Operation) input.getUnsafeNativeHandle(), input.index());
@@ -114,6 +120,10 @@ public final class GraphOperationBuilder implements OperationBuilder {
 
   @Override
   public GraphOperationBuilder addInputList(Output<?>[] inputs) {
+    for (Output<?> input : inputs) {
+      graph.checkInput(input);
+    }
+
     Graph.Reference r = graph.ref();
     try {
       TF_Operation[] opHandles = new TF_Operation[inputs.length];

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Operation.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Operation.java
@@ -25,16 +25,24 @@ import org.tensorflow.types.family.TType;
  */
 public interface Operation {
 
-  /** Returns the full name of the Operation. */
+  /**
+   * Returns the full name of the Operation.
+   */
   String name();
 
   /**
-   * Returns the type of the operation, i.e., the name of the computation performed by the
-   * operation.
+   * Returns the type of the operation, i.e., the name of the computation performed by the operation.
    */
   String type();
 
-  /** Returns the number of tensors produced by this operation. */
+  /**
+   * Returns the execution environment this operation was created in.
+   */
+  ExecutionEnvironment env();
+
+  /**
+   * Returns the number of tensors produced by this operation.
+   */
   int numOutputs();
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/Op.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/Op.java
@@ -15,6 +15,7 @@ limitations under the License.
 
 package org.tensorflow.op;
 
+import org.tensorflow.ExecutionEnvironment;
 import org.tensorflow.Operation;
 
 /**
@@ -48,4 +49,11 @@ public interface Op {
    * @return an {@link Operation}
    */
   Operation op();
+
+  /**
+   * Return the execution environment this op was created in.
+   */
+  default ExecutionEnvironment env() {
+    return op().env();
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/Scope.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/Scope.java
@@ -16,14 +16,12 @@ limitations under the License.
 package org.tensorflow.op;
 
 import java.util.ArrayList;
-
 import org.tensorflow.DeviceSpec;
 import org.tensorflow.ExecutionEnvironment;
 import org.tensorflow.OperationBuilder;
 
 /**
- * Manages groups of related properties when creating Tensorflow Operations, such as a common name
- * prefix.
+ * Manages groups of related properties when creating Tensorflow Operations, such as a common name prefix.
  *
  * <p>A {@code Scope} is a container for common properties applied to TensorFlow Ops. Normal user
  * code initializes a {@code Scope} and provides it to Operation building classes. For example:
@@ -88,7 +86,9 @@ public final class Scope {
     this(env, new NameScope(), new ArrayList<>(), DeviceSpec.newBuilder().build());
   }
 
-  /** Returns the execution environment used by this scope. */
+  /**
+   * Returns the execution environment used by this scope.
+   */
   public ExecutionEnvironment env() {
     return env;
   }
@@ -97,8 +97,7 @@ public final class Scope {
    * Returns a new scope where added operations will have the provided name prefix.
    *
    * <p>Ops created with this scope will have {@code name/childScopeName/} as the prefix. The actual
-   * name will be unique in the returned scope. All other properties are inherited from the current
-   * scope.
+   * name will be unique in the returned scope. All other properties are inherited from the current scope.
    *
    * <p>The child scope name must match the regular expression {@code [A-Za-z0-9.][A-Za-z0-9_.\-]*}
    *
@@ -129,7 +128,8 @@ public final class Scope {
   /**
    * Return a new scope that uses the provided device specification for an op.
    *
-   * <p>Operations created within this scope will place the created operations on the device(s) matching the provided spec.
+   * <p>Operations created within this scope will place the created operations on the device(s) matching the provided
+   * spec.
    *
    * @param deviceSpec device specification for an operator in the returned scope
    * @return a new Scope that uses opName for operations.
@@ -151,8 +151,8 @@ public final class Scope {
    * }</pre>
    *
    * <p><b>Note:</b> if you provide a composite operator building class (i.e, a class that creates a
-   * set of related operations by calling other operator building code), the provided name will act
-   * as a subscope to all underlying operators.
+   * set of related operations by calling other operator building code), the provided name will act as a subscope to all
+   * underlying operators.
    *
    * @param defaultName name for the underlying operator.
    * @return unique name for the operator.
@@ -180,11 +180,15 @@ public final class Scope {
    * @return a new scope with the provided control dependencies
    */
   public Scope withControlDependencies(Iterable<Op> controls) {
+    for (Op control : controls) {
+      env.checkInput(control);
+    }
     return new Scope(env, nameScope, controls, deviceSpec);
   }
 
   /**
-   * Applies device specification and adds each Operand in controlDependencies as a control input to the provided builder.
+   * Applies device specification and adds each Operand in controlDependencies as a control input to the provided
+   * builder.
    *
    * @param builder OperationBuilder to add control inputs and device specification to
    */
@@ -210,7 +214,9 @@ public final class Scope {
   private final NameScope nameScope;
   private final DeviceSpec deviceSpec;
 
-  /** Returns device string from the scope. */
+  /**
+   * Returns device string from the scope.
+   */
   public String getDeviceString() {
     return deviceSpec.toString();
   }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/GraphOperationBuilderTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/GraphOperationBuilderTest.java
@@ -23,29 +23,12 @@ import org.junit.jupiter.api.Test;
 import org.tensorflow.exceptions.TFInvalidArgumentException;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Ops;
-import org.tensorflow.op.core.Constant;
 import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.types.TBool;
 import org.tensorflow.types.TInt32;
 
 /** Unit tests for {@link org.tensorflow.GraphOperationBuilder}. */
 public class GraphOperationBuilderTest {
-
-  @Test
-  public void failWhenMixingOperationsOnDifferentGraphs() {
-    try (Graph g1 = new Graph();
-        Graph g2 = new Graph()) {
-      Ops tf = Ops.create(g1);
-      Constant<TInt32> c1 = tf.constant(3);
-      tf.math.add(c1, c1);
-      try {
-        Ops tf2 = Ops.create(g2);
-        tf2.math.add(c1, c1);
-      } catch (Exception e) {
-        fail(e.toString());
-      }
-    }
-  }
 
   @Test
   public void failOnUseAfterBuild() {

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/WrongEnvTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/WrongEnvTest.java
@@ -1,0 +1,108 @@
+/*
+  Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ==============================================================================
+ */
+package org.tensorflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.Test;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.TInt32;
+
+/**
+ * Tests for using Operands in different environments
+ */
+public class WrongEnvTest {
+
+  /**
+   * Should work fine
+   */
+  @Test
+  public void testTwoEagers() {
+    try (EagerSession e1 = EagerSession.create();
+        EagerSession e2 = EagerSession.create()) {
+      Ops tf1 = Ops.create(e1);
+      Ops tf2 = Ops.create(e2);
+
+      Operand<TInt32> a = tf1.constant(5);
+      Operand<TInt32> b = tf2.constant(6);
+
+      Operand<TInt32> c = tf2.math.add(a, b);
+
+      try (TInt32 tensor = c.asTensor()) {
+        assertEquals(11, tensor.getInt());
+      }
+
+    }
+  }
+
+  @Test
+  public void testEagerInGraph() {
+    try (EagerSession e1 = EagerSession.create();
+        Graph e2 = new Graph()) {
+      Ops tf1 = Ops.create(e1);
+      Ops tf2 = Ops.create(e2);
+
+      Operand<TInt32> a = tf1.constant(5);
+      Operand<TInt32> b = tf2.constant(6);
+
+      Operand<TInt32> c = tf2.math.add(a, b);
+
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("was from an eager session, can't use in a graph"));
+    }
+  }
+
+  @Test
+  public void testGraphInEager() {
+    try (Graph e1 = new Graph();
+        EagerSession e2 = EagerSession.create()) {
+      Ops tf1 = Ops.create(e1);
+      Ops tf2 = Ops.create(e2);
+
+      Operand<TInt32> a = tf1.constant(5);
+      Operand<TInt32> b = tf2.constant(6);
+
+      Operand<TInt32> c = tf2.math.add(a, b);
+
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Can't use graph operation"));
+    }
+  }
+
+  @Test
+  public void testTwoGraphs() {
+    try (Graph e1 = new Graph();
+        Graph e2 = new Graph()) {
+      Ops tf1 = Ops.create(e1);
+      Ops tf2 = Ops.create(e2);
+
+      Operand<TInt32> a = tf1.constant(5);
+      Operand<TInt32> b = tf2.constant(6);
+
+      Operand<TInt32> c = tf2.math.add(a, b);
+
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("was from a different graph"));
+    }
+  }
+
+}


### PR DESCRIPTION
This PR exposes `env()` to `Operation` and `Op`, and adds nicer error messages when using inputs from other environments.

@karllessard it's currently failing the [`failWhenMixingOperationsOnDifferentGraphs` test](https://github.com/tensorflow/java/blob/master/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/GraphOperationBuilderTest.java#L35-L35), but looking at it it looks like the test is wrong.  It fails when an exception is thrown, which given the name seems backwards.  Mixing graphs like this fails anyways, just not until the session is ran (it gives a very cryptic `Graph is invalid, contains a cycle` exception, but I'm assuming that's due to the mixing).