### PR TITLE
Remove ndarray from the docs generator.

### DIFF
--- a/tools/build_java_api_docs.py
+++ b/tools/build_java_api_docs.py
@@ -68,8 +68,6 @@ def main(unused_argv):
             merged_source/'java/org/tensorflow')
   shutil.copytree(REPO_ROOT/'tensorflow-framework/src/main/java/org/tensorflow/framework',
                   merged_source/'java/org/tensorflow/framework')
-  shutil.copytree(REPO_ROOT/'ndarray/src/main/java/org/tensorflow/ndarray',
-                  merged_source/'java/org/tensorflow/ndarray')
 
   gen_java.gen_java_docs(
       package='org.tensorflow',


### PR DESCRIPTION
`ndarray` is not part of the repo anymore. 
This is preventing me from updating the docs to v0.4.

We need to either remove it here or add code to this script to clone that repo and copy-in the code.