### PR TITLE
Boolean mask ops

### DIFF
--- a/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
@@ -276,6 +276,27 @@ public final class Shape {
   }
 
   /**
+   * Return a {@code end - begin} dimensional shape with dimensions matching this Shape from {@code begin} to {@code end}.
+   * @param begin Where to start the sub-shape.
+   * @param end Where to end the sub-shape, exclusive.
+   * @return the sub-shape bounded by begin and end.
+   */
+  public Shape subShape(int begin, int end){
+    if (end > numDimensions()) {
+      throw new ArrayIndexOutOfBoundsException(
+          "End index " + end + " out of bounds: shape only has " + numDimensions() + " dimensions.");
+    }
+    if (begin < 0) {
+      throw new ArrayIndexOutOfBoundsException(
+          "Begin index " + begin + " out of bounds: cannot be less than 0.");
+    }
+
+    long[] newDimensions = new long[end - begin];
+    System.arraycopy(dimensionSizes, begin, newDimensions, 0, end - begin);
+    return Shape.of(newDimensions);
+  }
+
+  /**
    * Returns a new Shape, with a new first dimension added. In order for this call to succeed,
    * {@link Shape#isUnknown()} must be {@code false}.
    *

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -991,11 +991,28 @@ public final class Ops {
   }
 
   /**
-   * empty
+   * Apply boolean mask to tensor.
+   *  <p>
+   *  Numpy equivalent is `tensor[mask]`.
+   *  <p>
+   *  In general, {@code 0 < dim(mask) = K <= dim(tensor)}, and {@code mask}'s shape must match
+   *  the first K dimensions of {@code tensor}'s shape.  We then have:
+   *    {@code booleanMask(tensor, mask)[i, j1,...,jd] = tensor[i1,...,iK,j1,...,jd]}
+   *  where {@code (i1,...,iK)} is the ith {@code true} entry of {@code mask} (row-major order).
+   *  <p>
+   *  The {@code axis} could be used with {@code mask} to indicate the axis to mask from (it's 0 by default).
+   *  In that case, {@code axis + dim(mask) <= dim(tensor)} and {@code mask}'s shape must match
+   *  the first {@code axis + dim(mask)} dimensions of {@code tensor}'s shape.
+   *
+   * @param scope
+   * @param tensor The tensor to mask.
+   * @param mask The mask to apply.
+   * @param options carries optional attributes values
+   * @return The masked tensor.
    */
