### PR TITLE
Load TF library before computing TString size

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
@@ -404,6 +404,11 @@ public final class EagerSession implements ExecutionEnvironment, AutoCloseable {
   }
 
   static {
-    TensorFlow.init();
+    try {
+      // Ensure that TensorFlow native library and classes are ready to be used
+      Class.forName("org.tensorflow.TensorFlow");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
@@ -1070,6 +1070,11 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
   }
 
   static {
-    TensorFlow.init();
+    try {
+      // Ensure that TensorFlow native library and classes are ready to be used
+      Class.forName("org.tensorflow.TensorFlow");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/RawTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/RawTensor.java
@@ -228,6 +228,11 @@ public final class RawTensor implements Tensor {
   private ByteDataBuffer buffer = null;
 
   static {
-    TensorFlow.init();
+    try {
+      // Ensure that TensorFlow native library and classes are ready to be used
+      Class.forName("org.tensorflow.TensorFlow");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -435,6 +435,11 @@ public class SavedModelBundle implements AutoCloseable {
   }
 
   static {
-    TensorFlow.init();
+    try {
+      // Ensure that TensorFlow native library and classes are ready to be used
+      Class.forName("org.tensorflow.TensorFlow");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Server.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Server.java
@@ -178,6 +178,11 @@ public final class Server implements AutoCloseable {
   private int numJoining;
 
   static {
-    TensorFlow.init();
+    try {
+      // Ensure that TensorFlow native library and classes are ready to be used
+      Class.forName("org.tensorflow.TensorFlow");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
@@ -32,6 +32,12 @@ import org.tensorflow.proto.framework.OpList;
 
 /** Static utility methods describing the TensorFlow runtime. */
 public final class TensorFlow {
+
+  /** Make sure all TensorFlow native libraries have been loaded properly */
+  public static void init() {
+    // Do nothing, we'll let the class static initializer load the native library if needed
+  }
+
   /** Returns the version of the underlying TensorFlow runtime. */
   public static String version() {
     return TF_Version().getString();
@@ -106,7 +112,7 @@ public final class TensorFlow {
   private TensorFlow() {}
 
   /** Load the TensorFlow runtime C library. */
-  static void init() {
+  private static void initTensorFlow() {
     try {
       NativeLibrary.load();
     } catch (Exception e) {
@@ -123,6 +129,6 @@ public final class TensorFlow {
   }
 
   static {
-    init();
+    initTensorFlow();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
@@ -33,11 +33,6 @@ import org.tensorflow.proto.framework.OpList;
 /** Static utility methods describing the TensorFlow runtime. */
 public final class TensorFlow {
 
-  /** Make sure all TensorFlow native libraries have been loaded properly */
-  public static void init() {
-    // Do nothing, we'll let the class static initializer load the native library if needed
-  }
-
   /** Returns the version of the underlying TensorFlow runtime. */
   public static String version() {
     return TF_Version().getString();
@@ -112,7 +107,7 @@ public final class TensorFlow {
   private TensorFlow() {}
 
   /** Load the TensorFlow runtime C library. */
-  private static void initTensorFlow() {
+  static {
     try {
       NativeLibrary.load();
     } catch (Exception e) {
@@ -126,9 +121,5 @@ public final class TensorFlow {
       e.printStackTrace();
       throw e;
     }
-  }
-
-  static {
-    initTensorFlow();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/ByteSequenceTensorBuffer.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/ByteSequenceTensorBuffer.java
@@ -135,6 +135,11 @@ public class ByteSequenceTensorBuffer extends AbstractDataBuffer<byte[]> {
   private final TF_TString data;
 
   static {
-    TensorFlow.init(); // make sure TF library is loaded before working with `TF_TString` native objects
+    try {
+      // Ensure that TensorFlow native library and classes are ready to be used
+      Class.forName("org.tensorflow.TensorFlow");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/ByteSequenceTensorBuffer.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/buffer/ByteSequenceTensorBuffer.java
@@ -28,6 +28,7 @@ import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.Loader;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerScope;
+import org.tensorflow.TensorFlow;
 import org.tensorflow.ndarray.buffer.DataBuffer;
 import org.tensorflow.internal.c_api.TF_TString;
 import org.tensorflow.ndarray.impl.buffer.AbstractDataBuffer;
@@ -132,4 +133,8 @@ public class ByteSequenceTensorBuffer extends AbstractDataBuffer<byte[]> {
   }
 
   private final TF_TString data;
+
+  static {
+    TensorFlow.init(); // make sure TF library is loaded before working with `TF_TString` native objects
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/WrongEnvTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/WrongEnvTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.tensorflow.op.Ops;
 import org.tensorflow.types.TInt32;
 

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskTest.java
@@ -18,7 +18,7 @@ package org.tensorflow.op.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.tensorflow.Graph;
 import org.tensorflow.Operand;
 import org.tensorflow.Session;
@@ -29,6 +29,7 @@ import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt32;
 
 public class BooleanMaskTest {
+
   @Test
   public void testBooleanMask(){
     try (Graph g = new Graph();
@@ -43,24 +44,24 @@ public class BooleanMaskTest {
       Operand<TInt32> output1 = BooleanMask.create(scope, input, mask);
       Operand<TInt32> output2 = BooleanMask.create(scope, input2, mask, BooleanMask.axis(1));
 
-      try (TFloat32 result = (TFloat32) sess.runner().fetch(output1).run().get(0)) {
+      try (TInt32 result = (TInt32) sess.runner().fetch(output1).run().get(0)) {
         // expected shape from Python tensorflow
         assertEquals(Shape.of(5), result.shape());
-        assertEquals(0, result.getFloat(0));
-        assertEquals(1, result.getFloat(1));
-        assertEquals(4, result.getFloat(2));
-        assertEquals(5, result.getFloat(3));
-        assertEquals(6, result.getFloat(4));
+        assertEquals(0, result.getInt(0));
+        assertEquals(1, result.getInt(1));
+        assertEquals(4, result.getInt(2));
+        assertEquals(5, result.getInt(3));
+        assertEquals(6, result.getInt(4));
       }
 
-      try (TFloat32 result = (TFloat32) sess.runner().fetch(output2).run().get(0)) {
+      try (TInt32 result = (TInt32) sess.runner().fetch(output2).run().get(0)) {
         // expected shape from Python tensorflow
-        assertEquals(Shape.of(5), result.shape());
-        assertEquals(0, result.getFloat(0));
-        assertEquals(1, result.getFloat(1));
-        assertEquals(4, result.getFloat(2));
-        assertEquals(5, result.getFloat(3));
-        assertEquals(6, result.getFloat(4));
+        assertEquals(Shape.of(1, 5), result.shape());
+        assertEquals(0, result.getInt(0, 0));
+        assertEquals(1, result.getInt(0, 1));
+        assertEquals(4, result.getInt(0, 2));
+        assertEquals(5, result.getInt(0, 3));
+        assertEquals(6, result.getInt(0, 4));
       }
     }
   }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskUpdateTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/BooleanMaskUpdateTest.java
@@ -19,7 +19,8 @@ package org.tensorflow.op.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.tensorflow.Graph;
 import org.tensorflow.Operand;
 import org.tensorflow.Session;

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/IndexingTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/IndexingTest.java
@@ -17,7 +17,7 @@ package org.tensorflow.op.core;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.tensorflow.Graph;
 import org.tensorflow.Session;
 import org.tensorflow.ndarray.Shape;

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TStringTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TStringTest.java
@@ -23,7 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+
 import org.bytedeco.javacpp.Pointer;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.tensorflow.ndarray.NdArray;
 import org.tensorflow.ndarray.NdArrays;
@@ -39,16 +41,15 @@ public class TStringTest {
     assertEquals("Pretty vacant", tensor.getObject());
   }
 
-    @Test
-    public void createrScalarLongerThan127() {
-        TString tensor = TString.scalarOf("Long String 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 !");
-        assertNotNull(tensor);
-        assertEquals(Shape.scalar(), tensor.shape());
-        assertEquals("Long String 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 !", tensor.getObject());
-    }
+  @Test
+  public void createrScalarLongerThan127() {
+    TString tensor = TString.scalarOf("Long String 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 !");
+    assertNotNull(tensor);
+    assertEquals(Shape.scalar(), tensor.shape());
+    assertEquals("Long String 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 !", tensor.getObject());
+  }
 
-
-    @Test
+  @Test
   public void createVector() {
     TString tensor = TString.vectorOf("Pretty", "vacant");
     assertNotNull(tensor);
@@ -106,6 +107,7 @@ public class TStringTest {
   }
 
   @Test
+  @Disabled // FIXME This test does not deterministically succeed, so skip it by default
   public void testNoLeaks() throws Exception {
     // warm up and try to get all JIT compilation done to stabilize memory usage...
     for (int i = 0; i < 1000; i++) {


### PR DESCRIPTION
Fixes #320 

Make sure the TF native libraries have been loaded properly before instantiating a String tensor, since we need to know in advance the size of the `TF_TString` native class to compute the required size of the whole buffer.

Also cleaned up a few unrelated unit tests... (@rnett if you want to take a look, especially at `BooleanMaskTest`)