### PR TITLE
Enable lint and errorprone checks in Jdk11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,26 @@ jobs:
   quick-build:
     if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: ubuntu-latest
+    container: centos:7
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
-      - name: Setup Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8 
+      - name: Install environment
+        run: |
+          yum -y update
+          yum -y install centos-release-scl-rh epel-release
+          yum -y install java-11-openjdk-devel devtoolset-7
+          echo Downloading Maven
+          curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -o $HOME/apache-maven-3.6.3-bin.tar.gz
+          tar xzf $HOME/apache-maven-3.6.3-bin.tar.gz -C /opt/
+          ln -sf /opt/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
       - name: Build project
         run: |
-          git --version
+          source scl_source enable devtoolset-7 || true 
+          export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
+          echo $JAVA_HOME
           mvn -version
-          mvn clean install -Pdev -B -U -e
+          mvn clean install -Pdev,jdk11 -B -U -e
   prepare:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
           export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
           echo $JAVA_HOME
           mvn -version
-          mvn clean install -Pdev,jdk11 -B -U -e
+          mvn clean install -Pdev,jdk11 -B -U -e -Dlint.skip=true
+      - name: Run lint checks
+        run: |
+          mvn compiler:compile -Pdev,jdk11 -B -U -e
   prepare:
     runs-on: ubuntu-latest
     outputs:

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <junit.version>5.6.2</junit.version>
     <jmh.version>1.21</jmh.version>
     <versions-plugin.version>2.7</versions-plugin.version>
+    <errorprone.version>2.6.0</errorprone.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.source.skip>true</maven.source.skip>
     <gpg.skip>true</gpg.skip>
@@ -173,6 +174,31 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+              <showWarnings>true</showWarnings>
+              <compilerArgs combine.children="append">
+                <!--arg>-Werror</arg-->
+                <arg>-Xlint:all</arg>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne</arg>
+              </compilerArgs>
+              <annotationProcessorPaths combine.children="append">
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,23 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
       </properties>
+    </profile>
+
+    <!--
+      Profile that enables lint checks on compilation
+      Uses Google Error Prone for more coverage
+    -->
+    <profile>
+      <id>lint</id>
+      <activation>
+        <!-- activate lint checks only on JDK1.9+ (required by Error Prone) -->
+        <jdk>(1.9,)</jdk>
+        <!-- custom property to disable link checks on command line (enabled by default) -->
+        <property>
+          <name>!lint.skip</name>
+          <value>!true</value>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>
@@ -182,11 +199,23 @@
             <version>3.8.0</version>
             <configuration>
               <showWarnings>true</showWarnings>
+              <fork>true</fork> <!-- Required for JDK16+ -->
               <compilerArgs combine.children="append">
-                <!--arg>-Werror</arg-->
+                <!--arg>-Werror</arg--> <!-- Disabled (temporarily?) -->
                 <arg>-Xlint:all</arg>
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne</arg>
+                <!-- Following are required on JDK16+ -->
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
               </compilerArgs>
               <annotationProcessorPaths combine.children="append">
                 <path>

--- a/tensorflow-core/tensorflow-core-generator/pom.xml
+++ b/tensorflow-core/tensorflow-core-generator/pom.xml
@@ -59,11 +59,6 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This PR enables lint checks from javac and Google's errorprone plugin. It's enabled only in JDK11 mode for now, since errorprone won't work with standard javac compiler of JDK8.

Right now I've enabled only default error and warning checks in errorprone since adding them all increase drastically the compilation time (see the list of all checks available [here](https://github.com/google/error-prone/blob/v2.6.0/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java)).

We'll readjust and add more checks if needed, plus clear all warnings that we already have in a separate PR.