### PR TITLE
Handle empty user build flags

### DIFF
--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -33,7 +33,7 @@ BUILD_FLAGS="$BUILD_FLAGS --experimental_repo_remote_exec --python_path="$PYTHON
 BUILD_FLAGS="$BUILD_FLAGS --distinct_host_configuration=true"
 
 # Build C/C++ API of TensorFlow itself including a target to generate ops for Java
-bazel build $BUILD_FLAGS $BUILD_EXTRA_FLAGS \
+bazel build $BUILD_FLAGS ${BUILD_USER_FLAGS:-} \
     @org_tensorflow//tensorflow:tensorflow_cc \
     @org_tensorflow//tensorflow/tools/lib_package:jnilicenses_generate \
     :java_proto_gen_sources \

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -260,7 +260,7 @@
               </buildCommand>
               <environmentVariables>
                 <EXTENSION>${javacpp.platform.extension}</EXTENSION>
-                <BUILD_EXTRA_FLAGS>${native.build.flags}</BUILD_EXTRA_FLAGS>
+                <BUILD_USER_FLAGS>${native.build.flags}</BUILD_USER_FLAGS>
               </environmentVariables>
               <workingDirectory>${project.basedir}</workingDirectory>
             </configuration>


### PR DESCRIPTION
Fix `mvn install` when `native.build.flags` are not set.