### PR TITLE
Multi-release jar v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,32 @@ jobs:
       - name: Run lint checks
         run: |
           mvn compiler:compile -Pdev,jdk11 -B -U -e
+  quick-build-jdk8:
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI build')
+    runs-on: ubuntu-latest
+    container: centos:7
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Install environment
+        run: |
+          yum -y update
+          yum -y install centos-release-scl-rh epel-release
+          yum -y install java-1.8.0-openjdk-devel devtoolset-7
+          echo Downloading Maven
+          curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -o $HOME/apache-maven-3.6.3-bin.tar.gz
+          tar xzf $HOME/apache-maven-3.6.3-bin.tar.gz -C /opt/
+          ln -sf /opt/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
+      - name: Build project
+        run: |
+          source scl_source enable devtoolset-7 || true
+          export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
+          echo $JAVA_HOME
+          mvn -version
+          mvn clean install -Pdev -B -U -e -Dlint.skip=true
+      - name: Run lint checks
+        run: |
+          mvn compiler:compile -Pdev -B -U -e
   check-format:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -22,6 +22,9 @@
     <java.module.name>org.tensorflow.core.api</java.module.name>
     <ndarray.version>0.3.1</ndarray.version>
     <truth.version>1.0.1</truth.version>
+
+    <java9.sourceDirectory>${project.basedir}/src/main/java9</java9.sourceDirectory>
+    <java9.build.outputDirectory>${project.build.directory}/classes-java9</java9.build.outputDirectory>
   </properties>
 
   <dependencies>
@@ -139,6 +142,50 @@
               <sources>
                 <source>${project.basedir}/src/gen/java</source>
               </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>compile-java9</id>
+            <phase>compile</phase>
+            <configuration>
+              <target>
+                <mkdir dir="${java9.build.outputDirectory}" />
+                <javac srcdir="${java9.sourceDirectory}" destdir="${java9.build.outputDirectory}"
+                  classpath="${project.build.outputDirectory}" includeantruntime="false"
+                  target="9" source="9" release="9"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/META-INF/versions/9</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${java9.build.outputDirectory}</directory>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>
@@ -372,6 +419,7 @@
           <archive>
             <manifestEntries>
               <Automatic-Module-Name>${java.module.name}</Automatic-Module-Name>
+              <Multi-Release>true</Multi-Release>
             </manifestEntries>
           </archive>
         </configuration>

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/MRTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/MRTest.java
@@ -17,8 +17,8 @@ limitations under the License.
 */
 package org.tensorflow;
 
-public class MRTest {
-  public static int version() {
+class MRTest {
+  static int version() {
     return 8;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/MRTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/MRTest.java
@@ -1,0 +1,24 @@
+/*
+ Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================
+
+*/
+package org.tensorflow;
+
+public class MRTest {
+  public static int version() {
+    return 8;
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/main/java9/org/tensorflow/MRTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java9/org/tensorflow/MRTest.java
@@ -1,0 +1,27 @@
+/*
+  Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ =======================================================================
+
+ */
+package org.tensorflow;
+
+import java.lang.ref.Cleaner;
+
+public class MRTest {
+  public static int version(){
+    Cleaner.create();
+    return 9;
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/MultiReleaseTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/MultiReleaseTest.java
@@ -17,8 +17,22 @@
  */
 package org.tensorflow;
 
-class MRTest {
-  static int version(){
-    return 9;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class MultiReleaseTest {
+
+  @Test
+  public void testMultirelease(){
+    String javaVersion = System.getProperty("java.version");
+    System.out.println("Testing on Java version " + javaVersion);
+    int value = MRTest.version();
+    if(javaVersion.compareTo("9") >= 0){
+      assertEquals(9, value);
+    } else {
+      assertEquals(8, value);
+    }
   }
+
 }


### PR DESCRIPTION
Does multi-release jars in-module using an ant task.  Includes a test and a CI task to run tests on JDK 8.

Currently the added release is 9, since the only thing I plan on using is Cleaner.  We could bump it to 11, but since we only need APIs from 9 (so far) I don't see a reason to, if someone is using it on 9 then they should get the Java 9 version.

Not sure if we should merge this now, or wait until it's used somewhere.