### PR TITLE
Adds `Session.restore` to allow loading of checkpoints saved by `Session.save`

### DIFF
--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -373,7 +373,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
+        <version>3.0.0-M5</version>
         <executions>
           <execution>
             <!--
@@ -389,6 +389,8 @@
           </execution>
         </executions>
         <configuration>
+          <!-- Activate the use of TCP to transmit events to the plugin -->
+          <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
           <additionalClasspathElements>
             <additionalClasspathElement>${project.build.directory}/${project.artifactId}-${project.version}-${native.classifier}.jar</additionalClasspathElement>
             <!-- Note: the following path is not accessible in deploying profile, so other libraries like

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
@@ -28,6 +28,7 @@ import static org.tensorflow.internal.c_api.global.tensorflow.TF_NewWhile;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -47,6 +48,7 @@ import org.tensorflow.ndarray.StdArrays;
 import org.tensorflow.op.Op;
 import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Constant;
+import org.tensorflow.op.core.Identity;
 import org.tensorflow.op.core.NoOp;
 import org.tensorflow.op.core.Placeholder;
 import org.tensorflow.op.train.Restore;
@@ -439,15 +441,32 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
    * Return the {@link SaverDef} instance used to save the state of all variables present in
    * this graph.
    *
-   * <p/>On the first call of this method, all nodes necessary to save and restore the state of the
-   * variables are added to the graph. Consequently, any variables that are added to the graph after
-   * this call could not be saved nor restored using this {@link SaverDef}.
+   * <p/> The first time this method is called it builds the {@link SaverDef}. If this graph already
+   * contains a "save/restore_all" operation then it is assumed to contain all necessary saving and
+   * restoring operations. If that operation does not exist then the graph is mutated to add all
+   * the nodes necessary to save and restore the state of the graph. Consequently, any variables
+   * that are added to the graph after this call will not be saved nor restored using this
+   * {@link SaverDef}.
    *
    * @return a {@link SaverDef} instance
    */
   synchronized SaverDef saverDef() {
     if (saverDef == null) {
-      saverDef = addVariableSaver(this);
+      // Check to see if this graph has a restore operation
+      if (operation("save/restore_all") == null) {
+        // No saver, create one by mutating the graph
+        saverDef = addVariableSaver(this);
+      } else {
+        // This graph already has saving/restoring operations,
+        // regenerate SaverDef without mutating. The names mirror
+        // the python implementation for compatibility.
+        // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/training/saver.py
+        saverDef = SaverDef.newBuilder()
+                           .setFilenameTensorName("save/filename")
+                           .setSaveTensorName("save/Save")
+                           .setRestoreOpName("save/restore_all")
+                           .build();
+      }
     }
     return saverDef;
   }
@@ -798,13 +817,15 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
     Constant<TString> varNamesTensor = tf.constant(StdArrays.ndCopyOf(varNames.toArray(tmp)));
     Operand<TString> varSlices = tf.zerosLike(varNamesTensor);
 
-    Placeholder<TString> saveFilename = tf.placeholder(TString.class);
+    Placeholder<TString> saveFilename = tf.withName("filename").placeholder(TString.class);
     Save saveVariables = tf.train.save(
         saveFilename,
         varNamesTensor,
         varSlices,
         varOutputs
     );
