### PR TITLE
Fix for SavedModelBundle with an empty tag set

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.PointerScope;
@@ -529,7 +530,7 @@ public class SavedModelBundle implements AutoCloseable {
   }
 
   private static void validateTags(String[] tags) {
-    if (tags == null || Arrays.stream(tags).anyMatch(t -> t == null || t.isEmpty())) {
+    if (tags == null || Arrays.stream(tags).anyMatch(Objects::isNull)) {
       throw new IllegalArgumentException("Invalid tags: " + Arrays.toString(tags));
     }
   }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SavedModelBundleTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SavedModelBundleTest.java
@@ -1,18 +1,18 @@
 /* Copyright 2019-2021 The TensorFlow Authors. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- =======================================================================
- */
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================
+*/
 package org.tensorflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -269,16 +269,10 @@ public class SavedModelBundleTest {
         IllegalArgumentException.class,
         () -> SavedModelBundle.loader("/").withTags(new String[] {"tag", null}));
     assertThrows(
-        IllegalArgumentException.class,
-        () -> SavedModelBundle.loader("/").withTags(new String[] {"tag", ""}));
-    assertThrows(
         IllegalArgumentException.class, () -> SavedModelBundle.exporter("/").withTags(null));
     assertThrows(
         IllegalArgumentException.class,
         () -> SavedModelBundle.exporter("/").withTags(new String[] {"tag", null}));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> SavedModelBundle.exporter("/").withTags(new String[] {"tag", ""}));
   }
 
   @Test


### PR DESCRIPTION
Saved models can use the empty string as a tag set (e.g. https://tfhub.dev/google/elmo/3) which we had previously treated as invalid.