### PR TITLE
Fix filename tensor name in SaverDef

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
@@ -38,6 +38,11 @@ public final class Output<T extends TType> implements Operand<T> {
     return index;
   }
 
+  /** Returns the full name of this Output (a.k.a. tensor name) */
+  public String name() {
+    return op().name() + ":" + index;
+  }
+
   /** Returns the DataType of the tensor referred to by this Output. */
   @SuppressWarnings("unchecked")
   public DataType dataType() {
@@ -48,7 +53,7 @@ public final class Output<T extends TType> implements Operand<T> {
   @SuppressWarnings("unchecked")
   @Override
   public Class<T> type() {
-    return (Class<T>)TensorTypeRegistry.find(dataType()).type();
+    return (Class<T>) TensorTypeRegistry.find(dataType()).type();
   }
 
   /**
@@ -63,7 +68,10 @@ public final class Output<T extends TType> implements Operand<T> {
   public <U extends TType> Output<U> expect(Class<U> type) {
     if (type != type()) {
       throw new IllegalArgumentException(
-          "Cannot cast from output of " + this.type().getSimpleName() + " to output of " + type.getSimpleName());
+          "Cannot cast from output of "
+              + this.type().getSimpleName()
+              + " to output of "
+              + type.getSimpleName());
     }
     return ((Output<U>) this);
   }
@@ -80,17 +88,16 @@ public final class Output<T extends TType> implements Operand<T> {
    *
    * @return tensor
    * @throws IllegalStateException if this output results from a graph
-   * @throws ClassCastException if the type of the tensor and this output are unexpectedly incompatible
+   * @throws ClassCastException if the type of the tensor and this output are unexpectedly
+   *     incompatible
    * @see EagerSession
    */
   @SuppressWarnings("unchecked")
   public T asTensor() {
-    return (T)operation.tensor(index);
+    return (T) operation.tensor(index);
   }
 
-  /**
-   * Returns the (possibly partially known) shape of the tensor referred to by this output.
-   */
+  /** Returns the (possibly partially known) shape of the tensor referred to by this output. */
   @Override
   public Shape shape() {
     return operation.shape(index);

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
@@ -1,18 +1,18 @@
 /* Copyright 2020-2021 The TensorFlow Authors. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- =======================================================================
- */
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================
+*/
 package org.tensorflow;
 
 import java.util.Collections;
@@ -208,7 +208,7 @@ public class Signature {
 
   @Override
   public String toString() {
-    StringBuilder strBuilder = new StringBuilder("Signature for \"" + key +"\":\n");
+    StringBuilder strBuilder = new StringBuilder("Signature for \"" + key + "\":\n");
     String methodName = methodName();
     if (methodName != null && !methodName.isEmpty()) {
       strBuilder.append("\tMethod: \"").append(methodName).append("\"\n");

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SavedModelBundleTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SavedModelBundleTest.java
@@ -43,6 +43,7 @@ import org.tensorflow.proto.framework.ConfigProto;
 import org.tensorflow.proto.framework.RunOptions;
 import org.tensorflow.proto.framework.SignatureDef;
 import org.tensorflow.proto.framework.TensorInfo;
+import org.tensorflow.proto.util.SaverDef;
 import org.tensorflow.types.TFloat32;
 
 /** Unit tests for {@link org.tensorflow.SavedModelBundle}. */
@@ -171,7 +172,13 @@ public class SavedModelBundleTest {
     try (SavedModelBundle savedModel =
         SavedModelBundle.load(testFolder.toString(), SavedModelBundle.DEFAULT_TAG)) {
       assertNotNull(savedModel.metaGraphDef());
-      assertNotNull(savedModel.metaGraphDef().getSaverDef());
+
+      SaverDef saverDef = savedModel.metaGraphDef().getSaverDef();
+      assertNotNull(saverDef);
+      assertEquals("save/filename:0", saverDef.getFilenameTensorName());
+      assertEquals("save/control_dependency", saverDef.getSaveTensorName());
+      assertEquals("save/restore_all", saverDef.getRestoreOpName());
+
       assertEquals(1, savedModel.metaGraphDef().getSignatureDefCount());
       assertEquals(
           Signature.DEFAULT_KEY,


### PR DESCRIPTION
This allows Python to load a model saved from Java, see #372  for more details.