### PR TITLE
Number constant ops

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -1832,6 +1832,19 @@ public final class Ops {
   }
 
   /**
+   * Creates a scalar of {@code type}, with the value of {@code number}.
+   *  {@code number} may be truncated if it does not fit in the target type.
+   *
+   * @param type the type of tensor to create.  Must be concrete (i.e. not {@link org.tensorflow.types.family.TFloating})
+   * @param number the value of the tensor
+   * @return a constant of the passed type
+   * @throws IllegalArgumentException if the type is abstract (i.e. {@link org.tensorflow.types.family.TFloating}) or unknown.
+   */
+  public <T extends TNumber> Constant<T> constant(Class<T> type, Number number) {
+    return Constant.tensorOf(scope, type, number);
+  }
+
+  /**
    * Create a {@link TString} constant with data from the given buffer, using the given encoding.
    *
    * @param scope is a scope used to add the underlying operation.
@@ -1874,6 +1887,20 @@ public final class Ops {
    */
   public <T extends TType> Constant<T> constantOf(T tensor) {
     return Constant.create(scope, tensor);
+  }
+
+  /**
+   * Creates a scalar of the same type as {@code toMatch}, with the value of {@code number}.
+   *  {@code number} may be truncated if it does not fit in the target type.
+   *
+   * @param toMatch the operand providing the target type
+   * @param number the value of the tensor
+   * @return a constant with the same type as {@code toMatch}
+   * @see Ops#constant(Class, Number)
+   * @throws IllegalArgumentException if the type is unknown (which should be impossible).
+   */
+  public <T extends TNumber> Constant<T> constantOfSameType(Operand<T> toMatch, Number number) {
+    return Constant.tensorOfSameType(scope, toMatch, number);
   }
 
   /**


### PR DESCRIPTION
Adds a `constant` ops that takes `Number` and a `TNumber` class, and one that does the same based off of an `Operand`'s runtime type.  The conversion is done using `Number.doubleValue()` etc rather than `cast`, since it avoids adding an op, and is necessary to call the other `constant` ops.  It's useful when you want to create a composite op that works with any numeric types, but need to add a constant, or for enabling things like the `+` operator in Kotlin to not need a new overload for each scalar type.