### PR TITLE
Disable windows op export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
           )          
           df -h
           wmic pagefile list /format:list
+          set "SKIP_EXPORT=true"
           echo Executing Maven %MAVEN_PHASE%
           call mvn clean %MAVEN_PHASE% -B -U -e -Djavacpp.platform=windows-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }} -pl %NATIVE_BUILD_PROJECTS% -am -DstagingRepositoryId=${{ needs.prepare.outputs.stagingRepositoryId }} "-Dnative.build.flags=%BAZEL_CACHE%"
           if ERRORLEVEL 1 exit /b

--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -82,7 +82,7 @@ mkdir -p $GEN_SRCS_DIR
 GEN_RESOURCE_DIR=src/gen/resources/org/tensorflow/op
 mkdir -p $GEN_RESOURCE_DIR
 
-if [[ -z "$SKIP_EXPORT" ]]; then
+if [[ -z ${SKIP_EXPORT} ]]; then
   # Export op defs
   echo "Exporting Ops"
   $BAZEL_BIN/java_op_exporter \

--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -89,7 +89,7 @@ if [[ -z "$SKIP_EXPORT" ]]; then
       --api_dirs=$BAZEL_SRCS/external/org_tensorflow/tensorflow/core/api_def/base_api,src/bazel/api_def \
       $TENSORFLOW_LIB > $GEN_RESOURCE_DIR/ops.pb
 else
-  echo "Skiping Op export"
+  echo "Skipping Op export"
 fi
 
 

--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -82,7 +82,7 @@ mkdir -p $GEN_SRCS_DIR
 GEN_RESOURCE_DIR=src/gen/resources/org/tensorflow/op
 mkdir -p $GEN_RESOURCE_DIR
 
-if [[ -z ${SKIP_EXPORT} ]]; then
+if [[ -z "${SKIP_EXPORT:-}" ]]; then
   # Export op defs
   echo "Exporting Ops"
   $BAZEL_BIN/java_op_exporter \

--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -82,10 +82,15 @@ mkdir -p $GEN_SRCS_DIR
 GEN_RESOURCE_DIR=src/gen/resources/org/tensorflow/op
 mkdir -p $GEN_RESOURCE_DIR
 
-# Export op defs
-$BAZEL_BIN/java_op_exporter \
-    --api_dirs=$BAZEL_SRCS/external/org_tensorflow/tensorflow/core/api_def/base_api,src/bazel/api_def \
-    $TENSORFLOW_LIB > $GEN_RESOURCE_DIR/ops.pb
+if [[ -z "$SKIP_EXPORT" ]]; then
+  # Export op defs
+  echo "Exporting Ops"
+  $BAZEL_BIN/java_op_exporter \
+      --api_dirs=$BAZEL_SRCS/external/org_tensorflow/tensorflow/core/api_def/base_api,src/bazel/api_def \
+      $TENSORFLOW_LIB > $GEN_RESOURCE_DIR/ops.pb
+else
+  echo "Skiping Op export"
+fi
 
 
 # Copy generated Java protos from source jars


### PR DESCRIPTION
Temporary fix, disables op exports on windows and just uses the ops.pb file in git (which was generated on Linux).

cc @karllessard 