+    Identity<TString> id = tf.withSubScope("control_dependency")
+            .withControlDependencies(Arrays.asList(saveFilename,saveVariables)).identity(saveFilename);
     Restore restoreVariables = tf.train.restore(
         saveFilename,
         varNamesTensor,
@@ -815,11 +836,11 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
     for (int i = 0; i < varOutputs.size(); ++i) {
       restoreOps.add(tf.assign(varOutputs.get(i), (Operand) restoreVariables.tensors().get(i)));
     }
-    NoOp restoreAll = tf.withControlDependencies(restoreOps).noOp();
+    NoOp restoreAll = tf.withControlDependencies(restoreOps).withName("restore_all").noOp();
 
     return SaverDef.newBuilder()
         .setFilenameTensorName(saveFilename.op().name())
-        .setSaveTensorName(saveVariables.op().name())
+        .setSaveTensorName(id.op().name())
         .setRestoreOpName(restoreAll.op().name())
         .build();
   }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -512,14 +512,13 @@ public final class Session implements AutoCloseable {
    * <i>mymodel/myvariables</i> and named <i>variables.data-*-of-*</i>
    *
    * <p>Note that this method might alter the underlying graph if it is the first time that one
-   * of its session is saved, see {@link Graph#saverDef()} for more details.
+   * of its sessions is saved, see {@link Graph#saverDef()} for more details.
    *
    * @param prefix prefix to the variable files to save
    */
   public void save(String prefix) {
     SaverDef saverDef = graph.saverDef();
-    runner()
-            .addTarget(saverDef.getSaveTensorName())
+    runner().addTarget(saverDef.getSaveTensorName())
             .feed(saverDef.getFilenameTensorName(), TString.scalarOf(prefix))
             .run();
   }
@@ -532,14 +531,16 @@ public final class Session implements AutoCloseable {
    * <i>mymodel/myvariables/variables</i>, then the files are loaded from
    * <i>mymodel/myvariables</i> and named <i>variables.data-*-of-*</i>
    *
+   * <p>Note that this method might alter the underlying graph if it is the first time that one
+   * of its sessions is saved, see {@link Graph#saverDef()} for more details.
+   *
    * @param prefix prefix to restore from
    */
   public void restore(String prefix) {
     SaverDef saverDef = graph.saverDef();
-    runner()
-        .addTarget(saverDef.getRestoreOpName())
-        .feed(saverDef.getFilenameTensorName(), TString.scalarOf(prefix))
-        .run();
+    runner().addTarget(saverDef.getRestoreOpName())
+            .feed(saverDef.getFilenameTensorName(), TString.scalarOf(prefix))
+            .run();
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -519,7 +519,25 @@ public final class Session implements AutoCloseable {
   public void save(String prefix) {
     SaverDef saverDef = graph.saverDef();
     runner()
-        .addTarget(saverDef.getSaveTensorName())
+            .addTarget(saverDef.getSaveTensorName())
+            .feed(saverDef.getFilenameTensorName(), TString.scalarOf(prefix))
+            .run();
+  }
+
+  /**
+   * Restore the actual state of the variables of this session's graph.
+   *
+   * <p>{@code prefix} is the path where the files containing the variables state live,
+   * followed by the filename prefix. For example, if {@code prefix} is set to
+   * <i>mymodel/myvariables/variables</i>, then the files are loaded from
+   * <i>mymodel/myvariables</i> and named <i>variables.data-*-of-*</i>
+   *
+   * @param prefix prefix to restore from
+   */
+  public void restore(String prefix) {
+    SaverDef saverDef = graph.saverDef();
+    runner()
+        .addTarget(saverDef.getRestoreOpName())
         .feed(saverDef.getFilenameTensorName(), TString.scalarOf(prefix))
         .run();
   }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SessionTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SessionTest.java
@@ -226,10 +226,6 @@ public class SessionTest {
         s.save(testFolder.resolve("checkpoint").toString());
         GraphDef graphDef = g.toGraphDef();
 
-        try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(testFolder.resolve("graph.pb").toFile()))) {
-          graphDef.writeTo(os);
-        }
-
         try (Graph restoredGraph = new Graph()) {
           restoredGraph.importGraphDef(graphDef);
           try (Session restoredSession = new Session(restoredGraph)) {

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SessionTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SessionTest.java
@@ -20,10 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Init;
@@ -32,6 +36,7 @@ import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.linalg.MatMul;
 import org.tensorflow.op.math.Add;
 import org.tensorflow.proto.framework.ConfigProto;
+import org.tensorflow.proto.framework.GraphDef;
 import org.tensorflow.proto.framework.RunOptions;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.NdArrays;
@@ -208,21 +213,39 @@ public class SessionTest {
   }
 
   @Test
-  public void save() throws IOException  {
-    Path testFolder = Files.createTempDirectory("tf-session-save-test");
+  public void saveAndRestore() throws IOException  {
+    Path testFolder = Files.createTempDirectory("tf-session-save-restore-test");
     try (Graph g = new Graph()) {
       Ops tf = Ops.create(g);
-      Variable<TFloat32> x = tf.variable(tf.random.randomUniform(tf.constant(Shape.of(3, 3L)), TFloat32.class));
-      Variable<TFloat32> y = tf.variable(tf.random.randomUniform(tf.constant(Shape.of(3, 3L)), TFloat32.class));
+      Variable<TFloat32> x = tf.withName("x").variable(tf.random.randomUniform(tf.constant(Shape.of(3, 3L)), TFloat32.class));
+      Variable<TFloat32> y = tf.withName("y").variable(tf.random.randomUniform(tf.constant(Shape.of(3, 3L)), TFloat32.class));
       Init init = tf.init();
+      GraphDef graphDef = g.toGraphDef();
 
       try (Session s = new Session(g)) {
         s.run(init);
         s.save(testFolder.resolve("checkpoint").toString());
+        try (Graph restoredGraph = new Graph()) {
+          restoredGraph.importGraphDef(graphDef);
+          try (Session restoredSession = new Session(restoredGraph)) {
+            restoredSession.restore(testFolder.resolve("checkpoint").toString());
+            try (AutoCloseableList<Tensor> oldList = new AutoCloseableList<>(s.runner().fetch("x").fetch("y").run());
+                 AutoCloseableList<Tensor> newList = new AutoCloseableList<>(restoredSession.runner().fetch("x").fetch("y").run())){
+              assertEquals(oldList.get(0),newList.get(0));
+              assertEquals(oldList.get(1),newList.get(1));
+            }
+          }
+        }
       }
     }
     assertTrue(Files.exists(testFolder.resolve("checkpoint.index")));
     assertTrue(Files.exists(testFolder.resolve("checkpoint.data-00000-of-00001")));
+
+    // Cleanup test dir
+    Files.walk(testFolder)
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
   }
 
   private static RunOptions fullTraceRunOptions() {


### PR DESCRIPTION
This allows the easy restoration of checkpoints during training. A fresh graph object loaded from a `GraphDef` will not have a `SaverDef` defined, so the method that creates a `SaverDef` was modified to check if the graph already had restore operations, in which case the names of the operations are filled in rather than trying to mutate the graph twice (which will throw an exception). The names are set based on the defaults used in Saver.py, though it's not identical as that adds an extra placeholder called "save/Const" for unspecified backwards compatibility, and when I mirror that in Java calling session.run gives TFIllegalArgumentException complaining that placeholder is unfilled.

It's not quite the same as the TF 2 checkpoint restore mechanism, but that seems tightly woven into the Python structure and we don't quite have the infrastructure yet.

I also bumped the version of `maven-surefire-plugin` as otherwise I get error messages out of Maven when running the tests. Not sure when this started, but it's happening for me on Ubuntu 20.04 x86_64.