### PR TITLE
Fix memory leak occuring with new layout of string tensors

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -604,23 +604,16 @@ public final class Session implements AutoCloseable {
         status.throwExceptionIfNotOK();
       }
 
-      TF_Session session = TF_NewSession(graphHandle, opts, status);
+      TF_Session session = TF_Session.newSession(graphHandle, opts, status);
       status.throwExceptionIfNotOK();
 
-      return session;
+      return session.retainReference();
     }
   }
 
   private static void delete(TF_Session handle) {
     requireHandle(handle);
-
-    try (PointerScope scope = new PointerScope()) {
-      TF_Status status = TF_Status.newStatus();
-      TF_CloseSession(handle, status);
-      // Result of close is ignored, delete anyway.
-      TF_DeleteSession(handle, status);
-      status.throwExceptionIfNotOK();
-    }
+    handle.releaseReference();
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/ByteSequenceTensorBuffer.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/ByteSequenceTensorBuffer.java
@@ -19,7 +19,6 @@ package org.tensorflow.internal.buffer;
 
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_TString_Assign;
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_TString_Copy;
-import static org.tensorflow.internal.c_api.global.tensorflow.TF_TString_Init;
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_TString_GetDataPointer;
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_TString_GetSize;
 
@@ -127,7 +126,6 @@ public class ByteSequenceTensorBuffer extends AbstractDataBuffer<byte[]> {
     void writeNext(byte[] bytes) {
       try (PointerScope scope = new PointerScope()) {
         TF_TString tstring = data.getPointer(index++);
-        TF_TString_Init(tstring);
         TF_TString_Copy(tstring, new BytePointer(bytes), bytes.length);
       }
     }


### PR DESCRIPTION
Also fix and actually use JavaCPP deallocator for TF_Session as well

Fixes #251 and we should probably add a regression test for that somewhere.
What would be a good place?