### PR TITLE
Updating issue templates with Java specific information

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-performance-issue.md
+++ b/.github/ISSUE_TEMPLATE/00-bug-performance-issue.md
@@ -11,7 +11,7 @@ about: Use this template for reporting a bug or a performance issue.
 - OS Platform and Distribution (e.g., Linux Ubuntu 16.04 x86\_64):
 - TensorFlow installed from (source or binary):
 - TensorFlow version (use command below):
-- Java version:
+- Java version (i.e., the output of `java -version`):
 - Java command line flags (e.g., GC parameters):
 - Python version (if transferring a model trained in Python):
 - Bazel version (if compiling from source):

--- a/.github/ISSUE_TEMPLATE/00-bug-performance-issue.md
+++ b/.github/ISSUE_TEMPLATE/00-bug-performance-issue.md
@@ -8,20 +8,16 @@ about: Use this template for reporting a bug or a performance issue.
 
 **System information**
 - Have I written custom code (as opposed to using a stock example script provided in TensorFlow):
-- OS Platform and Distribution (e.g., Linux Ubuntu 16.04):
-- Mobile device (e.g. iPhone 8, Pixel 2, Samsung Galaxy) if the issue happens on mobile device:
+- OS Platform and Distribution (e.g., Linux Ubuntu 16.04 x86\_64):
 - TensorFlow installed from (source or binary):
 - TensorFlow version (use command below):
-- Python version:
+- Java version:
+- Java command line flags (e.g., GC parameters):
+- Python version (if transferring a model trained in Python):
 - Bazel version (if compiling from source):
 - GCC/Compiler version (if compiling from source):
 - CUDA/cuDNN version:
 - GPU model and memory:
-
-
-You can collect some of this information using our environment capture [script](https://github.com/tensorflow/tensorflow/tree/master/tools/tf_env_collect.sh)
-You can also obtain the TensorFlow version with
-python -c "import tensorflow as tf; print(tf.GIT_VERSION, tf.VERSION)"
 
 **Describe the current behavior**
 

--- a/.github/ISSUE_TEMPLATE/10-build-installation-issue.md
+++ b/.github/ISSUE_TEMPLATE/10-build-installation-issue.md
@@ -7,23 +7,21 @@ about: Use this template for build/installation issues
 <em>Please make sure that this is a build/installation issue. As per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:build_template</em>
 
 **System information**
-- OS Platform and Distribution (e.g., Linux Ubuntu 16.04):
-- Mobile device (e.g. iPhone 8, Pixel 2, Samsung Galaxy) if the issue happens on mobile device:
+- OS Platform and Distribution (e.g., Linux Ubuntu 16.04 x86\_64):
 - TensorFlow installed from (source or binary):
 - TensorFlow version:
-- Python version:
-- Installed using virtualenv? pip? conda?:
+- Java version:
+- Java command line flags (e.g., GC parameters):
+- Installed from Maven Central?:
 - Bazel version (if compiling from source):
 - GCC/Compiler version (if compiling from source):
 - CUDA/cuDNN version:
 - GPU model and memory:
 
 
-
 **Describe the problem**
 
 **Provide the exact sequence of commands / steps that you executed before running into the problem**
-
 
 **Any other info / logs**
 Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks, please include the full traceback. Large logs and files should be attached.

--- a/.github/ISSUE_TEMPLATE/10-build-installation-issue.md
+++ b/.github/ISSUE_TEMPLATE/10-build-installation-issue.md
@@ -10,7 +10,7 @@ about: Use this template for build/installation issues
 - OS Platform and Distribution (e.g., Linux Ubuntu 16.04 x86\_64):
 - TensorFlow installed from (source or binary):
 - TensorFlow version:
-- Java version:
+- Java version (i.e., the output of `java -version`):
 - Java command line flags (e.g., GC parameters):
 - Installed from Maven Central?:
 - Bazel version (if compiling from source):


### PR DESCRIPTION
The templates we copied over from tensorflow/tensorflow don't cover all the things we need for Java issues.