-  public <T extends TType> Operand<T> booleanMask(Operand<T> x, Operand<TBool> mask,
+  public <T extends TType> Operand<T> booleanMask(Operand<T> tensor, Operand<TBool> mask,
       BooleanMask.Options... options) {
-    return BooleanMask.create(scope, x, mask, options);
+    return BooleanMask.create(scope, tensor, mask, options);
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -60,6 +60,7 @@ import org.tensorflow.op.core.BatchToSpace;
 import org.tensorflow.op.core.BatchToSpaceNd;
 import org.tensorflow.op.core.Bitcast;
 import org.tensorflow.op.core.BooleanMask;
+import org.tensorflow.op.core.BooleanMaskUpdate;
 import org.tensorflow.op.core.BroadcastDynamicShape;
 import org.tensorflow.op.core.BroadcastTo;
 import org.tensorflow.op.core.Bucketize;
@@ -348,9 +349,9 @@ public final class Ops {
 
   public final SignalOps signal;
 
-  public final QuantizationOps quantization;
-
   public final TrainOps train;
+
+  public final QuantizationOps quantization;
 
   private final Scope scope;
 
@@ -373,8 +374,8 @@ public final class Ops {
     math = new MathOps(this);
     audio = new AudioOps(this);
     signal = new SignalOps(this);
-    quantization = new QuantizationOps(this);
     train = new TrainOps(this);
+    quantization = new QuantizationOps(this);
   }
 
   /**
@@ -991,9 +992,9 @@ public final class Ops {
   }
 
   /**
-   * Apply boolean mask to tensor.
+   * Apply boolean mask to tensor.  Returns the flat array of each element corresponding to a {@code true} in the mask.
    *  <p>
-   *  Numpy equivalent is `tensor[mask]`.
+   *  Numpy equivalent is {@code tensor[mask]}.
    *  <p>
    *  In general, {@code 0 < dim(mask) = K <= dim(tensor)}, and {@code mask}'s shape must match
    *  the first K dimensions of {@code tensor}'s shape.  We then have:
@@ -1013,6 +1014,36 @@ public final class Ops {
   public <T extends TType> Operand<T> booleanMask(Operand<T> tensor, Operand<TBool> mask,
       BooleanMask.Options... options) {
     return BooleanMask.create(scope, tensor, mask, options);
+  }
+
+  /**
+   * Updates a tensor at the masked values, and returns the updated tensor.  Does not mutate the input tensors.  {@code
+   *  updates} will be broadcasted by default
+   *  <p>
+   *  Numpy equivalent is `tensor[mask] = updates`.
+   *  <p>
+   *  In general, {@code 0 < dim(mask) = K <= dim(tensor)}, and {@code mask}'s shape must match the first K dimensions of
+   *  {@code tensor}'s shape.  We then have: {@code booleanMask(tensor, mask)[i, j1,...,jd] =
+   *  tensor[i1,...,iK,j1,...,jd]} where {@code (i1,...,iK)} is the ith {@code true} entry of {@code mask} (row-major
+   *  order).
+   *  <p>
+   *  The {@code axis} could be used with {@code mask} to indicate the axis to mask from (it's 0 by default). In that
+   *  case, {@code axis + dim(mask) <= dim(tensor)} and {@code mask}'s shape must match the first {@code axis +
+   *  dim(mask)} dimensions of {@code tensor}'s shape.
+   *  <p>
+   *  The shape of {@code updates} should be {@code [n, t_1, t_2, ...]} where {@code n} is the number of true values in
+   *  {@code mask} and {@code t_i} is the {@code i}th dimension of {@code tensor} after {@code axis} and {@code mask}.
+   *  {@code updates} will be broadcasted to this shape by default, which can be disabled using {@code options}.
+   *
+   * @param tensor The tensor to mask.
+   * @param mask The mask to apply.
+   * @param updates the new values
+   * @param options carries optional attributes values
+   * @return The masked tensor.
+   */
+  public <T extends TType> Operand<T> booleanMaskUpdate(Operand<T> tensor, Operand<TBool> mask,
+      Operand<T> updates, BooleanMaskUpdate.Options... options) {
+    return BooleanMaskUpdate.create(scope, tensor, mask, updates, options);
   }
 
   /**
@@ -1860,13 +1891,14 @@ public final class Ops {
   }
 
   /**
-   * Creates a scalar of {@code type}, with the value of {@code number}.
-   *  {@code number} may be truncated if it does not fit in the target type.
+   * Creates a scalar of {@code type}, with the value of {@code number}. {@code number} may be truncated if it does not
+   *  fit in the target type.
    *
    * @param type the type of tensor to create.  Must be concrete (i.e. not {@link org.tensorflow.types.family.TFloating})
    * @param number the value of the tensor
    * @return a constant of the passed type
-   * @throws IllegalArgumentException if the type is abstract (i.e. {@link org.tensorflow.types.family.TFloating}) or unknown.
+   * @throws IllegalArgumentException if the type is abstract (i.e. {@link org.tensorflow.types.family.TFloating}) or
+   *  unknown.
    */
   public <T extends TNumber> Constant<T> constant(Class<T> type, Number number) {
     return Constant.tensorOf(scope, type, number);
@@ -1918,14 +1950,14 @@ public final class Ops {
   }
 
   /**
-   * Creates a scalar of the same type as {@code toMatch}, with the value of {@code number}.
-   *  {@code number} may be truncated if it does not fit in the target type.
+   * Creates a scalar of the same type as {@code toMatch}, with the value of {@code number}. {@code number} may be
+   *  truncated if it does not fit in the target type.
    *
    * @param toMatch the operand providing the target type
    * @param number the value of the tensor
    * @return a constant with the same type as {@code toMatch}
-   * @see Ops#constant(Class, Number)
    * @throws IllegalArgumentException if the type is unknown (which should be impossible).
+   * @see Ops#constant(Class, Number)
    */
   public <T extends TNumber> Constant<T> constantOfSameType(Operand<T> toMatch, Number number) {
     return Constant.tensorOfSameType(scope, toMatch, number);

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -59,6 +59,7 @@ import org.tensorflow.op.core.Batch;
 import org.tensorflow.op.core.BatchToSpace;
 import org.tensorflow.op.core.BatchToSpaceNd;
 import org.tensorflow.op.core.Bitcast;
+import org.tensorflow.op.core.BooleanMask;
 import org.tensorflow.op.core.BroadcastDynamicShape;
 import org.tensorflow.op.core.BroadcastTo;
 import org.tensorflow.op.core.Bucketize;
@@ -987,6 +988,14 @@ public final class Ops {
    */
   public <U extends TType> Bitcast<U> bitcast(Operand<? extends TType> input, Class<U> type) {
     return Bitcast.create(scope, input, type);
+  }
+
+  /**
+   * empty
+   */
+  public <T extends TType> Operand<T> booleanMask(Operand<T> x, Operand<TBool> mask,
+      BooleanMask.Options... options) {
+    return BooleanMask.create(scope, x, mask, options);
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/Scope.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/Scope.java
@@ -126,6 +126,25 @@ public final class Scope {
   }
 
   /**
+   * Returns a new scope where added operations will be prefixed by this scope's op name
+   * (set by {@link #withName(String)}), or the given default if it is unset.  This is intended to be used for
+   * composite ops.
+   *
+   * <p>Ops created with this scope will have {@code name/opName/} as the prefix. The actual
+   * name will be unique in the returned scope. All other properties are inherited from the current
+   * scope.
+   *
+   * <p>The default child scope name must match the regular expression {@code [A-Za-z0-9.][A-Za-z0-9_.\-]*}
+   *
+   * @param defaultName name of the sub scope if this scope's name hasn't been set.
+   * @return a new subscope
+   * @throws IllegalArgumentException if the name is invalid
+   */
+  public Scope withNameAsSubScope(String defaultName){
+    return new Scope(env, nameScope.withSubScope(nameScope.makeOpName(defaultName)), controlDependencies, deviceSpec);
+  }
+
+  /**
    * Return a new scope that uses the provided device specification for an op.
    *
    * <p>Operations created within this scope will place the created operations on the device(s) matching the provided

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/BooleanMask.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/BooleanMask.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import org.tensorflow.Operand;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.index.Indices;
-import org.tensorflow.op.Ops;
 import org.tensorflow.op.Scope;
 import org.tensorflow.op.annotation.Endpoint;
 import org.tensorflow.op.annotation.Operator;
@@ -36,7 +35,7 @@ public abstract class BooleanMask {
   /**
    * Apply boolean mask to tensor.  Returns the flat array of each element corresponding to a {@code true} in the mask.
    * <p>
-   * Numpy equivalent is `tensor[mask]`.
+   * Numpy equivalent is {@code tensor[mask]}.
    * <p>
    * In general, {@code 0 < dim(mask) = K <= dim(tensor)}, and {@code mask}'s shape must match
    * the first K dimensions of {@code tensor}'s shape.  We then have:

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/BooleanMask.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/BooleanMask.java
@@ -149,14 +149,6 @@ public abstract class BooleanMask {
       return this;
     }
 
-    /**
-     * @param axis (Optional) The axis to mask from, or 0 if not set.
-     */
-    public Options axis(int axis) {
-      this.axis = axis;
-      return this;
-    }
-
     private Integer axis;
 
     private Options() {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/BooleanMask.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/BooleanMask.java
@@ -1,0 +1,123 @@
+/*
+  Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ==============================================================================
+ */
+package org.tensorflow.op.core;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.tensorflow.Operand;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.index.Indices;
+import org.tensorflow.op.Scope;
+import org.tensorflow.op.annotation.Endpoint;
+import org.tensorflow.op.annotation.Operator;
+import org.tensorflow.types.TBool;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.TInt64;
+import org.tensorflow.types.family.TType;
+
+@Operator
+public abstract class BooleanMask {
+
+  @Endpoint(name = "booleanMask")
+  public static <T extends TType> Operand<T> create(Scope scope, Operand<T> x, Operand<TBool> mask,
+      Options... options) {
+
+    //TODO naming to match python
+
+    int axis = 0;
+    if (options != null) {
+      for (Options opts : options) {
+        if (opts.axis != null) {
+          axis = opts.axis;
+        }
+      }
+    }
+
+    if (axis < 0) {
+      axis += x.rank();
+    }
+
+    Shape maskShape = mask.shape();
+    Shape tensorShape = x.shape();
+
+    if (maskShape.numDimensions() == 0) {
+      throw new IllegalArgumentException("Mask cannot be scalar.");
+    }
+    if (maskShape.hasUnknownDimension()) {
+      throw new IllegalArgumentException("Mask cannot have unknown number of dimensions");
+    }
+
+    Operand<TInt32> axisTensor = Constant.scalarOf(scope, axis);
+    Shape requiredMaskShape = tensorShape.subShape(axis, axis + maskShape.numDimensions());
+    if (!requiredMaskShape.isCompatibleWith(maskShape)) {
+      throw new IllegalArgumentException(
+          "Mask shape " + maskShape + " is not compatible with required mask shape: " + requiredMaskShape + ".");
+    }
+
+    org.tensorflow.op.core.Shape<TInt32> liveShape = org.tensorflow.op.core.Shape.create(scope, x);
+
+    Operand<TInt32> leadingSize = ReduceProd.create(scope,
+        StridedSliceHelper.stridedSlice(scope,
+            liveShape,
+            Indices.range(axis, axis + maskShape.numDimensions())
+        ),
+        Constant.arrayOf(scope, 0)
+    );
+
+    Operand<T> tensor = Reshape.create(scope, x, Concat.create(
+        scope,
+        Arrays.asList(
+            StridedSliceHelper.stridedSlice(scope, liveShape, Indices.to(axis)),
+            Reshape.create(scope, leadingSize, Constant.arrayOf(scope, 1)),
+            StridedSliceHelper.stridedSlice(scope, liveShape, Indices.from(axis + maskShape.numDimensions()))
+        ),
+        Constant.scalarOf(scope, 0)
+    ));
+    Operand<TBool> flatMask = Reshape.create(scope, mask, Constant.arrayOf(scope, -1));
+
+    Operand<TInt64> indices = Squeeze.create(scope, Where.create(scope, flatMask), Squeeze.axis(Collections.singletonList(1L)));
+    return Gather.create(scope, tensor, indices, axisTensor);
+  }
+
+  /**
+   * Optional attributes for {@link org.tensorflow.op.core.BooleanMask}
+   */
+  public static class Options {
+
+    /**
+     * @param axis (Optional) The axis to mask from, or 0 if not set.
+     */
+    public Options axis(Integer axis) {
+      this.axis = axis;
+      return this;
+    }
+
+    /**
+     * @param axis (Optional) The axis to mask from, or 0 if not set.
+     */
+    public Options axis(int axis) {
+      this.axis = axis;
+      return this;
+    }
+
+    private Integer axis;
+
+    private Options() {
+    }
+  }
+
+}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/BooleanMask.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/BooleanMask.java
@@ -55,7 +55,7 @@ public abstract class BooleanMask {
     Shape tensorShape = x.shape();
 
     if (maskShape.numDimensions() == 0) {
-      throw new IllegalArgumentException("Mask cannot be scalar.");
+      throw new IllegalArgumentException("Mask cannot be a scalar.");
     }
     if (maskShape.hasUnknownDimension()) {
       throw new IllegalArgumentException("Mask cannot have unknown number of dimensions");
@@ -65,7 +65,7 @@ public abstract class BooleanMask {
     Shape requiredMaskShape = tensorShape.subShape(axis, axis + maskShape.numDimensions());
     if (!requiredMaskShape.isCompatibleWith(maskShape)) {
       throw new IllegalArgumentException(
-          "Mask shape " + maskShape + " is not compatible with required mask shape: " + requiredMaskShape + ".");
+          "Mask shape " + maskShape + " is not compatible with the required mask shape: " + requiredMaskShape + ".");
     }
 
     org.tensorflow.op.core.Shape<TInt32> liveShape = org.tensorflow.op.core.Shape.create(scope, x);
@@ -87,6 +87,7 @@ public abstract class BooleanMask {
         ),
         Constant.scalarOf(scope, 0)
     ));
+
     Operand<TBool> flatMask = Reshape.create(scope, mask, Constant.arrayOf(scope, -1));
 
     Operand<TInt64> indices = Squeeze.create(scope, Where.create(scope, flatMask), Squeeze.axis(Collections.singletonList(1L)));

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskTest.java
@@ -1,0 +1,67 @@
+/*
+  Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ==============================================================================
+ */
+package org.tensorflow.op.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.Test;
+import org.tensorflow.Graph;
+import org.tensorflow.Operand;
+import org.tensorflow.Session;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Scope;
+import org.tensorflow.types.TBool;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TInt32;
+
+public class BooleanMaskTest {
+  @Test
+  public void testBooleanMask(){
+    try (Graph g = new Graph();
+        Session sess = new Session(g)) {
+      Scope scope = new Scope(g);
+
+      Operand<TInt32> input = Constant.arrayOf(scope, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+      Operand<TInt32> input2 = ExpandDims.create(scope, input, Constant.scalarOf(scope, 0));
+
+      Operand<TBool> mask = Constant.arrayOf(scope, true, true, false, false, true, true, true, false, false, false);
+
+      Operand<TInt32> output1 = BooleanMask.create(scope, input, mask);
+      Operand<TInt32> output2 = BooleanMask.create(scope, input2, mask, BooleanMask.axis(1));
+
+      try (TFloat32 result = (TFloat32) sess.runner().fetch(output1).run().get(0)) {
+        // expected shape from Python tensorflow
+        assertEquals(Shape.of(5), result.shape());
+        assertEquals(result.getFloat(0), 0);
+        assertEquals(result.getFloat(1), 1);
+        assertEquals(result.getFloat(2), 4);
+        assertEquals(result.getFloat(3), 5);
+        assertEquals(result.getFloat(4), 6);
+      }
+
+      try (TFloat32 result = (TFloat32) sess.runner().fetch(output2).run().get(0)) {
+        // expected shape from Python tensorflow
+        assertEquals(Shape.of(5), result.shape());
+        assertEquals(result.getFloat(0), 0);
+        assertEquals(result.getFloat(1), 1);
+        assertEquals(result.getFloat(2), 4);
+        assertEquals(result.getFloat(3), 5);
+        assertEquals(result.getFloat(4), 6);
+      }
+    }
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskTest.java
@@ -46,21 +46,21 @@ public class BooleanMaskTest {
       try (TFloat32 result = (TFloat32) sess.runner().fetch(output1).run().get(0)) {
         // expected shape from Python tensorflow
         assertEquals(Shape.of(5), result.shape());
-        assertEquals(result.getFloat(0), 0);
-        assertEquals(result.getFloat(1), 1);
-        assertEquals(result.getFloat(2), 4);
-        assertEquals(result.getFloat(3), 5);
-        assertEquals(result.getFloat(4), 6);
+        assertEquals(0, result.getFloat(0));
+        assertEquals(1, result.getFloat(1));
+        assertEquals(4, result.getFloat(2));
+        assertEquals(5, result.getFloat(3));
+        assertEquals(6, result.getFloat(4));
       }
 
       try (TFloat32 result = (TFloat32) sess.runner().fetch(output2).run().get(0)) {
         // expected shape from Python tensorflow
         assertEquals(Shape.of(5), result.shape());
-        assertEquals(result.getFloat(0), 0);
-        assertEquals(result.getFloat(1), 1);
-        assertEquals(result.getFloat(2), 4);
-        assertEquals(result.getFloat(3), 5);
-        assertEquals(result.getFloat(4), 6);
+        assertEquals(0, result.getFloat(0));
+        assertEquals(1, result.getFloat(1));
+        assertEquals(4, result.getFloat(2));
+        assertEquals(5, result.getFloat(3));
+        assertEquals(6, result.getFloat(4));
       }
     }
   }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskUpdateTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskUpdateTest.java
@@ -18,10 +18,13 @@ package org.tensorflow.op.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import org.junit.Test;
 import org.tensorflow.Graph;
 import org.tensorflow.Operand;
 import org.tensorflow.Session;
+import org.tensorflow.Session.Run;
+import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.index.Indices;
 import org.tensorflow.op.Scope;
@@ -37,7 +40,7 @@ public class BooleanMaskUpdateTest {
         Session sess = new Session(g)) {
       Scope scope = new Scope(g);
 
-      Operand<TInt32> input = Constant.tensorOf(scope, new int[][]{ {0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
+      Operand<TInt32> input = Constant.tensorOf(scope, new int[][]{{0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
 
       Operand<TBool> mask = Constant.arrayOf(scope, true, false, false);
 
@@ -45,18 +48,25 @@ public class BooleanMaskUpdateTest {
 
       Operand<TInt32> output = BooleanMaskUpdate.create(scope, input, mask, value);
 
-      try (TFloat32 result = (TFloat32) sess.runner().fetch(output).run().get(0)) {
-        // expected shape from Python tensorflow
+      Operand<TInt32> bcastOutput = BooleanMaskUpdate.create(scope, input, mask, Constant.scalarOf(scope, -1));
+
+      List<Tensor> results = sess.runner().fetch(output).fetch(bcastOutput).run();
+      try (TInt32 result = (TInt32) results.get(0);
+          TInt32 bcastResult = (TInt32) results.get(1)) {
+
         assertEquals(Shape.of(3, 3), result.shape());
-        assertEquals(-1, result.getFloat(0, 0));
-        assertEquals(-1, result.getFloat(0, 1));
-        assertEquals(-1, result.getFloat(0, 2));
-        assertEquals(1, result.getFloat(1, 0));
-        assertEquals(1, result.getFloat(1, 1));
-        assertEquals(1, result.getFloat(1, 2));
-        assertEquals(2, result.getFloat(2, 0));
-        assertEquals(2, result.getFloat(2, 1));
-        assertEquals(2, result.getFloat(2, 2));
+
+        assertEquals(-1, result.getInt(0, 0));
+        assertEquals(-1, result.getInt(0, 1));
+        assertEquals(-1, result.getInt(0, 2));
+        assertEquals(1, result.getInt(1, 0));
+        assertEquals(1, result.getInt(1, 1));
+        assertEquals(1, result.getInt(1, 2));
+        assertEquals(2, result.getInt(2, 0));
+        assertEquals(2, result.getInt(2, 1));
+        assertEquals(2, result.getInt(2, 2));
+
+        assertEquals(result, bcastResult);
       }
     }
   }
@@ -75,19 +85,27 @@ public class BooleanMaskUpdateTest {
 
       Operand<TInt32> output = BooleanMaskUpdate.create(scope, input, mask, value, BooleanMaskUpdate.axis(2));
 
-      try (TFloat32 result = (TFloat32) sess.runner().fetch(output).run().get(0)) {
-        // expected shape from Python tensorflow
+      Operand<TInt32> bcastOutput = BooleanMaskUpdate
+          .create(scope, input, mask, Constant.scalarOf(scope, -1), BooleanMaskUpdate.axis(2));
+
+      List<Tensor> results = sess.runner().fetch(output).fetch(bcastOutput).run();
+      try (TInt32 result = (TInt32) results.get(0);
+          TInt32 bcastResult = (TInt32) results.get(1)) {
+
         assertEquals(Shape.of(1, 1, 10), result.shape());
-        assertEquals(-1, result.getFloat(0, 0, 0));
-        assertEquals(-1, result.getFloat(0, 0, 1));
-        assertEquals(2, result.getFloat(0, 0, 2));
-        assertEquals(3, result.getFloat(0, 0, 3));
-        assertEquals(-1, result.getFloat(0, 0, 4));
-        assertEquals(-1, result.getFloat(0, 0, 5));
-        assertEquals(-1, result.getFloat(0, 0, 6));
-        assertEquals(7, result.getFloat(0, 0, 7));
-        assertEquals(8, result.getFloat(0, 0, 8));
-        assertEquals(9, result.getFloat(0, 0, 9));
+
+        assertEquals(-1, result.getInt(0, 0, 0));
+        assertEquals(-1, result.getInt(0, 0, 1));
+        assertEquals(2, result.getInt(0, 0, 2));
+        assertEquals(3, result.getInt(0, 0, 3));
+        assertEquals(-1, result.getInt(0, 0, 4));
+        assertEquals(-1, result.getInt(0, 0, 5));
+        assertEquals(-1, result.getInt(0, 0, 6));
+        assertEquals(7, result.getInt(0, 0, 7));
+        assertEquals(8, result.getInt(0, 0, 8));
+        assertEquals(9, result.getInt(0, 0, 9));
+
+        assertEquals(result, bcastResult);
       }
     }
   }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskUpdateTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskUpdateTest.java
@@ -1,0 +1,94 @@
+/*
+  Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ==============================================================================
+ */
+package org.tensorflow.op.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.Test;
+import org.tensorflow.Graph;
+import org.tensorflow.Operand;
+import org.tensorflow.Session;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.index.Indices;
+import org.tensorflow.op.Scope;
+import org.tensorflow.types.TBool;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TInt32;
+
+public class BooleanMaskUpdateTest {
+
+  @Test
+  public void testBooleanMaskUpdateSlice() {
+    try (Graph g = new Graph();
+        Session sess = new Session(g)) {
+      Scope scope = new Scope(g);
+
+      Operand<TInt32> input = Constant.tensorOf(scope, new int[][]{ {0, 0, 0}, {1, 1, 1}, {2, 2, 2}});
+
+      Operand<TBool> mask = Constant.arrayOf(scope, true, false, false);
+
+      Operand<TInt32> value = Constant.tensorOf(scope, new int[][]{{-1, -1, -1}});
+
+      Operand<TInt32> output = BooleanMaskUpdate.create(scope, input, mask, value);
+
+      try (TFloat32 result = (TFloat32) sess.runner().fetch(output).run().get(0)) {
+        // expected shape from Python tensorflow
+        assertEquals(Shape.of(3, 3), result.shape());
+        assertEquals(-1, result.getFloat(0, 0));
+        assertEquals(-1, result.getFloat(0, 1));
+        assertEquals(-1, result.getFloat(0, 2));
+        assertEquals(1, result.getFloat(1, 0));
+        assertEquals(1, result.getFloat(1, 1));
+        assertEquals(1, result.getFloat(1, 2));
+        assertEquals(2, result.getFloat(2, 0));
+        assertEquals(2, result.getFloat(2, 1));
+        assertEquals(2, result.getFloat(2, 2));
+      }
+    }
+  }
+
+  @Test
+  public void testBooleanMaskUpdateAxis() {
+    try (Graph g = new Graph();
+        Session sess = new Session(g)) {
+      Scope scope = new Scope(g);
+
+      Operand<TInt32> input = Constant.tensorOf(scope, new int[][][]{{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}});
+
+      Operand<TBool> mask = Constant.arrayOf(scope, true, true, false, false, true, true, true, false, false, false);
+
+      Operand<TInt32> value = Constant.arrayOf(scope, -1, -1, -1, -1, -1);
+
+      Operand<TInt32> output = BooleanMaskUpdate.create(scope, input, mask, value, BooleanMaskUpdate.axis(2));
+
+      try (TFloat32 result = (TFloat32) sess.runner().fetch(output).run().get(0)) {
+        // expected shape from Python tensorflow
+        assertEquals(Shape.of(1, 1, 10), result.shape());
+        assertEquals(-1, result.getFloat(0, 0, 0));
+        assertEquals(-1, result.getFloat(0, 0, 1));
+        assertEquals(2, result.getFloat(0, 0, 2));
+        assertEquals(3, result.getFloat(0, 0, 3));
+        assertEquals(-1, result.getFloat(0, 0, 4));
+        assertEquals(-1, result.getFloat(0, 0, 5));
+        assertEquals(-1, result.getFloat(0, 0, 6));
+        assertEquals(7, result.getFloat(0, 0, 7));
+        assertEquals(8, result.getFloat(0, 0, 8));
+        assertEquals(9, result.getFloat(0, 0, 9));
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds custom ops for boolean masking (`tensor[mask]` and `tensor[mask] = update`).

Note that there is no Python equivalent of `BooleanMaskUpdate`, but there is in Numpy and PyTorch, so I included it.