### PR TITLE
Fix sometimes generating Javadoc for scope param in Ops

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnOps.java
@@ -1833,7 +1833,6 @@ public final class NnOps {
    *
    *  <p>
    *
-   * @param scope The TensorFlow scope
    * @param labels the labels
    * @param logits the logits of type float32 or float64
    * @param <T> the type of labels and logits
@@ -1894,7 +1893,6 @@ public final class NnOps {
    *  disallow backpropagation into <code>labels</code>, pass label tensors through <code>
    *  tf.stopGradient</code> before feeding it to this function.
    *
-   * @param scope current scope
    * @param labels Each vector along the class dimension should hold a valid probability
    *      distribution e.g. for the case in which labels are of shape <code>[batch_size, num_classes]
    *      </code>, each row of <code>labels[i]</code> must be a valid probability distribution.
@@ -2127,7 +2125,6 @@ public final class NnOps {
    *  , or <code>TFloat64</code>, and <code>labels</code> must have the dtype of <code>TInt32</code>
    *  or <code>TInt64</code>.
    *
-   * @param scope current scope
    * @param labels <code>Tensor</code> of shape <code>[d_0, d_1, ..., d_{r-1}]</code> (where <code>r
    *      </code> is rank of <code>labels</code> and result) and the dataType is <code>TInt32</code>
    *      or <code>TInt64</code>. Each entry in <code>labels</code> must be an index in <code>[0,

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -446,20 +446,8 @@ public final class Ops {
   }
 
   /**
-   * Creates a constant of {@code int} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant.
-   * @return a float constant
-   */
-  public Constant<TInt32> array(int... data) {
-    return Constant.arrayOf(scope, data);
-  }
-
-  /**
    * Creates a constant of {@code String} elements, using the default UTF-8 charset.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant.
    * @return the {@code String} constant
    */
@@ -468,42 +456,18 @@ public final class Ops {
   }
 
   /**
-   * Creates a constant of {@code boolean} elements.
+   * Creates a constant of {@code int} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant.
-   * @return a boolean constant
-   */
-  public Constant<TBool> array(boolean... data) {
-    return Constant.arrayOf(scope, data);
-  }
-
-  /**
-   * Creates a constant of {@code long} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant.
-   * @return a long constant
-   */
-  public Constant<TInt64> array(long... data) {
-    return Constant.arrayOf(scope, data);
-  }
-
-  /**
-   * Creates a constant of {@code float} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant.
    * @return a float constant
    */
-  public Constant<TFloat32> array(float... data) {
+  public Constant<TInt32> array(int... data) {
     return Constant.arrayOf(scope, data);
   }
 
   /**
    * Creates a constant of {@code double} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant.
    * @return a double constant
    */
@@ -512,9 +476,18 @@ public final class Ops {
   }
 
   /**
+   * Creates a constant of {@code long} elements.
+   *
+   * @param data An array containing the values to put into the new constant.
+   * @return a long constant
+   */
+  public Constant<TInt64> array(long... data) {
+    return Constant.arrayOf(scope, data);
+  }
+
+  /**
    * Creates a constant of {@code byte} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant.
    * @return a byte constant
    */
@@ -523,9 +496,28 @@ public final class Ops {
   }
 
   /**
+   * Creates a constant of {@code boolean} elements.
+   *
+   * @param data An array containing the values to put into the new constant.
+   * @return a boolean constant
+   */
+  public Constant<TBool> array(boolean... data) {
+    return Constant.arrayOf(scope, data);
+  }
+
+  /**
+   * Creates a constant of {@code float} elements.
+   *
+   * @param data An array containing the values to put into the new constant.
+   * @return a float constant
+   */
+  public Constant<TFloat32> array(float... data) {
+    return Constant.arrayOf(scope, data);
+  }
+
+  /**
    * Creates a constant of {@code String} elements, using the given charset.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param charset charset for encoding/decoding strings bytes.
    * @param data An array containing the values to put into the new constant. String elements are
    *      sequences of bytes from the last array dimension.
@@ -1021,7 +1013,6 @@ public final class Ops {
    *  In that case, {@code axis + dim(mask) <= dim(tensor)} and {@code mask}'s shape must match
    *  the first {@code axis + dim(mask)} dimensions of {@code tensor}'s shape.
    *
-   * @param scope
    * @param tensor The tensor to mask.
    * @param mask The mask to apply.
    * @param options carries optional attributes values
@@ -1178,337 +1169,8 @@ public final class Ops {
   }
 
   /**
-   * Creates a constant of {@code long} elements that is a copy of a given n-dimensional array.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data an n-dimensional array of {@code long} elements.
-   * @return a long constant
-   */
-  public Constant<TInt64> constant(LongNdArray data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-1 constant of {@code int} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return an integer constant
-   */
-  public Constant<TInt32> constant(int[] data) {
-    return Constant.vectorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-3 constant of {@code int} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return an integer constant
-   */
-  public Constant<TInt32> constant(int[][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a constant containing a single {@code double} element.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data The value to put into the new constant.
-   * @return a double constant
-   */
-  public Constant<TFloat64> constant(double data) {
-    return Constant.scalarOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-5 constant of {@code long} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a long constant
-   */
-  public Constant<TInt64> constant(long[][][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-5 constant of {@code boolean} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a boolean constant
-   */
-  public Constant<TBool> constant(boolean[][][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a constant of {@code int} elements that is a copy of a given n-dimensional array.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data an n-dimensional array of {@code int} elements.
-   * @return an integer constant
-   */
-  public Constant<TInt32> constant(IntNdArray data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a constant of {@code double} elements that is a copy of a given n-dimensional array.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data an n-dimensional array of {@code double} elements.
-   * @return a double constant
-   */
-  public Constant<TFloat64> constant(DoubleNdArray data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-4 constant of {@code int} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return an integer constant
-   */
-  public Constant<TInt32> constant(int[][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-6 constant of {@code float} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a float constant
-   */
-  public Constant<TFloat32> constant(float[][][][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a constant containing a single {@code byte} element.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data The value to put into the new constant.
-   * @return a byte constant
-   */
-  public Constant<TUint8> constant(byte data) {
-    return Constant.scalarOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-3 constant of {@code boolean} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a boolean constant
-   */
-  public Constant<TBool> constant(boolean[][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-4 constant of {@code float} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a float constant
-   */
-  public Constant<TFloat32> constant(float[][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-2 constant of {@code long} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a long constant
-   */
-  public Constant<TInt64> constant(long[][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-5 constant of {@code byte} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a byte constant
-   */
-  public Constant<TUint8> constant(byte[][][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a constant of {@code boolean} elements that is a copy of a given n-dimensional array.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data an n-dimensional array of {@code boolean} elements.
-   * @return a boolean constant
-   */
-  public Constant<TBool> constant(BooleanNdArray data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-2 constant of {@code float} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a float constant
-   */
-  public Constant<TFloat32> constant(float[][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a constant of {@code byte} elements that is a copy of a given n-dimensional array.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data an n-dimensional array of {@code byte} elements.
-   * @return a byte constant
-   */
-  public Constant<TUint8> constant(ByteNdArray data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-2 constant of {@code byte} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a byte constant
-   */
-  public Constant<TUint8> constant(byte[][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-5 constant of {@code double} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a double constant
-   */
-  public Constant<TFloat64> constant(double[][][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-3 constant of {@code float} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a float constant
-   */
-  public Constant<TFloat32> constant(float[][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-1 constant of {@code byte} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a byte constant
-   */
-  public Constant<TUint8> constant(byte[] data) {
-    return Constant.vectorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-1 constant of {@code float} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a float constant
-   */
-  public Constant<TFloat32> constant(float[] data) {
-    return Constant.vectorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-2 constant of {@code boolean} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a boolean constant
-   */
-  public Constant<TBool> constant(boolean[][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a constant of {@code String} elements that is a copy of a given n-dimensional array,
-   *  using the default UTF-8 encoding.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data an n-dimensional array of {@code String} elements.
-   * @return a string constant
-   */
-  public Constant<TString> constant(NdArray<String> data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a {@code String} constant using the default, UTF-8 encoding.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data The string to put into the new constant.
-   * @return a string constant
-   */
-  public Constant<TString> constant(String data) {
-    return Constant.scalarOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-4 constant of {@code double} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a double constant
-   */
-  public Constant<TFloat64> constant(double[][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-2 constant of {@code double} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a double constant
-   */
-  public Constant<TFloat64> constant(double[][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
    * Creates a constant containing a single {@code int} element.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data The value to put into the new constant.
    * @return an integer constant
    */
@@ -1517,67 +1179,8 @@ public final class Ops {
   }
 
   /**
-   * Creates a rank-4 constant of {@code byte} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a byte constant
-   */
-  public Constant<TUint8> constant(byte[][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-6 constant of {@code int} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return an integer constant
-   */
-  public Constant<TInt32> constant(int[][][][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a constant containing a single {@code long} element.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data The value to put into the new constant.
-   * @return a long constant
-   */
-  public Constant<TInt64> constant(long data) {
-    return Constant.scalarOf(scope, data);
-  }
-
-  /**
-   * Creates a constant containing a single {@code float} element.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data The value to put into the new constant.
-   * @return a float constant
-   */
-  public Constant<TFloat32> constant(float data) {
-    return Constant.scalarOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-5 constant of {@code float} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a float constant
-   */
-  public Constant<TFloat32> constant(float[][][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
    * Creates a rank-3 constant of {@code double} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
    * @return a double constant
@@ -1587,33 +1190,297 @@ public final class Ops {
   }
 
   /**
-   * Creates a rank-6 constant of {@code long} elements.
+   * Creates a rank-5 constant of {@code byte} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
-   * @return a long constant
+   * @return a byte constant
    */
-  public Constant<TInt64> constant(long[][][][][][] data) {
+  public Constant<TUint8> constant(byte[][][][][] data) {
     return Constant.tensorOf(scope, data);
   }
 
   /**
-   * Creates a rank-4 constant of {@code long} elements.
+   * Creates a constant of {@code String} elements that is a copy of a given n-dimensional array,
+   *  using the default UTF-8 encoding.
    *
-   * @param scope is a scope used to add the underlying operation.
+   * @param data an n-dimensional array of {@code String} elements.
+   * @return a string constant
+   */
+  public Constant<TString> constant(NdArray<String> data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-4 constant of {@code int} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return an integer constant
+   */
+  public Constant<TInt32> constant(int[][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a constant containing a single {@code byte} element.
+   *
+   * @param data The value to put into the new constant.
+   * @return a byte constant
+   */
+  public Constant<TUint8> constant(byte data) {
+    return Constant.scalarOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-2 constant of {@code long} elements.
+   *
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
    * @return a long constant
    */
-  public Constant<TInt64> constant(long[][][][] data) {
+  public Constant<TInt64> constant(long[][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-6 constant of {@code float} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a float constant
+   */
+  public Constant<TFloat32> constant(float[][][][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-6 constant of {@code boolean} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a boolean constant
+   */
+  public Constant<TBool> constant(boolean[][][][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-4 constant of {@code boolean} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a boolean constant
+   */
+  public Constant<TBool> constant(boolean[][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-3 constant of {@code float} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a float constant
+   */
+  public Constant<TFloat32> constant(float[][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-5 constant of {@code float} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a float constant
+   */
+  public Constant<TFloat32> constant(float[][][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-5 constant of {@code long} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a long constant
+   */
+  public Constant<TInt64> constant(long[][][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-1 constant of {@code int} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return an integer constant
+   */
+  public Constant<TInt32> constant(int[] data) {
+    return Constant.vectorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-2 constant of {@code float} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a float constant
+   */
+  public Constant<TFloat32> constant(float[][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-2 constant of {@code boolean} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a boolean constant
+   */
+  public Constant<TBool> constant(boolean[][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a constant containing a single {@code double} element.
+   *
+   * @param data The value to put into the new constant.
+   * @return a double constant
+   */
+  public Constant<TFloat64> constant(double data) {
+    return Constant.scalarOf(scope, data);
+  }
+
+  /**
+   * Creates a constant containing a single {@code boolean} element.
+   *
+   * @param data The value to put into the new constant.
+   * @return a boolean constant
+   */
+  public Constant<TBool> constant(boolean data) {
+    return Constant.scalarOf(scope, data);
+  }
+
+  /**
+   * Creates a constant containing a single {@code long} element.
+   *
+   * @param data The value to put into the new constant.
+   * @return a long constant
+   */
+  public Constant<TInt64> constant(long data) {
+    return Constant.scalarOf(scope, data);
+  }
+
+  /**
+   * Creates a {@code String} constant using the default, UTF-8 encoding.
+   *
+   * @param data The string to put into the new constant.
+   * @return a string constant
+   */
+  public Constant<TString> constant(String data) {
+    return Constant.scalarOf(scope, data);
+  }
+
+  /**
+   * Creates a constant of {@code boolean} elements that is a copy of a given n-dimensional array.
+   *
+   * @param data an n-dimensional array of {@code boolean} elements.
+   * @return a boolean constant
+   */
+  public Constant<TBool> constant(BooleanNdArray data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-1 constant of {@code double} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a double constant
+   */
+  public Constant<TFloat64> constant(double[] data) {
+    return Constant.vectorOf(scope, data);
+  }
+
+  /**
+   * Creates a constant of {@code long} elements that is a copy of a given n-dimensional array.
+   *
+   * @param data an n-dimensional array of {@code long} elements.
+   * @return a long constant
+   */
+  public Constant<TInt64> constant(LongNdArray data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-1 constant of {@code float} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a float constant
+   */
+  public Constant<TFloat32> constant(float[] data) {
+    return Constant.vectorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-3 constant of {@code long} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a long constant
+   */
+  public Constant<TInt64> constant(long[][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-3 constant of {@code boolean} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a boolean constant
+   */
+  public Constant<TBool> constant(boolean[][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-1 constant of {@code byte} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a byte constant
+   */
+  public Constant<TUint8> constant(byte[] data) {
+    return Constant.vectorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-3 constant of {@code int} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return an integer constant
+   */
+  public Constant<TInt32> constant(int[][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a constant of {@code int} elements that is a copy of a given n-dimensional array.
+   *
+   * @param data an n-dimensional array of {@code int} elements.
+   * @return an integer constant
+   */
+  public Constant<TInt32> constant(IntNdArray data) {
     return Constant.tensorOf(scope, data);
   }
 
   /**
    * Creates a rank-1 constant of {@code long} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
    * @return a long constant
@@ -1623,57 +1490,8 @@ public final class Ops {
   }
 
   /**
-   * Creates a rank-1 constant of {@code boolean} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a boolean constant
-   */
-  public Constant<TBool> constant(boolean[] data) {
-    return Constant.vectorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-3 constant of {@code byte} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a byte constant
-   */
-  public Constant<TUint8> constant(byte[][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-6 constant of {@code byte} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a byte constant
-   */
-  public Constant<TUint8> constant(byte[][][][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-2 constant of {@code int} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return an integer constant
-   */
-  public Constant<TInt32> constant(int[][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
    * Creates a constant of {@code float} elements that is a copy of a given n-dimensional array.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data an n-dimensional array of {@code float} elements.
    * @return a float constant
    */
@@ -1684,7 +1502,6 @@ public final class Ops {
   /**
    * Creates a rank-5 constant of {@code int} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
    * @return an integer constant
@@ -1694,33 +1511,51 @@ public final class Ops {
   }
 
   /**
-   * Creates a rank-1 constant of {@code double} elements.
+   * Creates a rank-5 constant of {@code double} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
    * @return a double constant
    */
-  public Constant<TFloat64> constant(double[] data) {
-    return Constant.vectorOf(scope, data);
+  public Constant<TFloat64> constant(double[][][][][] data) {
+    return Constant.tensorOf(scope, data);
   }
 
   /**
-   * Creates a rank-6 constant of {@code boolean} elements.
+   * Creates a rank-5 constant of {@code boolean} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
    * @return a boolean constant
    */
-  public Constant<TBool> constant(boolean[][][][][][] data) {
+  public Constant<TBool> constant(boolean[][][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-6 constant of {@code int} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return an integer constant
+   */
+  public Constant<TInt32> constant(int[][][][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a constant of {@code double} elements that is a copy of a given n-dimensional array.
+   *
+   * @param data an n-dimensional array of {@code double} elements.
+   * @return a double constant
+   */
+  public Constant<TFloat64> constant(DoubleNdArray data) {
     return Constant.tensorOf(scope, data);
   }
 
   /**
    * Creates a rank-6 constant of {@code double} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
    * @return a double constant
@@ -1730,37 +1565,143 @@ public final class Ops {
   }
 
   /**
-   * Creates a constant containing a single {@code boolean} element.
+   * Creates a rank-6 constant of {@code long} elements.
    *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data The value to put into the new constant.
-   * @return a boolean constant
-   */
-  public Constant<TBool> constant(boolean data) {
-    return Constant.scalarOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-4 constant of {@code boolean} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param data An array containing the values to put into the new constant. The dimensions of the
-   *      new constant will match those of the array.
-   * @return a boolean constant
-   */
-  public Constant<TBool> constant(boolean[][][][] data) {
-    return Constant.tensorOf(scope, data);
-  }
-
-  /**
-   * Creates a rank-3 constant of {@code long} elements.
-   *
-   * @param scope is a scope used to add the underlying operation.
    * @param data An array containing the values to put into the new constant. The dimensions of the
    *      new constant will match those of the array.
    * @return a long constant
    */
-  public Constant<TInt64> constant(long[][][] data) {
+  public Constant<TInt64> constant(long[][][][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-2 constant of {@code int} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return an integer constant
+   */
+  public Constant<TInt32> constant(int[][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-1 constant of {@code boolean} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a boolean constant
+   */
+  public Constant<TBool> constant(boolean[] data) {
+    return Constant.vectorOf(scope, data);
+  }
+
+  /**
+   * Creates a constant containing a single {@code float} element.
+   *
+   * @param data The value to put into the new constant.
+   * @return a float constant
+   */
+  public Constant<TFloat32> constant(float data) {
+    return Constant.scalarOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-4 constant of {@code byte} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a byte constant
+   */
+  public Constant<TUint8> constant(byte[][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-4 constant of {@code float} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a float constant
+   */
+  public Constant<TFloat32> constant(float[][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a constant of {@code byte} elements that is a copy of a given n-dimensional array.
+   *
+   * @param data an n-dimensional array of {@code byte} elements.
+   * @return a byte constant
+   */
+  public Constant<TUint8> constant(ByteNdArray data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-6 constant of {@code byte} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a byte constant
+   */
+  public Constant<TUint8> constant(byte[][][][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-4 constant of {@code long} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a long constant
+   */
+  public Constant<TInt64> constant(long[][][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-2 constant of {@code byte} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a byte constant
+   */
+  public Constant<TUint8> constant(byte[][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-2 constant of {@code double} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a double constant
+   */
+  public Constant<TFloat64> constant(double[][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-3 constant of {@code byte} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a byte constant
+   */
+  public Constant<TUint8> constant(byte[][][] data) {
+    return Constant.tensorOf(scope, data);
+  }
+
+  /**
+   * Creates a rank-4 constant of {@code double} elements.
+   *
+   * @param data An array containing the values to put into the new constant. The dimensions of the
+   *      new constant will match those of the array.
+   * @return a double constant
+   */
+  public Constant<TFloat64> constant(double[][][][] data) {
     return Constant.tensorOf(scope, data);
   }
 
@@ -1768,7 +1709,6 @@ public final class Ops {
    * Creates a rank-1 constant of {@code long} elements representing the size of each dimensions of
    *  the given shape.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param shape a shape
    * @return a long constant
    */
@@ -1777,9 +1717,20 @@ public final class Ops {
   }
 
   /**
+   * Creates a constant of {@code String} elements that is a copy of a given n-dimensional array,
+   *  using the given encoding.
+   *
+   * @param charset charset used to encode/decode string bytes.
+   * @param data an n-dimensional array of {@code String} elements.
+   * @return a string constant
+   */
+  public Constant<TString> constant(Charset charset, NdArray<String> data) {
+    return Constant.tensorOf(scope, charset, data);
+  }
+
+  /**
    * Creates a constant of {@code String} elements, using the given charset.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param charset charset for encoding/decoding strings bytes.
    * @param data An array containing the values to put into the new constant. String elements are
    *      sequences of bytes from the last array dimension.
@@ -1792,7 +1743,6 @@ public final class Ops {
   /**
    * Creates a {@code String} constant using a specified encoding.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param charset The encoding from String to bytes.
    * @param data The string to put into the new constant.
    * @return a string constant
@@ -1802,35 +1752,8 @@ public final class Ops {
   }
 
   /**
-   * Creates a constant of {@code String} elements that is a copy of a given n-dimensional array,
-   *  using the given encoding.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param charset charset used to encode/decode string bytes.
-   * @param data an n-dimensional array of {@code String} elements.
-   * @return a string constant
-   */
-  public Constant<TString> constant(Charset charset, NdArray<String> data) {
-    return Constant.tensorOf(scope, charset, data);
-  }
-
-  /**
-   * Create a {@link TFloat32} constant with data from the given buffer.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param shape the tensor shape.
-   * @param data a buffer containing the tensor data.
-   * @return a float constant
-   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
-   */
-  public Constant<TFloat32> constant(Shape shape, FloatDataBuffer data) {
-    return Constant.tensorOf(scope, shape, data);
-  }
-
-  /**
    * Create a {@link TBool} constant with data from the given buffer.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param shape the tensor shape.
    * @param data a buffer containing the tensor data.
    * @return an boolean constant
@@ -1841,36 +1764,9 @@ public final class Ops {
   }
 
   /**
-   * Create a {@link TUint8} constant with data from the given buffer.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param shape the tensor shape.
-   * @param data a buffer containing the tensor data.
-   * @return a byte constant
-   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
-   */
-  public Constant<TUint8> constant(Shape shape, ByteDataBuffer data) {
-    return Constant.tensorOf(scope, shape, data);
-  }
-
-  /**
-   * Create a {@link TInt64} constant with data from the given buffer.
-   *
-   * @param scope is a scope used to add the underlying operation.
-   * @param shape the tensor shape.
-   * @param data a buffer containing the tensor data.
-   * @return a long constant
-   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
-   */
-  public Constant<TInt64> constant(Shape shape, LongDataBuffer data) {
-    return Constant.tensorOf(scope, shape, data);
-  }
-
-  /**
    * Create a {@link TString} constant with data from the given buffer, using the default UTF-8
    *  encoding.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param shape the tensor shape.
    * @param data a buffer containing the tensor data.
    * @return a string constant
@@ -1881,9 +1777,44 @@ public final class Ops {
   }
 
   /**
+   * Create a {@link TUint8} constant with data from the given buffer.
+   *
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   * @return a byte constant
+   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
+   */
+  public Constant<TUint8> constant(Shape shape, ByteDataBuffer data) {
+    return Constant.tensorOf(scope, shape, data);
+  }
+
+  /**
+   * Create a {@link TInt32} constant with data from the given buffer.
+   *
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   * @return an integer constant
+   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
+   */
+  public Constant<TInt32> constant(Shape shape, IntDataBuffer data) {
+    return Constant.tensorOf(scope, shape, data);
+  }
+
+  /**
+   * Create a {@link TInt64} constant with data from the given buffer.
+   *
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   * @return a long constant
+   * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
+   */
+  public Constant<TInt64> constant(Shape shape, LongDataBuffer data) {
+    return Constant.tensorOf(scope, shape, data);
+  }
+
+  /**
    * Create a {@link TFloat64} constant with data from the given buffer.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param shape the tensor shape.
    * @param data a buffer containing the tensor data.
    * @return a double constant
@@ -1894,15 +1825,14 @@ public final class Ops {
   }
 
   /**
-   * Create a {@link TInt32} constant with data from the given buffer.
+   * Create a {@link TFloat32} constant with data from the given buffer.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param shape the tensor shape.
    * @param data a buffer containing the tensor data.
-   * @return an integer constant
+   * @return a float constant
    * @throws IllegalArgumentException If the tensor shape is not compatible with the buffer
    */
-  public Constant<TInt32> constant(Shape shape, IntDataBuffer data) {
+  public Constant<TFloat32> constant(Shape shape, FloatDataBuffer data) {
     return Constant.tensorOf(scope, shape, data);
   }
 
@@ -1923,7 +1853,6 @@ public final class Ops {
   /**
    * Create a {@link TString} constant with data from the given buffer, using the given encoding.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param charset charset used to encode/decode string bytes.
    * @param shape the tensor shape.
    * @param data a buffer containing the tensor data.
@@ -1938,7 +1867,6 @@ public final class Ops {
    * Create a constant with data from the given buffer.
    *
    * @param <T> the tensor type
-   * @param scope is a scope used to add the underlying operation.
    * @param type the tensor type class
    * @param shape the tensor shape.
    * @param data a buffer containing the tensor data.
@@ -1957,7 +1885,6 @@ public final class Ops {
    *  <p>Note: this endpoint cannot be simply called {@code constant} since it will conflict with
    *  other endpoints accepting an NdArray in parameter {e.g. {@link #tensorOf(Scope, FloatNdArray)}}.
    *
-   * @param scope is a scope used to add the underlying operation.
    * @param tensor a Tensor holding the constant value
    * @return a constant of the same data type as `tensor`
    */
@@ -2728,7 +2655,6 @@ public final class Ops {
   /**
    * Adds gradients computation ops to the graph according to scope.
    *
-   * @param scope current graph scope
    * @param y outputs of the function to derive
    * @param x inputs of the function for which partial derivatives are computed
    * @param options carries optional attributes values
@@ -2973,7 +2899,6 @@ public final class Ops {
    *  }
    *  }</pre>
    *
-   * @param scope current scope
    * @return an op grouping all initializers added to the graph
    * @throws IllegalArgumentException if the execution environment in scope is not a graph
    */
@@ -2988,7 +2913,6 @@ public final class Ops {
    *  and executing an {@link org.tensorflow.op.core.Init#create(Scope) init} operation from a graph
    *  session.  This is a no-op if executed in an eager session.
    *
-   * @param scope
    * @param initializer
    * @see org.tensorflow.op.core.Init#create(Scope) init
    */
@@ -3703,7 +3627,6 @@ public final class Ops {
   /**
    * Creates a one valued tensor given its type and shape.
    *
-   * @param scope is a scope used to add the underlying operation
    * @param dims a 1-D operand that represents the shape of the output tensor
    * @param type the output tensor type class. Can not be TString.
    * @return a constant tensor initialized with ones
@@ -6210,7 +6133,6 @@ public final class Ops {
    *  <i>Requirements</i>:
    *  `0 != strides[i] for i in [0, m)` Only one ellipsis.
    *
-   * @param scope current scope
    * @param <T> data type for {@code output()} output
    * @param indices The indices to slice.  See {@link Indices}.
    * @return a new instance of StridedSlice
@@ -6342,7 +6264,6 @@ public final class Ops {
    *  the slice of `ref`.
    *
    * @param <T> data type for {@code outputRef()} output
-   * @param scope current scope
    * @param ref the tensor to assign to.
    * @param value the value to assign.
    * @param indices The indices to slice.  See {@link Indices}.
@@ -7943,7 +7864,6 @@ public final class Ops {
    *  Only supported on Graph sessions as the {@link org.tensorflow.op.core.Assign} op
    *  does not work in an EagerSession.
    *
-   * @param scope current scope
    * @param init The op to use to initialise this variable.
    * @param options carries optional attributes values
    * @return a new instance of Variable
@@ -8117,7 +8037,6 @@ public final class Ops {
   /**
    * Creates a zeroed tensor given its type and shape.
    *
-   * @param scope is a scope used to add the underlying operation
    * @param dims a 1-D operand that represents the shape of the output tensor
    * @param type the output tensor datatype
    * @return a constant tensor initialized with zeros

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/ShapeOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/ShapeOps.java
@@ -44,7 +44,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional operand containing the dimensions of a shape followed by the last
    *  dimension.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param lastDimension the dimension(s) to append
    * @return a 1-dimensional operand containing the dimensions of a shape followed by the last
@@ -58,7 +57,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional operand containing the dimensions of a shape followed by the last
    *  dimension.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param lastDimension the dimension(s) to append
    * @return a 1-dimensional operand containing the dimensions of a shape followed by the last
@@ -73,7 +71,6 @@ public final class ShapeOps {
    *  operand representing a shape, followed by the dimensions of an operand representing a shape to
    *  append.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param shapeToAppend the other shape to append
    * @return a 1-dimensional operand that represents a new shape containing the dimensions of the
@@ -88,7 +85,6 @@ public final class ShapeOps {
    * Flatten the operand to 1 dimension.
    *
    * @param <T> the type of operand
-   * @param scope current scope
    * @param operand the operand to flatten
    * @return the reshaped operand
    */
@@ -99,7 +95,6 @@ public final class ShapeOps {
   /**
    * Flatten the shape to 1 dimension.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @return the flattened shape
    */
@@ -112,7 +107,6 @@ public final class ShapeOps {
    *
    * @param <T> the type of operand
    * @param <U> the shape datatype
-   * @param scope current scope
    * @param operand the operand to flatten
    * @param type the shape datatype
    * @return the reshaped operand
@@ -126,7 +120,6 @@ public final class ShapeOps {
    * Flatten the shape to 1 dimension.
    *
    * @param <U> the shape datatype
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param type the shape datatype
    * @return the flattened shape
@@ -138,7 +131,6 @@ public final class ShapeOps {
   /**
    * Creates a 1-dimensional Operand containing the Shape's first dimension.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @return a 1-dimensional Operand containing the Shape's first dimension
    */
@@ -149,7 +141,6 @@ public final class ShapeOps {
   /**
    * Creates a 1-dimensional Operand containing the Shape's first dimension.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param type the shape datatype.
    * @param <U> the shape datatype.
@@ -162,7 +153,6 @@ public final class ShapeOps {
   /**
    * Get the number of dimensions of the shape object.
    *
-   * @param scope current scope
    * @param shape the shape
    * @return the number of dimensions
    */
@@ -174,7 +164,6 @@ public final class ShapeOps {
    * Get the number of dimensions of the shape object.
    *
    * @param <U> the shape datatype
-   * @param scope the curren scope
    * @param shape the shape
    * @param type the shape datatype
    * @return the number of dimensions
@@ -187,7 +176,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional operand containing the first dimension followed by the dimensions of
    *  the shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param firstDimension the dimension to prepend
    * @return a 1-dimensional operand containing the first dimension followed by the dimensions of
@@ -201,7 +189,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional operand containing the first dimension followed by the dimensions of
    *  the shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param firstDimension the dimension to prepend
    * @return a 1-dimensional operand containing the first dimension followed by the dimensions of
@@ -216,7 +203,6 @@ public final class ShapeOps {
    *  operand representing the shape to prepend, followed by the dimensions of an operand
    *  representing a shape.
    *
-   * @param scope current scope
    * @param shape an operand containing the dimensions of a shape
    * @param shapeToPrepend an operand containing the dimensions of the shape to prepend
    * @return a 1-dimensional operand that represents a new shape containing the dimensions of an
@@ -231,7 +217,6 @@ public final class ShapeOps {
    * Reshapes the operand by reducing the shape to the specified axis.
    *
    * @param <T> the type of Operand
-   * @param scope current scope
    * @param operand the operand
    * @param axis the axis
    * @return the reshaped operand
@@ -243,7 +228,6 @@ public final class ShapeOps {
   /**
    * Reduces the shape to the specified axis.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param axis the axis
    * @return an operand containing the dimensions for the reduced shape
@@ -257,7 +241,6 @@ public final class ShapeOps {
    *
    * @param <T> the type of Operand
    * @param <U> the shape datatype
-   * @param scope current scope
    * @param operand the operand
    * @param axis the axis
    * @param type the shape datatype
@@ -272,7 +255,6 @@ public final class ShapeOps {
    * Reduces the shape to the specified axis.
    *
    * @param <U> the shape datatype
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param axis the axis
    * @param type the shape datatype
@@ -285,7 +267,6 @@ public final class ShapeOps {
   /**
    * Get the size represented by the TensorFlow shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @return the size
    */
@@ -296,7 +277,6 @@ public final class ShapeOps {
   /**
    * Get the size of the specified dimension for the shape of the tensor.
    *
-   * @param scope current scope
    * @param input the operand
    * @param dim the dimension
    * @return the size of the specified dimension
@@ -308,7 +288,6 @@ public final class ShapeOps {
   /**
    * Get the size of the specified dimension in the shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param dim the dimension
    * @return the size of the specified dimension
@@ -321,7 +300,6 @@ public final class ShapeOps {
    * Get the size represented by the TensorFlow shape.
    *
    * @param <U> the type of the shape
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param type the shape datatype
    * @return the size
@@ -334,7 +312,6 @@ public final class ShapeOps {
    * Get the size of the specified dimension for the shape of the tensor.
    *
    * @param <U> the shape datatype
-   * @param scope current scope
    * @param input the operand
    * @param dim the dimension
    * @param type the shape datatype
@@ -349,7 +326,6 @@ public final class ShapeOps {
    * Get the size of the specified dimension in the shape.
    *
    * @param <U> the shape datatype
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param dim the dimension
    * @param type the shape datatype
@@ -362,7 +338,6 @@ public final class ShapeOps {
   /**
    * Removes dimensions of size 1 from the shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @return the squeezed shape
    */
@@ -374,7 +349,6 @@ public final class ShapeOps {
    * Removes dimensions of size 1 from the shape.
    *
    * @param <U> the shape datatype.
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param type the shape datatype.
    * @return the squeezed shape
@@ -387,7 +361,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional Operand that contains the dimension matching the last dimension of the
    *  Shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @return a 1-dimensional Operand that contains the dimension matching the last dimension of the
    *      Shape
@@ -400,7 +373,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional Operand that contains the dimension matching the last dimension of *
    *  the Shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param type the shape datatype.
    * @param <U> the shape datatype.
@@ -415,7 +387,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional operand with the dimensions matching the first n dimensions of the
    *  shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param n the number of leading dimensions to get, must be <= than the shape's numDimensions()
    * @return a 1-dimensional operand with the dimensions matching the first n dimensions of the
@@ -429,7 +400,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional operand containin the dimensions matching the first n dimensions of the
    *  shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param n the number of leading dimensions to get, must be <= than the shape's numDimensions()
    * @param type the shape datatype.
@@ -445,7 +415,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional operand containing the dimensions matching the last n dimensions of the
    *  shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param n the number of leading dimensions to get, must be <= than the shape's numDimensions()
    * @return a 1-dimensional operand containing the dimensions matching the last n dimensions of the
@@ -459,7 +428,6 @@ public final class ShapeOps {
    * Creates a 1-dimensional operand containing the dimensions matching the last n dimensions of the
    *  shape.
    *
-   * @param scope current scope
    * @param shape the TensorFlow shape
    * @param n the number of leading dimensions to get, must be <= than the shape's numDimensions()
    * @param type the shape datatype.

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
@@ -363,18 +363,24 @@ public final class OperatorProcessor extends AbstractProcessor {
   private String buildOpMethodJavadoc(
       TypeElement opClass, ExecutableElement endpointMethod, boolean copyClassDescription) {
     Javadoc methodJavadoc = parseJavadoc(endpointMethod);
+
+    Javadoc javadoc;
+
     if (!copyClassDescription) {
-      return methodJavadoc.toText();
+      javadoc = new Javadoc(methodJavadoc.getDescription());
+    } else {
+      javadoc = parseJavadoc(opClass);
     }
-    Javadoc classJavadoc = parseJavadoc(opClass);
+
     // Copy all endpoint method tags to the description, except for the `scope` parameter which
     // will be inferred by the Ops class
     methodJavadoc.getBlockTags().forEach(t -> {
-      if (!t.getTagName().equals("param") || t.getName().map(s -> !s.equals("scope")).orElse(true)) {
-        classJavadoc.addBlockTag(t);
+      if (!(t.getTagName().equals("param") && t.getName().map(s -> s.equals("scope")).orElse(false))) {
+        javadoc.addBlockTag(t);
       }
     });
-    return classJavadoc.toText();
+
+    return javadoc.toText();
   }
 
   private static Collection<OpsSpec> collectGroupOps(OpsSpec ops, Multimap<String, MethodSpec> groupedMethods) {


### PR DESCRIPTION
For non `describeByClass` endpoints, the `scope` parameter javadoc would be erroneously copied into Ops.  This fixes that.