### PR TITLE
Multi-release jar support (Java 9 to start)

### DIFF
--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -31,6 +31,7 @@
   <description>Parent POM of TensorFlow core artifacts</description>
 
   <modules>
+    <module>tensorflow-core-api-java9</module>
     <module>tensorflow-core-generator</module>
     <module>tensorflow-core-api</module>
   </modules>

--- a/tensorflow-core/tensorflow-core-api-java9/pom.xml
+++ b/tensorflow-core/tensorflow-core-api-java9/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>tensorflow-core</artifactId>
     <version>0.4.0-SNAPSHOT</version>
   </parent>
-  <artifactId>tensorflow-core-java9</artifactId>
+  <artifactId>tensorflow-core-api-java9</artifactId>
   <packaging>jar</packaging>
 
   <name>TensorFlow Core Java 9 API Classes</name>

--- a/tensorflow-core/tensorflow-core-api-java9/pom.xml
+++ b/tensorflow-core/tensorflow-core-api-java9/pom.xml
@@ -1,0 +1,31 @@
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.tensorflow</groupId>
+    <artifactId>tensorflow-core</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>tensorflow-core-java9</artifactId>
+  <packaging>jar</packaging>
+
+  <name>TensorFlow Core Java 9 API Classes</name>
+  <description>Java 9 classes for the Tensorflow Core API</description>
+
+  <properties>
+    <java.module.name>org.tensorflow.core.api.java9</java.module.name>
+    <maven.compiler.source>9</maven.compiler.source>
+    <maven.compiler.target>9</maven.compiler.target>
+    <maven.compiler.release>9</maven.compiler.release>
+    <maven.install.skip>true</maven.install.skip>
+  </properties>
+
+  <dependencies>
+  </dependencies>
+
+  <build>
+    <plugins>
+    </plugins>
+  </build>
+</project>

--- a/tensorflow-core/tensorflow-core-api-java9/src/main/java/org/tensorflow/MRTest.java
+++ b/tensorflow-core/tensorflow-core-api-java9/src/main/java/org/tensorflow/MRTest.java
@@ -1,0 +1,24 @@
+/*
+ Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================
+
+*/
+package org.tensorflow;
+
+public class MRTest {
+  public static int version() {
+    return 9;
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -15,6 +15,7 @@
   <description>Platform-dependent native code and pure-Java code for the TensorFlow machine intelligence library.</description>
 
   <properties>
+    <maven.install.skip>false</maven.install.skip>
     <native.build.skip>false</native.build.skip>
     <javacpp.build.skip>${native.build.skip}</javacpp.build.skip>
     <javacpp.parser.skip>${native.build.skip}</javacpp.parser.skip>
@@ -475,12 +476,35 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
+          <appendAssemblyId>false</appendAssemblyId>
+          <descriptors>
+            <descriptor>src/assembly/mrjar.xml</descriptor>
+          </descriptors>
+          <archive>
+            <manifestEntries>
+              <Multi-Release>true</Multi-Release>
+            </manifestEntries>
+          </archive>
+          <mergeManifestMode>merge</mergeManifestMode>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>3.0.3</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/tensorflow-core/tensorflow-core-api/src/assembly/mrjar.xml
+++ b/tensorflow-core/tensorflow-core-api/src/assembly/mrjar.xml
@@ -1,0 +1,54 @@
+
+<!--
+  /* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  =======================================================================
+  */
+  -->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>mvjar</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>org.tensorflow:tensorflow-core-api</include>
+      </includes>
+      <binaries>
+        <unpack>true</unpack>
+        <includeDependencies>false</includeDependencies>
+      </binaries>
+    </moduleSet>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>org.tensorflow:tensorflow-core-api-java9</include>
+      </includes>
+      <binaries>
+        <outputDirectory>META-INF/versions/9</outputDirectory>
+        <unpack>true</unpack>
+        <includeDependencies>false</includeDependencies>
+        <unpackOptions>
+          <excludes>
+            <exclude>/META-INF/**</exclude>
+          </excludes>
+        </unpackOptions>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+</assembly>

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/MRTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/MRTest.java
@@ -1,0 +1,24 @@
+/*
+ Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================
+
+*/
+package org.tensorflow;
+
+public class MRTest {
+  public static int version() {
+    return 8;
+  }
+}


### PR DESCRIPTION
Adds support for multi-release jars.  Only Java 9 to start with, but it's easy to extend.

Adam or Karl, can you add the CI build tag?  I need to check that native artifacts are still built correctly.

TODO:
- [ ] Add tests (will need a CI task to test w/ Java 9+).
- [ ] Add binary compat tests?  See https://github.com/hboutemy/maven-jep238/blob/master/multirelease-base/pom.xml#L22