### PR TITLE
Use spotless plugin for formating

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,5 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/license-header
+++ b/license-header
@@ -1,0 +1,14 @@
+/*
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ =======================================================================
+ */

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -45,6 +45,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.source.skip>true</maven.source.skip>
     <gpg.skip>true</gpg.skip>
+    <spotless.version>2.10.3</spotless.version>
   </properties>
 
   <repositories>
@@ -103,19 +104,19 @@
         <artifactId>junit-jupiter-engine</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
-    </dependency>
-	  <dependency>
-	    <groupId>org.openjdk.jmh</groupId>
-	    <artifactId>jmh-core</artifactId>
-	    <version>${jmh.version}</version>
-  	    <scope>test</scope>
-	  </dependency>
-	  <dependency>
-	    <groupId>org.openjdk.jmh</groupId>
-	    <artifactId>jmh-generator-annprocess</artifactId>
-	    <version>${jmh.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${jmh.version}</version>
         <scope>test</scope>
-	  </dependency>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>${jmh.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -298,6 +299,25 @@
           <generateBackupPoms>false</generateBackupPoms>
           <processAllModules>true</processAllModules>
           <updateMatchingVersions>true</updateMatchingVersions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <ratchetFrom>origin/master</ratchetFrom>
+
+          <lineEndings/>
+          <java>
+            <googleJavaFormat/>
+
+            <removeUnusedImports/>
+
+            <licenseHeader>
+              <file>./license-header</file>
+            </licenseHeader>
+          </java>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,17 @@
             </licenseHeader>
           </java>
         </configuration>
+
+        <executions>
+          <execution>
+            <!-- Runs in initialize phase to fail fast in case of formatting issues (should be before codegen).-->
+            <id>spotless-check</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
     <pluginManagement>

--- a/tensorflow-core/tensorflow-core-generator/pom.xml
+++ b/tensorflow-core/tensorflow-core-generator/pom.xml
@@ -59,6 +59,18 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <java>
+            <excludes>
+              <exclude>src/main/java/org/tensorflow/proto/framework/**</exclude>
+            </excludes>
+          </java>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Uses the [spotless plugin](https://github.com/diffplug/spotless/tree/master/plugin-maven) for formatting.  Will check formatting in the `initialize` phase (so its before codegen & native builds), and auto-format can be ran with `mvn spotless:apply`.  We can use it for the Kotlin API as well once diffplug/spotless#142 is fixed.

I have it set to ratchet from `master` (i.e. only check changed files), do we want to do a big "apply formatting everywhere" PR (it's ~500 files)?