### PR TITLE
Allow output targets in Session runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ gradleBuild
 **/target
 .tf_configure.bazelrc
 .clwb/
+
+# Deployment Files
+settings.xml
+pom.xml.asc

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -430,7 +430,7 @@ public class SavedModelBundle implements AutoCloseable {
    * @return object that can be used to make calls to a function
    * @throws IllegalArgumentException if {@code signatureKey} is not found in this saved model.
    */
-  public TensorFunction function(String signatureKey) {
+  public SessionFunction function(String signatureKey) {
     SessionFunction function = functions.get(signatureKey);
     if (function == null) {
       throw new IllegalArgumentException(
@@ -444,7 +444,7 @@ public class SavedModelBundle implements AutoCloseable {
    *
    * <p><b>All functions use the bundle's underlying session.</b>
    */
-  public List<TensorFunction> functions() {
+  public List<SessionFunction> functions() {
     return new ArrayList<>(functions.values());
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -397,12 +397,13 @@ public final class Session implements AutoCloseable {
      * Make {@link #run()} execute {@code operation}, but not return any evaluated {@link Tensor
      * Tensors}.
      *
-     * @param operation the string name of the operation to execute
+     * @param operation Is either the string name of the operation or it is a string of the form
+     *     <tt>operation_name:output_index</tt>, where <tt>output_index</tt> will simply be ignored.
      * @return this session runner
      * @throws IllegalArgumentException if no operation exists with the provided name
      */
     public Runner addTarget(String operation) {
-      return addTarget(graph.operationOrThrow(operation));
+      return addTarget(graph.outputOrThrow(operation));
     }
 
     /**


### PR DESCRIPTION
This solves issue #387 , allowing operation and output names to be passed as session targets.