### PR TITLE
Add CI checks for un-committed code generation

### DIFF
--- a/.github/actions/check-generation/action.yml
+++ b/.github/actions/check-generation/action.yml
@@ -1,0 +1,10 @@
+name: "Check generation is committed"
+description: "Ensure that all code generation is present in the commits"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+      git add .
+      git update-index --refresh
+      git diff-index --name-status --exit-code HEAD tensorflow-core/tensorflow-core-api/src/gen/** > changes.txt || echo "::error file=changes.txt,line=0,title=\"Un-commited generation\"::Generated classes after build do not match what was committed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Run lint checks
         run: |
           mvn compiler:compile -Pdev,jdk11 -B -U -e
+      - name: Check for un-committed generation
+        uses: ./.github/actions/check-generation
   check-format:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -148,6 +150,8 @@ jobs:
           echo Executing Maven $MAVEN_PHASE
           mvn clean $MAVEN_PHASE -B -U -e -Djavacpp.platform=linux-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }} -pl $NATIVE_BUILD_PROJECTS -am -DstagingRepositoryId=${{ needs.prepare.outputs.stagingRepositoryId }} "-Dnative.build.flags=$BAZEL_CACHE"
           df -h
+      - name: Check for un-committed generation
+        uses: ./.github/actions/check-generation
   macosx-x86_64:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: macos-latest
@@ -184,6 +188,8 @@ jobs:
           echo Executing Maven $MAVEN_PHASE
           mvn clean $MAVEN_PHASE -B -U -e -Djavacpp.platform=macosx-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }} -pl $NATIVE_BUILD_PROJECTS -am -DstagingRepositoryId=${{ needs.prepare.outputs.stagingRepositoryId }} "-Dnative.build.flags=$BAZEL_CACHE"
           df -h
+      - name: Check for un-committed generation
+        uses: ./.github/actions/check-generation
   windows-x86_64:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: windows-latest
@@ -261,6 +267,8 @@ jobs:
           if ERRORLEVEL 1 exit /b
           df -h
           wmic pagefile list /format:list
+      - name: Check for un-committed generation
+        uses: ./.github/actions/check-generation
   deploy:
     if: github.event_name == 'push' && contains(github.ref, 'master')
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64]

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
@@ -698,19 +698,21 @@ public final class OperatorProcessor extends AbstractProcessor {
       MethodSpec.Builder ctorBuilder,
       List<OpsSpec> groups,
       boolean isTopClass) {
-    groups.forEach(
-        group -> {
-          classBuilder.addField(
-              FieldSpec.builder(group.className, group.fieldName)
-                  .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                  .build());
-          ctorBuilder
-              .addStatement(
-                  "$L = new $T(" + (isTopClass ? "this" : "ops") + ")",
-                  group.fieldName,
-                  group.className)
-              .build();
-        });
+    groups.stream()
+        .sorted(Comparator.comparing(g -> g.fieldName))
+        .forEach(
+            group -> {
+              classBuilder.addField(
+                  FieldSpec.builder(group.className, group.fieldName)
+                      .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                      .build());
+              ctorBuilder
+                  .addStatement(
+                      "$L = new $T(" + (isTopClass ? "this" : "ops") + ")",
+                      group.fieldName,
+                      group.className)
+                  .build();
+            });
   }
 
   private static AnnotationMirror getAnnotationMirror(Element element, Name annotationName) {


### PR DESCRIPTION
Adds steps to the quick-build and full build CI tasks to check for any changes in `tensorflow-core/tensorflow-core-api/src/gen/`.

Also fixes the ordering issues with `Ops` group fields, since the would trigger it every time.  This is done by sorting them alphabetically.