### PR TITLE
Spotless updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,32 @@ jobs:
       - name: Run lint checks
         run: |
           mvn compiler:compile -Pdev,jdk11 -B -U -e
+  check-format:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    container: centos:7
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Install environment
+        run: |
+          yum -y update
+          yum -y install centos-release-scl-rh epel-release
+          yum -y install java-11-openjdk-devel devtoolset-7
+          echo Downloading Maven
+          curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -o $HOME/apache-maven-3.6.3-bin.tar.gz
+          tar xzf $HOME/apache-maven-3.6.3-bin.tar.gz -C /opt/
+          ln -sf /opt/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
+      - name: Build project
+        run: |
+          source scl_source enable devtoolset-7 || true
+          export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
+          echo $JAVA_HOME
+          mvn -version
+          mvn clean install -Pdev,jdk11 -B -U -e -Dlint.skip=true
+      - name: Run format checks
+        run: |
+          mvn spotless:check -Pdev,jdk11 -B -U -e
   prepare:
     runs-on: ubuntu-latest
     outputs:

--- a/pom.xml
+++ b/pom.xml
@@ -230,11 +230,12 @@
       </build>
     </profile>
 
+    <!--
+      Profile that enables format checks on compilation
+      Can auto-format using spotless:apply.
+    -->
     <profile>
-      <id>format</id>
-      <activation>
-        <jdk>(,16)</jdk>
-      </activation>
+      <id>check-format</id>
       <build>
         <plugins>
           <plugin>
@@ -340,26 +341,6 @@
             <googleJavaFormat/>
 
             <removeUnusedImports/>
-
-            <licenseHeader>
-              <content>
-/* Copyright $YEAR The TensorFlow Authors. All Rights Reserved.
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- =======================================================================
- */
-              </content>
-            </licenseHeader>
           </java>
         </configuration>
       </plugin>


### PR DESCRIPTION
As per recent discussions, makes format checks off by default (and changes the name), removes the license header check, and adds a separate CI task to check format on PRs.  We should probably note somewhere that formatting should be fixed after approval (in the PR template?).

cc @Craigacp @karllessard 