### PR TITLE
Changing quick build over to use actions/setup-java and Java 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
+      - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: 8 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8 
       - name: Build project
         run: |
           git --version


### PR DESCRIPTION
actions/setup-java is the preferred way of specifying the JDK in a Github action. This PR changes the quick-build ci pipeline over to use setup-java and specifies Java 8 as the build JDK. It doesn't modify any of the long builds or the packaging pipeline, we can experiment with introducing it there later.

This fixes our javadoc build failures. The javadoc still has errors in, but at least it doesn't fail the whole CI and ignore test results.