### PR TITLE
Add sparse tensor mappings

### DIFF
--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -20,7 +20,7 @@
     <javacpp.parser.skip>${native.build.skip}</javacpp.parser.skip>
     <javacpp.compiler.skip>${native.build.skip}</javacpp.compiler.skip>
     <java.module.name>org.tensorflow.core.api</java.module.name>
-    <ndarray.version>0.3.3</ndarray.version>
+    <ndarray.version>0.4.0-SNAPSHOT</ndarray.version>
     <truth.version>1.0.1</truth.version>
   </properties>
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/RawTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/RawTensor.java
@@ -34,12 +34,12 @@ import org.tensorflow.types.family.TType;
  * A tensor which memory has not been mapped to a data space directly accessible from the JVM.
  *
  * <p>A raw tensor is a minimalist representation of a tensor allocated in native memory by the
- * TensorFlow runtime library and it controls its lifetime within the current process. The data
- * is represented by a flat {@link ByteDataBuffer buffer of bytes}, until it is mapped in a
- * n-dimensional typed space by a {@link TType typed tensor}.</p>
+ * TensorFlow runtime library and it controls its lifetime within the current process. The data is
+ * represented by a flat {@link ByteDataBuffer buffer of bytes}, until it is mapped in a
+ * n-dimensional typed space by a {@link TType typed tensor}.
  *
- * <p>Instances of a RawTensor are <b>not</b> thread-safe and their resource must be released
- * by calling {@link #close()} explicitly or implicitly via try-with-resources.</p>
+ * <p>Instances of a RawTensor are <b>not</b> thread-safe and their resource must be released by
+ * calling {@link #close()} explicitly or implicitly via try-with-resources.
  */
 public final class RawTensor implements Tensor {
 
@@ -81,9 +81,7 @@ public final class RawTensor implements Tensor {
     return buffer;
   }
 
-  /**
-   * Returns a string describing the type and shape of the tensor.
-   */
+  /** Returns a string describing the type and shape of the tensor. */
   @Override
   public String toString() {
     return String.format("%s tensor with shape %s", typeInfo.dataType(), shape);
@@ -92,20 +90,20 @@ public final class RawTensor implements Tensor {
   /**
    * Allocates a new tensor in native memory of the given type, shape and size.
    *
-   * <p>The size of the tensor must be at least large enough to contain all scalars for the
-   * given type and shape. More memory can also be allocated to store also metadata within the
-   * tensor itself, e.g. a lookup table in a string tensor.
+   * <p>The size of the tensor must be at least large enough to contain all scalars for the given
+   * type and shape. More memory can also be allocated to store also metadata within the tensor
+   * itself, e.g. a lookup table in a string tensor.
    *
    * @param type tensor type class
    * @param shape shape of the tensor
    * @param size size in bytes of the tensor, or -1 to compute the size from the shape
    * @return allocated tensor
    * @throws IllegalArgumentException if {@code size} is smaller than the minimum space required to
-   *                                  store the tensor data
-   * @throws IllegalArgumentException if {@code size} is set to -1 but elements of the given
-   *                                  {@code type} are of variable length (e.g. strings)
-   * @throws IllegalArgumentException if {@code shape} is totally or partially
-   *                                  {@link Shape#hasUnknownDimension() unknown}
+   *     store the tensor data
+   * @throws IllegalArgumentException if {@code size} is set to -1 but elements of the given {@code
+   *     type} are of variable length (e.g. strings)
+   * @throws IllegalArgumentException if {@code shape} is totally or partially {@link
+   *     Shape#hasUnknownDimension() unknown}
    * @throws IllegalStateException if tensor failed to be allocated
    */
   static RawTensor allocate(Class<? extends TType> type, Shape shape, long size) {
@@ -123,12 +121,14 @@ public final class RawTensor implements Tensor {
       allocatedSize = shape.size() * typeInfo.byteSize();
 
     } else if (!typeInfo.isVariableLength() && shape.size() * typeInfo.byteSize() > allocatedSize) {
-      // Minimum requirements for datatypes of variable length cannot be verified in a relevant way so
+      // Minimum requirements for datatypes of variable length cannot be verified in a relevant way
+      // so
       // we only validate them for fixed length datatypes
       throw new IllegalArgumentException(
           "Tensor size is not large enough to contain all scalar values");
     }
-    TF_Tensor nativeHandle = allocate(typeInfo.dataType().getNumber(), shape.asArray(), allocatedSize);
+    TF_Tensor nativeHandle =
+        allocate(typeInfo.dataType().getNumber(), shape.asArray(), allocatedSize);
     try (PointerScope scope = new PointerScope()) {
       scope.attach(nativeHandle);
       RawTensor t = new RawTensor(typeInfo, shape);
@@ -147,9 +147,9 @@ public final class RawTensor implements Tensor {
     TensorTypeInfo<?> typeInfo = TensorTypeRegistry.find(DataType.forNumber(dtype(handle)));
     RawTensor t = new RawTensor(typeInfo, Shape.of(shape(handle)));
     try (PointerScope scope = new PointerScope()) {
-        scope.attach(handle);
-        t.tensorHandle = handle;
-        t.tensorScope = scope.extend();
+      scope.attach(handle);
+      t.tensorHandle = handle;
+      t.tensorScope = scope.extend();
     }
     return t;
   }
@@ -168,6 +168,7 @@ public final class RawTensor implements Tensor {
 
   /**
    * Returns the native handle to this tensor
+   *
    * @throws IllegalStateException if tensor has been closed
    */
   TF_Tensor nativeHandle() {
@@ -178,7 +179,8 @@ public final class RawTensor implements Tensor {
    * Returns a typed reference to this tensor
    *
    * <p>In some cases, it is more useful to keep a typed reference to a tensor rather than its raw
-   * nature to prevent mapping its memory on every access (e.g. when calling {@link Operand#asTensor()}).
+   * nature to prevent mapping its memory on every access (e.g. when calling {@link
+   * Operand#asTensor()}).
    *
    * @return typed reference to this tensor
    */
@@ -186,9 +188,7 @@ public final class RawTensor implements Tensor {
     return typeInfo.mapper().mapDense(this);
   }
 
-  /**
-   * @return metadata about the type of this tensor.
-   */
+  /** @return metadata about the type of this tensor. */
   TensorTypeInfo<? extends TType> typeInfo() {
     return typeInfo;
   }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/RawTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/RawTensor.java
@@ -28,7 +28,6 @@ import org.tensorflow.internal.types.registry.TensorTypeRegistry;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.buffer.ByteDataBuffer;
 import org.tensorflow.proto.framework.DataType;
-import org.tensorflow.types.TInt64;
 import org.tensorflow.types.family.TType;
 
 /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/RawTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/RawTensor.java
@@ -28,6 +28,7 @@ import org.tensorflow.internal.types.registry.TensorTypeRegistry;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.buffer.ByteDataBuffer;
 import org.tensorflow.proto.framework.DataType;
+import org.tensorflow.types.TInt64;
 import org.tensorflow.types.family.TType;
 
 /**
@@ -184,6 +185,13 @@ public final class RawTensor implements Tensor {
    */
   TType asTypedTensor() {
     return typeInfo.mapper().mapDense(this);
+  }
+
+  /**
+   * @return metadata about the type of this tensor.
+   */
+  TensorTypeInfo<? extends TType> typeInfo() {
+    return typeInfo;
   }
 
   private static TF_Tensor requireHandle(TF_Tensor handle) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SparseTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SparseTensor.java
@@ -1,0 +1,108 @@
+package org.tensorflow;
+
+import org.tensorflow.types.TInt64;
+import org.tensorflow.types.family.TType;
+
+/**
+ * A virtual type of {@link Tensor} composed of three dense tensors (indices, values and dimensions) used to represent
+ * the sparse data into a multi-dimensional dense space.
+ *
+ * Any tensor returned by a sparse tensor factory (e.g. {@link TInt64#sparseTensorOf(TInt64, TInt64, TInt64)}) can be casted back
+ * to this interface to access directly the dense tensors it is composed of.
+ *
+ * @param <T> type of data stored in the tensor
+ */
+public interface SparseTensor<T extends TType> extends Tensor {
+
+  /**
+   * Creates a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense tensors.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   * @throws IllegalArgumentException if shapes of the dense tensors are not compatible
+   */
+  static <T extends TType> SparseTensor<T> of(TInt64 indices, T values, TInt64 denseShape) {
+    if (indices.rank() != 2) {
+      throw new IllegalArgumentException("Sparse indices must be a rank-2 tensor");
+    }
+    if (values.rank() != 1) {
+      throw new IllegalArgumentException("Sparse values must be a rank-1 tensor");
+    }
+    if (denseShape.rank() != 1) {
+      throw new IllegalArgumentException("Sparse shape must be a rank-1 tensor");
+    }
+    if (indices.shape().get(0) != values.shape().get(0)) {
+      throw new IllegalArgumentException("Number of indices must be equal to the number of values ["
+          + indices.shape().get(0) + " != " + values.shape().get(0) + "]");
+    }
+    if (indices.shape().get(1) != denseShape.shape().get(0)) {
+      throw new IllegalArgumentException("Indices must have a coordinate for each dimensions of the tensor ["
+          + indices.shape().get(1) + " != " + denseShape.shape().get(0) + "]");
+    }
+    // Use mapper of the values tensor as this is the one giving the type of the sparse tensor as well
+    TensorMapper<T> mapper = (TensorMapper<T>) values.asRawTensor().typeInfo().mapper();
+    return mapper.mapSparse(indices, values, denseShape);
+  }
+
+  @Override
+  default RawTensor asRawTensor() {
+    throw new UnsupportedOperationException("Sparse tensors cannot be converted to a single raw tensor");
+  }
+
+  /**
+   * Returns this instance as a typed tensor.
+   *
+   * This method is equivalent to cast directly the {@code SparseTensor<T>} instance to {@code T}.
+   *
+   * @return the typed tensor
+   */
+  default T asTypedTensor() {
+    return (T) this;
+  }
+
+  /**
+   * Gets the indices of the sparsed values.
+   *
+   * <p>Indices are a 2-D long array of shape {@code [N, ndims]}, that specifies the indices of
+   * the elements in the sparse tensor that contain nonzero values (elements are zero-indexed).
+   *
+   * <p>For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   * coordinates {@code [1,3]} and {@code [2,4]} have nonzero values.
+   *
+   * @return the indices
+   */
+  TInt64 indices();
+
+  /**
+   * Gets the sparse values.
+   *
+   * <p>Values are a 1-D array of type {@code T} and shape {@code [N]}, that supplies the values for each
+   * element in indices.
+   *
+   * <p>For example, given {@code indices=[[1,3], [2,4]]}, and {@code values=[18, 3.6]} specifies
+   * that element {@code [1,3]} of the sparse tensor has a value of {@code 18}, and element {@code
+   * [2,4]} of the sparse tensor has a value of {@code 3.6}.
+   *
+   * @return the values
+   */
+  T values();
+
+  /**
+   * Gets the sparse tensor dimensions defining the shape in that tensor in a dense space.
+   *
+   * <p>Dimensions A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   * represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *
+   * @return the dense shape
+   */
+  TInt64 denseShape();
+}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SparseTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SparseTensor.java
@@ -14,25 +14,25 @@ limitations under the License.
 ==============================================================================*/
 package org.tensorflow;
 
-import java.io.Closeable;
-import java.io.IOException;
 import org.bytedeco.javacpp.PointerScope;
-import org.tensorflow.internal.c_api.TF_Tensor;
 import org.tensorflow.types.TInt64;
 import org.tensorflow.types.family.TType;
 
 /**
- * A virtual type of {@link Tensor} composed of three dense tensors (indices, values and dimensions) used to represent
- * the sparse data into a multi-dimensional dense space.
+ * A virtual type of {@link Tensor} composed of three dense tensors (indices, values and dimensions)
+ * used to represent the sparse data into a multi-dimensional dense space.
  *
- * <p>Any tensor returned by a sparse tensor factory (e.g. {@link TInt64#sparseTensorOf(TInt64, TInt64, TInt64)}) can be casted back
- * to this interface to access directly the dense tensors it is composed of.
+ * <p>Any tensor returned by a sparse tensor factory (e.g. {@link TInt64#sparseTensorOf(TInt64,
+ * TInt64, TInt64)}) can be casted back to this interface to access directly the dense tensors it is
+ * composed of.
  *
- * <p>A sparse tensor will keep strong references to its dense tensors to prevent them to be released before it is closed itself.
- * Likewise, closing a sparse tensor won't release the memory of its dense tensors until they in turn are closed.
- * It is then important to protect not only the dense tensors within a <i>try-with-resource</i> block but the sparse tensor itself.
+ * <p>A sparse tensor will keep strong references to its dense tensors to prevent them to be
+ * released before it is closed itself. Likewise, closing a sparse tensor won't release the memory
+ * of its dense tensors until they in turn are closed. It is then important to protect not only the
+ * dense tensors within a <i>try-with-resource</i> block but the sparse tensor itself.
  *
  * <p>For example, this code is perfectly safe:
+ *
  * <pre>{@code
  * TFloat64 createSparseTensor() {
  *     try (TInt64 indices = TInt64.tensorOf(...);
@@ -51,16 +51,17 @@ import org.tensorflow.types.family.TType;
 public interface SparseTensor<T extends TType> extends Tensor {
 
   /**
-   * Creates a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense tensors.
+   * Creates a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
-   *     values=[18, 3.8]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8}.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3,1]} of the sparse tensor has a value
+   *     of {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
    *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
@@ -77,14 +78,23 @@ public interface SparseTensor<T extends TType> extends Tensor {
       throw new IllegalArgumentException("Sparse shape must be a rank-1 tensor");
     }
     if (indices.shape().get(0) != values.shape().get(0)) {
-      throw new IllegalArgumentException("Number of indices must be equal to the number of values ["
-          + indices.shape().get(0) + " != " + values.shape().get(0) + "]");
+      throw new IllegalArgumentException(
+          "Number of indices must be equal to the number of values ["
+              + indices.shape().get(0)
+              + " != "
+              + values.shape().get(0)
+              + "]");
     }
     if (indices.shape().get(1) != denseShape.shape().get(0)) {
-      throw new IllegalArgumentException("Indices must have a coordinate for each dimensions of the tensor ["
-          + indices.shape().get(1) + " != " + denseShape.shape().get(0) + "]");
+      throw new IllegalArgumentException(
+          "Indices must have a coordinate for each dimensions of the tensor ["
+              + indices.shape().get(1)
+              + " != "
+              + denseShape.shape().get(0)
+              + "]");
     }
-    // Use mapper of the values tensor as this is the one giving the type of the sparse tensor as well
+    // Use mapper of the values tensor as this is the one giving the type of the sparse tensor as
+    // well
     TensorMapper<T> mapper = (TensorMapper<T>) values.asRawTensor().typeInfo().mapper();
 
     // Keep a strong reference to all sub-tensors of the sparse tensor
@@ -98,13 +108,15 @@ public interface SparseTensor<T extends TType> extends Tensor {
 
   @Override
   default RawTensor asRawTensor() {
-    throw new UnsupportedOperationException("Sparse tensors cannot be converted to a single raw tensor");
+    throw new UnsupportedOperationException(
+        "Sparse tensors cannot be converted to a single raw tensor");
   }
 
   /**
    * Returns this instance as a typed tensor.
    *
-   * This method is equivalent to cast directly the {@code SparseTensor<T>} instance to {@code T}.
+   * <p>This method is equivalent to cast directly the {@code SparseTensor<T>} instance to {@code
+   * T}.
    *
    * @return the typed tensor
    */
@@ -115,8 +127,8 @@ public interface SparseTensor<T extends TType> extends Tensor {
   /**
    * Gets the indices of the sparsed values.
    *
-   * <p>Indices are a 2-D long array of shape {@code [N, ndims]}, that specifies the indices of
-   * the elements in the sparse tensor that contain nonzero values (elements are zero-indexed).
+   * <p>Indices are a 2-D long array of shape {@code [N, ndims]}, that specifies the indices of the
+   * elements in the sparse tensor that contain nonzero values (elements are zero-indexed).
    *
    * <p>For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
    * coordinates {@code [1,3]} and {@code [2,4]} have nonzero values.
@@ -128,8 +140,8 @@ public interface SparseTensor<T extends TType> extends Tensor {
   /**
    * Gets the sparse values.
    *
-   * <p>Values are a 1-D array of type {@code T} and shape {@code [N]}, that supplies the values for each
-   * element in indices.
+   * <p>Values are a 1-D array of type {@code T} and shape {@code [N]}, that supplies the values for
+   * each element in indices.
    *
    * <p>For example, given {@code indices=[[1,3], [2,4]]}, and {@code values=[18, 3.6]} specifies
    * that element {@code [1,3]} of the sparse tensor has a value of {@code 18}, and element {@code

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SparseTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SparseTensor.java
@@ -97,7 +97,9 @@ public interface SparseTensor<T extends TType> extends Tensor {
     // well
     TensorMapper<T> mapper = (TensorMapper<T>) values.asRawTensor().typeInfo().mapper();
 
-    // Keep a strong reference to all sub-tensors of the sparse tensor
+    // Attach all tensors to a new pointer scope (this will increment their reference count) and
+    // preserve a strong reference to that scope inside the sparse tensor. This is done by
+    // extending this scope in the sparse tensor constructors, via mapSparse()
     try (PointerScope scope = new PointerScope()) {
       scope.attach(indices.asRawTensor().nativeHandle());
       scope.attach(values.asRawTensor().nativeHandle());

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
@@ -16,13 +16,10 @@ limitations under the License.
 package org.tensorflow;
 
 import java.util.function.Consumer;
-import org.tensorflow.ndarray.LongNdArray;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.Shaped;
 import org.tensorflow.ndarray.buffer.ByteDataBuffer;
 import org.tensorflow.proto.framework.DataType;
-import org.tensorflow.types.TFloat64;
-import org.tensorflow.types.TInt64;
 import org.tensorflow.types.family.TType;
 
 /**
@@ -202,6 +199,8 @@ public interface Tensor extends Shaped, AutoCloseable {
 
   /**
    * Returns a raw (untyped) representation of this tensor
+   *
+   * @throws UnsupportedOperationException if this tensor is composed of multiple other tensors, such as {@link SparseTensor sparse tensors}.
    */
   RawTensor asRawTensor();
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
@@ -16,10 +16,13 @@ limitations under the License.
 package org.tensorflow;
 
 import java.util.function.Consumer;
+import org.tensorflow.ndarray.LongNdArray;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.Shaped;
 import org.tensorflow.ndarray.buffer.ByteDataBuffer;
 import org.tensorflow.proto.framework.DataType;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt64;
 import org.tensorflow.types.family.TType;
 
 /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
@@ -25,10 +25,10 @@ import org.tensorflow.types.family.TType;
 /**
  * A statically typed multi-dimensional array.
  *
- * <p>There are two categories of tensors in TensorFlow Java: {@link TType typed tensors} and
- * {@link RawTensor raw tensors}. The former maps the tensor native memory to an
- * n-dimensional typed data space, allowing direct I/O operations from the JVM, while the latter
- * is only a reference to a native tensor allowing basic operations and flat data access.</p>
+ * <p>There are two categories of tensors in TensorFlow Java: {@link TType typed tensors} and {@link
+ * RawTensor raw tensors}. The former maps the tensor native memory to an n-dimensional typed data
+ * space, allowing direct I/O operations from the JVM, while the latter is only a reference to a
+ * native tensor allowing basic operations and flat data access.
  *
  * <p><b>WARNING:</b> Resources consumed by the Tensor object <b>must</b> be explicitly freed by
  * invoking the {@link #close()} method when the object is no longer needed. For example, using a
@@ -39,6 +39,7 @@ import org.tensorflow.types.family.TType;
  *   doSomethingWith(t);
  * }
  * }</pre>
+ *
  * <p>Instances of a Tensor are <b>not</b> thread-safe.
  */
 public interface Tensor extends Shaped, AutoCloseable {
@@ -54,9 +55,9 @@ public interface Tensor extends Shaped, AutoCloseable {
    * @param shape shape of the tensor
    * @return an allocated but uninitialized tensor
    * @throws IllegalArgumentException if elements of the given {@code type} are of variable length
-   *                                  (e.g. strings)
-   * @throws IllegalArgumentException if {@code shape} is totally or partially
-   *                                  {@link Shape#hasUnknownDimension() unknown}
+   *     (e.g. strings)
+   * @throws IllegalArgumentException if {@code shape} is totally or partially {@link
+   *     Shape#hasUnknownDimension() unknown}
    * @throws IllegalStateException if tensor failed to be allocated
    */
   static <T extends TType> T of(Class<T> type, Shape shape) {
@@ -67,8 +68,8 @@ public interface Tensor extends Shaped, AutoCloseable {
    * Allocates a tensor of a given datatype, shape and size.
    *
    * <p>This method is identical to {@link #of(Class, Shape)}, except that the final size of the
-   * tensor can be explicitly set instead of computing it from the datatype and shape, which could be
-   * larger than the actual space required to store the data but not smaller.
+   * tensor can be explicitly set instead of computing it from the datatype and shape, which could
+   * be larger than the actual space required to store the data but not smaller.
    *
    * @param <T> the tensor type
    * @param type the tensor type class
@@ -77,17 +78,17 @@ public interface Tensor extends Shaped, AutoCloseable {
    * @return an allocated but uninitialized tensor
    * @see #of(Class, Shape)
    * @throws IllegalArgumentException if {@code size} is smaller than the minimum space required to
-   *                                  store the tensor data
-   * @throws IllegalArgumentException if {@code size} is set to -1 but elements of the given
-   *                                  {@code type} are of variable length (e.g. strings)
-   * @throws IllegalArgumentException if {@code shape} is totally or partially
-   *                                  {@link Shape#hasUnknownDimension() unknown}
+   *     store the tensor data
+   * @throws IllegalArgumentException if {@code size} is set to -1 but elements of the given {@code
+   *     type} are of variable length (e.g. strings)
+   * @throws IllegalArgumentException if {@code shape} is totally or partially {@link
+   *     Shape#hasUnknownDimension() unknown}
    * @throws IllegalStateException if tensor failed to be allocated
    */
   static <T extends TType> T of(Class<T> type, Shape shape, long size) {
     RawTensor tensor = RawTensor.allocate(type, shape, size);
     try {
-      return (T)tensor.asTypedTensor();
+      return (T) tensor.asTypedTensor();
     } catch (Exception e) {
       tensor.close();
       throw e;
@@ -114,12 +115,13 @@ public interface Tensor extends Shaped, AutoCloseable {
    * @param <T> the tensor type
    * @param type the tensor type class
    * @param shape shape of the tensor
-   * @param dataInitializer method receiving accessor to the allocated tensor data for initialization
+   * @param dataInitializer method receiving accessor to the allocated tensor data for
+   *     initialization
    * @return an allocated and initialized tensor
    * @throws IllegalArgumentException if elements of the given {@code type} are of variable length
-   *                                  (e.g. strings)
-   * @throws IllegalArgumentException if {@code shape} is totally or partially
-   *                                  {@link Shape#hasUnknownDimension() unknown}
+   *     (e.g. strings)
+   * @throws IllegalArgumentException if {@code shape} is totally or partially {@link
+   *     Shape#hasUnknownDimension() unknown}
    * @throws IllegalStateException if tensor failed to be allocated
    */
   static <T extends TType> T of(Class<T> type, Shape shape, Consumer<T> dataInitializer) {
@@ -129,28 +131,30 @@ public interface Tensor extends Shaped, AutoCloseable {
   /**
    * Allocates a tensor of a given datatype, shape and size.
    *
-   * <p>This method is identical to {@link #of(Class, Shape, Consumer)}, except that the final
-   * size for the tensor can be explicitly set instead of being computed from the datatype and shape.
+   * <p>This method is identical to {@link #of(Class, Shape, Consumer)}, except that the final size
+   * for the tensor can be explicitly set instead of being computed from the datatype and shape.
    *
-   * <p>This could be useful for tensor types that stores data but also metadata in the tensor memory,
-   * such as the lookup table in a tensor of strings.
+   * <p>This could be useful for tensor types that stores data but also metadata in the tensor
+   * memory, such as the lookup table in a tensor of strings.
    *
    * @param <T> the tensor type
    * @param type the tensor type class
    * @param shape shape of the tensor
    * @param size size in bytes of the tensor or -1 to compute the size from the shape
-   * @param dataInitializer method receiving accessor to the allocated tensor data for initialization
+   * @param dataInitializer method receiving accessor to the allocated tensor data for
+   *     initialization
    * @return an allocated and initialized tensor
    * @see #of(Class, Shape, long, Consumer)
    * @throws IllegalArgumentException if {@code size} is smaller than the minimum space required to
-   *                                  store the tensor data
-   * @throws IllegalArgumentException if {@code size} is set to -1 but elements of the given
-   *                                  {@code type} are of variable length (e.g. strings)
-   * @throws IllegalArgumentException if {@code shape} is totally or partially
-   *                                  {@link Shape#hasUnknownDimension() unknown}
+   *     store the tensor data
+   * @throws IllegalArgumentException if {@code size} is set to -1 but elements of the given {@code
+   *     type} are of variable length (e.g. strings)
+   * @throws IllegalArgumentException if {@code shape} is totally or partially {@link
+   *     Shape#hasUnknownDimension() unknown}
    * @throws IllegalStateException if tensor failed to be allocated
    */
-  static <T extends TType> T of(Class<T> type, Shape shape, long size, Consumer<T> dataInitializer) {
+  static <T extends TType> T of(
+      Class<T> type, Shape shape, long size, Consumer<T> dataInitializer) {
     T tensor = of(type, shape, size);
     try {
       dataInitializer.accept(tensor);
@@ -172,37 +176,45 @@ public interface Tensor extends Shaped, AutoCloseable {
    * @param shape the tensor shape.
    * @param rawData a buffer containing the tensor raw data.
    * @throws IllegalArgumentException if {@code rawData} is not large enough to contain the tensor
-   *                                  data
-   * @throws IllegalArgumentException if {@code shape} is totally or partially
-   *                                  {@link Shape#hasUnknownDimension() unknown}
+   *     data
+   * @throws IllegalArgumentException if {@code shape} is totally or partially {@link
+   *     Shape#hasUnknownDimension() unknown}
    * @throws IllegalStateException if tensor failed to be allocated with the given parameters
    */
   static <T extends TType> T of(Class<T> type, Shape shape, ByteDataBuffer rawData) {
-    return of(type, shape, rawData.size(), t -> rawData.copyTo(t.asRawTensor().data(), rawData.size()));
+    return of(
+        type, shape, rawData.size(), t -> rawData.copyTo(t.asRawTensor().data(), rawData.size()));
   }
 
-  /**
-   * Returns the {@link DataType} of elements stored in the tensor.
-   */
+  /** Returns the {@link DataType} of elements stored in the tensor. */
   DataType dataType();
 
-  /**
-   * Returns the size, in bytes, of the tensor data.
-   */
+  /** Returns the size, in bytes, of the tensor data. */
   long numBytes();
 
-  /**
-   * Returns the shape of the tensor.
-   */
+  /** Returns the shape of the tensor. */
   @Override
   Shape shape();
 
   /**
    * Returns a raw (untyped) representation of this tensor
    *
-   * @throws UnsupportedOperationException if this tensor is composed of multiple other tensors, such as {@link SparseTensor sparse tensors}.
+   * @throws UnsupportedOperationException if this tensor is composed of other tensors, such as
+   *     {@link SparseTensor sparse tensors}.
    */
   RawTensor asRawTensor();
+
+  /**
+   * Check if this tensor is sparse or not.
+   *
+   * <p>When this methods retuns {@code true}, the tensor could be cast to a {@link SparseTensor
+   * SparseTensor<T>} to access its <i>indices</i>, <i>values</i> and <i>denseShape</i> tensors.
+   *
+   * @retrun true if this tensor is a sparse
+   */
+  default boolean isSparse() {
+    return false;
+  }
 
   /**
    * Release resources associated with the Tensor.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorMapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorMapper.java
@@ -17,6 +17,7 @@
 package org.tensorflow;
 
 import org.tensorflow.internal.c_api.TF_Tensor;
+import org.tensorflow.types.TInt64;
 import org.tensorflow.types.family.TType;
 
 /**
@@ -37,6 +38,16 @@ public abstract class TensorMapper<T extends TType> {
    * @return an instance of {@code T}
    */
   protected abstract T mapDense(RawTensor tensor);
+
+  /**
+   * Maps the provided dense {@code tensors} as a sparse tensor of type {@code T}.
+   *
+   * @param indices indices of the non-default values in a dense space
+   * @param values non-default values of the tensor
+   * @param denseShape size of the dimensions definining the shape of the sparse tensor in a dense space.
+   * @return an instance of {@code T}, that could also be casted to a {@link SparseTensor SparseTensor<T>}
+   */
+  protected abstract SparseTensor<T> mapSparse(TInt64 indices, T values, TInt64 denseShape);
 
   /**
    * Helper for retrieving the native handle of a raw tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorMapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorMapper.java
@@ -22,8 +22,8 @@ import org.tensorflow.types.TInt64;
 import org.tensorflow.types.family.TType;
 
 /**
- * Maps the native memory of a {@link RawTensor} to a n-dimensional typed data space
- * accessible from the JVM.
+ * Maps the native memory of a {@link RawTensor} to a n-dimensional typed data space accessible from
+ * the JVM.
  *
  * <p>Usage of this class is reserved for internal purposes only.
  *
@@ -45,11 +45,15 @@ public abstract class TensorMapper<T extends TType> {
    *
    * @param indices indices of the non-default values in a dense space
    * @param values non-default values of the tensor
-   * @param denseShape size of the dimensions definining the shape of the sparse tensor in a dense space.
-   * @param tensorScope scope to extend to keep a reference on the sub-tensors composing this sparse tensor
-   * @return an instance of {@code T}, that could also be casted to a {@link SparseTensor SparseTensor<T>}
+   * @param denseShape size of the dimensions definining the shape of the sparse tensor in a dense
+   *     space.
+   * @param tensorScope scope to extend to keep a reference on the sub-tensors composing this sparse
+   *     tensor
+   * @return an instance of {@code T}, that could also be casted to a {@link SparseTensor
+   *     SparseTensor<T>}
    */
-  protected abstract SparseTensor<T> mapSparse(TInt64 indices, T values, TInt64 denseShape, PointerScope tensorScope);
+  protected abstract SparseTensor<T> mapSparse(
+      TInt64 indices, T values, TInt64 denseShape, PointerScope tensorScope);
 
   /**
    * Helper for retrieving the native handle of a raw tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorMapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorMapper.java
@@ -16,6 +16,7 @@
  */
 package org.tensorflow;
 
+import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.internal.c_api.TF_Tensor;
 import org.tensorflow.types.TInt64;
 import org.tensorflow.types.family.TType;
@@ -45,9 +46,10 @@ public abstract class TensorMapper<T extends TType> {
    * @param indices indices of the non-default values in a dense space
    * @param values non-default values of the tensor
    * @param denseShape size of the dimensions definining the shape of the sparse tensor in a dense space.
+   * @param tensorScope scope to extend to keep a reference on the sub-tensors composing this sparse tensor
    * @return an instance of {@code T}, that could also be casted to a {@link SparseTensor SparseTensor<T>}
    */
-  protected abstract SparseTensor<T> mapSparse(TInt64 indices, T values, TInt64 denseShape);
+  protected abstract SparseTensor<T> mapSparse(TInt64 indices, T values, TInt64 denseShape, PointerScope tensorScope);
 
   /**
    * Helper for retrieving the native handle of a raw tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/SparseHelpers.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/SparseHelpers.java
@@ -14,25 +14,18 @@ limitations under the License.
 ==============================================================================*/
 package org.tensorflow.internal.types;
 
-import java.io.Closeable;
-import java.io.IOException;
-import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.SparseTensor;
-import org.tensorflow.internal.c_api.TF_Tensor;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.StdArrays;
 import org.tensorflow.ndarray.impl.dimension.DimensionalSpace;
 import org.tensorflow.types.TInt64;
-import org.tensorflow.types.family.TType;
 
-/**
- * Internal helper class for sparse tensor mappers
- */
+/** Internal helper class for sparse tensor mappers */
 abstract class SparseHelpers {
 
   /**
-   * Convert a 1-D dense tensor, where each scalar represents the size of a dimension, to a {@link DimensionalSpace} instance as expected
-   * by the NdArray library.
+   * Convert a 1-D dense tensor, where each scalar represents the size of a dimension, to a {@link
+   * DimensionalSpace} instance as expected by the NdArray library.
    *
    * @param denseShape 1-D dense tensor holding the size of each dimensions
    * @return a {@link DimensionalSpace} with these dimensions
@@ -42,12 +35,15 @@ abstract class SparseHelpers {
   }
 
   /**
-   * Compute the total number of bytes required to store a sparse tensor by adding the size of each of its dense sub-tensors.
+   * Compute the total number of bytes required to store a sparse tensor by adding the size of each
+   * of its dense sub-tensors.
    *
    * @param sparseTensor the sparse tensor
    * @return the total number of bytes
    */
   static long numBytes(SparseTensor<?> sparseTensor) {
-    return sparseTensor.indices().numBytes() + sparseTensor.values().numBytes() + sparseTensor.denseShape().numBytes();
+    return sparseTensor.indices().numBytes()
+        + sparseTensor.values().numBytes()
+        + sparseTensor.denseShape().numBytes();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/SparseHelpers.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/SparseHelpers.java
@@ -1,0 +1,18 @@
+package org.tensorflow.internal.types;
+
+import org.tensorflow.SparseTensor;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.StdArrays;
+import org.tensorflow.ndarray.impl.dimension.DimensionalSpace;
+import org.tensorflow.types.TInt64;
+
+abstract class SparseHelpers {
+
+  static DimensionalSpace toDimensionalSpace(TInt64 denseShape) {
+    return DimensionalSpace.create(Shape.of(StdArrays.array1dCopyOf(denseShape)));
+  }
+
+  static long numBytes(SparseTensor<?> t) {
+    return t.indices().numBytes() + t.values().numBytes() + t.denseShape().numBytes();
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/SparseHelpers.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/SparseHelpers.java
@@ -1,18 +1,53 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 package org.tensorflow.internal.types;
 
+import java.io.Closeable;
+import java.io.IOException;
+import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.SparseTensor;
+import org.tensorflow.internal.c_api.TF_Tensor;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.StdArrays;
 import org.tensorflow.ndarray.impl.dimension.DimensionalSpace;
 import org.tensorflow.types.TInt64;
+import org.tensorflow.types.family.TType;
 
+/**
+ * Internal helper class for sparse tensor mappers
+ */
 abstract class SparseHelpers {
 
+  /**
+   * Convert a 1-D dense tensor, where each scalar represents the size of a dimension, to a {@link DimensionalSpace} instance as expected
+   * by the NdArray library.
+   *
+   * @param denseShape 1-D dense tensor holding the size of each dimensions
+   * @return a {@link DimensionalSpace} with these dimensions
+   */
   static DimensionalSpace toDimensionalSpace(TInt64 denseShape) {
     return DimensionalSpace.create(Shape.of(StdArrays.array1dCopyOf(denseShape)));
   }
 
-  static long numBytes(SparseTensor<?> t) {
-    return t.indices().numBytes() + t.values().numBytes() + t.denseShape().numBytes();
+  /**
+   * Compute the total number of bytes required to store a sparse tensor by adding the size of each of its dense sub-tensors.
+   *
+   * @param sparseTensor the sparse tensor
+   * @return the total number of bytes
+   */
+  static long numBytes(SparseTensor<?> sparseTensor) {
+    return sparseTensor.indices().numBytes() + sparseTensor.values().numBytes() + sparseTensor.denseShape().numBytes();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TBfloat16Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TBfloat16Mapper.java
@@ -30,20 +30,21 @@ import org.tensorflow.types.TBfloat16;
 import org.tensorflow.types.TInt64;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_BFLOAT16} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_BFLOAT16} tensors to a
+ * n-dimensional data space.
  */
 public final class TBfloat16Mapper extends TensorMapper<TBfloat16> {
 
   @Override
   protected TBfloat16 mapDense(RawTensor tensor) {
-    FloatDataBuffer buffer = DataLayouts.BFLOAT16.applyTo(TensorBuffers.toShorts(nativeHandle(tensor)));
+    FloatDataBuffer buffer =
+        DataLayouts.BFLOAT16.applyTo(TensorBuffers.toShorts(nativeHandle(tensor)));
     return new DenseTBfloat16(tensor, buffer);
   }
 
   @Override
-  protected SparseTensor<TBfloat16> mapSparse(TInt64 indices, TBfloat16 values, TInt64 denseShape,
-      PointerScope tensorScope) {
+  protected SparseTensor<TBfloat16> mapSparse(
+      TInt64 indices, TBfloat16 values, TInt64 denseShape, PointerScope tensorScope) {
     return new SparseTBfloat16(indices, values, denseShape, tensorScope);
   }
 
@@ -82,7 +83,8 @@ public final class TBfloat16Mapper extends TensorMapper<TBfloat16> {
     }
   }
 
-  private static final class SparseTBfloat16 extends FloatSparseNdArray implements TBfloat16, SparseTensor<TBfloat16> {
+  private static final class SparseTBfloat16 extends FloatSparseNdArray
+      implements TBfloat16, SparseTensor<TBfloat16> {
 
     @Override
     public Class<TBfloat16> type() {
@@ -102,6 +104,11 @@ public final class TBfloat16Mapper extends TensorMapper<TBfloat16> {
     @Override
     public void close() {
       tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
     }
 
     @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TBoolMapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TBoolMapper.java
@@ -16,6 +16,7 @@
  */
 package org.tensorflow.internal.types;
 
+import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.RawTensor;
 import org.tensorflow.SparseTensor;
 import org.tensorflow.TensorMapper;
@@ -40,8 +41,8 @@ public final class TBoolMapper extends TensorMapper<TBool> {
   }
 
   @Override
-  protected SparseTensor<TBool> mapSparse(TInt64 indices, TBool values, TInt64 denseShape) {
-    return new SparseTBool(indices, values, denseShape);
+  protected SparseTensor<TBool> mapSparse(TInt64 indices, TBool values, TInt64 denseShape, PointerScope tensorScope) {
+    return new SparseTBool(indices, values, denseShape, tensorScope);
   }
 
   private static final class DenseTBool extends BooleanDenseNdArray implements TBool {
@@ -98,7 +99,7 @@ public final class TBoolMapper extends TensorMapper<TBool> {
 
     @Override
     public void close() {
-      // sparse tensors do not own the dense tensors that compose them, nothing to close
+      tensorScope.close();
     }
 
     @Override
@@ -116,11 +117,13 @@ public final class TBoolMapper extends TensorMapper<TBool> {
       return denseShape;
     }
 
-    SparseTBool(TInt64 indices, TBool values, TInt64 denseShape) {
+    SparseTBool(TInt64 indices, TBool values, TInt64 denseShape, PointerScope tensorScope) {
       super(indices, values, false, SparseHelpers.toDimensionalSpace(denseShape));
       this.denseShape = denseShape;
+      this.tensorScope = tensorScope.extend();
     }
 
     private final TInt64 denseShape;
+    private final PointerScope tensorScope;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TBoolMapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TBoolMapper.java
@@ -29,8 +29,8 @@ import org.tensorflow.types.TBool;
 import org.tensorflow.types.TInt64;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_BOOL} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_BOOL} tensors to a n-dimensional
+ * data space.
  */
 public final class TBoolMapper extends TensorMapper<TBool> {
 
@@ -41,7 +41,8 @@ public final class TBoolMapper extends TensorMapper<TBool> {
   }
 
   @Override
-  protected SparseTensor<TBool> mapSparse(TInt64 indices, TBool values, TInt64 denseShape, PointerScope tensorScope) {
+  protected SparseTensor<TBool> mapSparse(
+      TInt64 indices, TBool values, TInt64 denseShape, PointerScope tensorScope) {
     return new SparseTBool(indices, values, denseShape, tensorScope);
   }
 
@@ -80,7 +81,8 @@ public final class TBoolMapper extends TensorMapper<TBool> {
     }
   }
 
-  private static final class SparseTBool extends BooleanSparseNdArray implements TBool, SparseTensor<TBool> {
+  private static final class SparseTBool extends BooleanSparseNdArray
+      implements TBool, SparseTensor<TBool> {
 
     @Override
     public Class<TBool> type() {
@@ -100,6 +102,11 @@ public final class TBoolMapper extends TensorMapper<TBool> {
     @Override
     public void close() {
       tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
     }
 
     @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat16Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat16Mapper.java
@@ -17,12 +17,16 @@
 package org.tensorflow.internal.types;
 
 import org.tensorflow.RawTensor;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.TensorMapper;
 import org.tensorflow.internal.buffer.TensorBuffers;
 import org.tensorflow.ndarray.buffer.FloatDataBuffer;
 import org.tensorflow.ndarray.buffer.layout.DataLayouts;
 import org.tensorflow.ndarray.impl.dense.FloatDenseNdArray;
+import org.tensorflow.ndarray.impl.sparse.FloatSparseNdArray;
+import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.types.TFloat16;
+import org.tensorflow.types.TInt64;
 
 /**
  * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_HALF} tensors
@@ -36,11 +40,31 @@ public final class TFloat16Mapper extends TensorMapper<TFloat16> {
     return new DenseTFloat16(tensor, buffer);
   }
 
+  @Override
+  protected SparseTensor<TFloat16> mapSparse(TInt64 indices, TFloat16 values, TInt64 denseShape) {
+    return new TFloat16Mapper.SparseTFloat16(indices, values, denseShape);
+  }
+
   private static final class DenseTFloat16 extends FloatDenseNdArray implements TFloat16 {
 
     @Override
     public Class<TFloat16> type() {
       return TFloat16.class;
+    }
+
+    @Override
+    public DataType dataType() {
+      return asRawTensor().dataType();
+    }
+
+    @Override
+    public long numBytes() {
+      return asRawTensor().numBytes();
+    }
+
+    @Override
+    public void close() {
+      asRawTensor().close();
     }
 
     @Override
@@ -54,5 +78,50 @@ public final class TFloat16Mapper extends TensorMapper<TFloat16> {
       super(buffer, rawTensor.shape());
       this.rawTensor = rawTensor;
     }
+  }
+
+  private static final class SparseTFloat16 extends FloatSparseNdArray implements TFloat16, SparseTensor<TFloat16> {
+
+    @Override
+    public Class<TFloat16> type() {
+      return TFloat16.class;
+    }
+
+    @Override
+    public DataType dataType() {
+      return values().dataType();
+    }
+
+    @Override
+    public long numBytes() {
+      return SparseHelpers.numBytes(this);
+    }
+
+    @Override
+    public void close() {
+      // sparse tensors do not own the dense tensors that compose them, nothing to close
+    }
+
+    @Override
+    public TInt64 indices() {
+      return (TInt64) getIndices();
+    }
+
+    @Override
+    public TFloat16 values() {
+      return (TFloat16) getValues();
+    }
+
+    @Override
+    public TInt64 denseShape() {
+      return denseShape;
+    }
+
+    SparseTFloat16(TInt64 indices, TFloat16 values, TInt64 denseShape) {
+      super(indices, values, 0.0f, SparseHelpers.toDimensionalSpace(denseShape));
+      this.denseShape = denseShape;
+    }
+
+    private final TInt64 denseShape;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat16Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat16Mapper.java
@@ -30,20 +30,21 @@ import org.tensorflow.types.TFloat16;
 import org.tensorflow.types.TInt64;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_HALF} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_HALF} tensors to a n-dimensional
+ * data space.
  */
 public final class TFloat16Mapper extends TensorMapper<TFloat16> {
 
   @Override
   protected TFloat16 mapDense(RawTensor tensor) {
-    FloatDataBuffer buffer = DataLayouts.FLOAT16.applyTo(TensorBuffers.toShorts(nativeHandle(tensor)));
+    FloatDataBuffer buffer =
+        DataLayouts.FLOAT16.applyTo(TensorBuffers.toShorts(nativeHandle(tensor)));
     return new DenseTFloat16(tensor, buffer);
   }
 
   @Override
-  protected SparseTensor<TFloat16> mapSparse(TInt64 indices, TFloat16 values, TInt64 denseShape,
-      PointerScope tensorScope) {
+  protected SparseTensor<TFloat16> mapSparse(
+      TInt64 indices, TFloat16 values, TInt64 denseShape, PointerScope tensorScope) {
     return new TFloat16Mapper.SparseTFloat16(indices, values, denseShape, tensorScope);
   }
 
@@ -82,7 +83,8 @@ public final class TFloat16Mapper extends TensorMapper<TFloat16> {
     }
   }
 
-  private static final class SparseTFloat16 extends FloatSparseNdArray implements TFloat16, SparseTensor<TFloat16> {
+  private static final class SparseTFloat16 extends FloatSparseNdArray
+      implements TFloat16, SparseTensor<TFloat16> {
 
     @Override
     public Class<TFloat16> type() {
@@ -102,6 +104,11 @@ public final class TFloat16Mapper extends TensorMapper<TFloat16> {
     @Override
     public void close() {
       tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
     }
 
     @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat32Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat32Mapper.java
@@ -29,8 +29,8 @@ import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt64;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_FLOAT} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_FLOAT} tensors to a
+ * n-dimensional data space.
  */
 public final class TFloat32Mapper extends TensorMapper<TFloat32> {
 
@@ -41,8 +41,8 @@ public final class TFloat32Mapper extends TensorMapper<TFloat32> {
   }
 
   @Override
-  protected SparseTensor<TFloat32> mapSparse(TInt64 indices, TFloat32 values, TInt64 denseShape,
-      PointerScope tensorScope) {
+  protected SparseTensor<TFloat32> mapSparse(
+      TInt64 indices, TFloat32 values, TInt64 denseShape, PointerScope tensorScope) {
     return new SparseTFloat32(indices, values, denseShape, tensorScope);
   }
 
@@ -81,7 +81,8 @@ public final class TFloat32Mapper extends TensorMapper<TFloat32> {
     }
   }
 
-  private static final class SparseTFloat32 extends FloatSparseNdArray implements TFloat32, SparseTensor<TFloat32> {
+  private static final class SparseTFloat32 extends FloatSparseNdArray
+      implements TFloat32, SparseTensor<TFloat32> {
 
     @Override
     public Class<TFloat32> type() {
@@ -101,6 +102,11 @@ public final class TFloat32Mapper extends TensorMapper<TFloat32> {
     @Override
     public void close() {
       tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
     }
 
     @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat64Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat64Mapper.java
@@ -17,11 +17,15 @@
 package org.tensorflow.internal.types;
 
 import org.tensorflow.RawTensor;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.TensorMapper;
 import org.tensorflow.internal.buffer.TensorBuffers;
 import org.tensorflow.ndarray.buffer.DoubleDataBuffer;
 import org.tensorflow.ndarray.impl.dense.DoubleDenseNdArray;
+import org.tensorflow.ndarray.impl.sparse.DoubleSparseNdArray;
+import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt64;
 
 /**
  * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_DOUBLE} tensors
@@ -35,11 +39,31 @@ public final class TFloat64Mapper extends TensorMapper<TFloat64> {
     return new DenseTFloat64(tensor, buffer);
   }
 
+  @Override
+  protected SparseTensor<TFloat64> mapSparse(TInt64 indices, TFloat64 values, TInt64 denseShape) {
+    return new SparseTFloat64(indices, values, denseShape);
+  }
+
   private static final class DenseTFloat64 extends DoubleDenseNdArray implements TFloat64 {
 
     @Override
     public Class<TFloat64> type() {
       return TFloat64.class;
+    }
+
+    @Override
+    public DataType dataType() {
+      return asRawTensor().dataType();
+    }
+
+    @Override
+    public long numBytes() {
+      return asRawTensor().numBytes();
+    }
+
+    @Override
+    public void close() {
+      asRawTensor().close();
     }
 
     @Override
@@ -53,5 +77,50 @@ public final class TFloat64Mapper extends TensorMapper<TFloat64> {
       super(buffer, rawTensor.shape());
       this.rawTensor = rawTensor;
     }
+  }
+
+  private static final class SparseTFloat64 extends DoubleSparseNdArray implements TFloat64, SparseTensor<TFloat64> {
+
+    @Override
+    public Class<TFloat64> type() {
+      return TFloat64.class;
+    }
+
+    @Override
+    public DataType dataType() {
+      return values().dataType();
+    }
+
+    @Override
+    public long numBytes() {
+      return SparseHelpers.numBytes(this);
+    }
+
+    @Override
+    public void close() {
+      // sparse tensors do not own the dense tensors that compose them, nothing to close
+    }
+
+    @Override
+    public TInt64 indices() {
+      return (TInt64) getIndices();
+    }
+
+    @Override
+    public TFloat64 values() {
+      return (TFloat64) getValues();
+    }
+
+    @Override
+    public TInt64 denseShape() {
+      return denseShape;
+    }
+
+    SparseTFloat64(TInt64 indices, TFloat64 values, TInt64 denseShape) {
+      super(indices, values, 0L, SparseHelpers.toDimensionalSpace(denseShape));
+      this.denseShape = denseShape;
+    }
+
+    private final TInt64 denseShape;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat64Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TFloat64Mapper.java
@@ -29,8 +29,8 @@ import org.tensorflow.types.TFloat64;
 import org.tensorflow.types.TInt64;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_DOUBLE} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_DOUBLE} tensors to a
+ * n-dimensional data space.
  */
 public final class TFloat64Mapper extends TensorMapper<TFloat64> {
 
@@ -41,8 +41,8 @@ public final class TFloat64Mapper extends TensorMapper<TFloat64> {
   }
 
   @Override
-  protected SparseTensor<TFloat64> mapSparse(TInt64 indices, TFloat64 values, TInt64 denseShape,
-      PointerScope tensorScope) {
+  protected SparseTensor<TFloat64> mapSparse(
+      TInt64 indices, TFloat64 values, TInt64 denseShape, PointerScope tensorScope) {
     return new SparseTFloat64(indices, values, denseShape, tensorScope);
   }
 
@@ -81,7 +81,8 @@ public final class TFloat64Mapper extends TensorMapper<TFloat64> {
     }
   }
 
-  private static final class SparseTFloat64 extends DoubleSparseNdArray implements TFloat64, SparseTensor<TFloat64> {
+  private static final class SparseTFloat64 extends DoubleSparseNdArray
+      implements TFloat64, SparseTensor<TFloat64> {
 
     @Override
     public Class<TFloat64> type() {
@@ -101,6 +102,11 @@ public final class TFloat64Mapper extends TensorMapper<TFloat64> {
     @Override
     public void close() {
       tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
     }
 
     @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TInt32Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TInt32Mapper.java
@@ -16,6 +16,7 @@
  */
 package org.tensorflow.internal.types;
 
+import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.RawTensor;
 import org.tensorflow.SparseTensor;
 import org.tensorflow.TensorMapper;
@@ -40,8 +41,8 @@ public final class TInt32Mapper extends TensorMapper<TInt32> {
   }
 
   @Override
-  protected SparseTensor<TInt32> mapSparse(TInt64 indices, TInt32 values, TInt64 denseShape) {
-    return new SparseTInt32(indices, values, denseShape);
+  protected SparseTensor<TInt32> mapSparse(TInt64 indices, TInt32 values, TInt64 denseShape, PointerScope tensorScope) {
+    return new SparseTInt32(indices, values, denseShape, tensorScope);
   }
 
   private static final class DenseTInt32 extends IntDenseNdArray implements TInt32 {
@@ -98,7 +99,7 @@ public final class TInt32Mapper extends TensorMapper<TInt32> {
 
     @Override
     public void close() {
-      // sparse tensors do not own the dense tensors that compose them, nothing to close
+      tensorScope.close();
     }
 
     @Override
@@ -116,11 +117,13 @@ public final class TInt32Mapper extends TensorMapper<TInt32> {
       return denseShape;
     }
 
-    SparseTInt32(TInt64 indices, TInt32 values, TInt64 denseShape) {
+    SparseTInt32(TInt64 indices, TInt32 values, TInt64 denseShape, PointerScope tensorScope) {
       super(indices, values, 0, SparseHelpers.toDimensionalSpace(denseShape));
       this.denseShape = denseShape;
+      this.tensorScope = tensorScope.extend();
     }
 
     private final TInt64 denseShape;
+    private final PointerScope tensorScope;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TInt32Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TInt32Mapper.java
@@ -29,8 +29,8 @@ import org.tensorflow.types.TInt32;
 import org.tensorflow.types.TInt64;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_INT32} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_INT32} tensors to a
+ * n-dimensional data space.
  */
 public final class TInt32Mapper extends TensorMapper<TInt32> {
 
@@ -41,7 +41,8 @@ public final class TInt32Mapper extends TensorMapper<TInt32> {
   }
 
   @Override
-  protected SparseTensor<TInt32> mapSparse(TInt64 indices, TInt32 values, TInt64 denseShape, PointerScope tensorScope) {
+  protected SparseTensor<TInt32> mapSparse(
+      TInt64 indices, TInt32 values, TInt64 denseShape, PointerScope tensorScope) {
     return new SparseTInt32(indices, values, denseShape, tensorScope);
   }
 
@@ -80,7 +81,8 @@ public final class TInt32Mapper extends TensorMapper<TInt32> {
     }
   }
 
-  private static final class SparseTInt32 extends IntSparseNdArray implements TInt32, SparseTensor<TInt32> {
+  private static final class SparseTInt32 extends IntSparseNdArray
+      implements TInt32, SparseTensor<TInt32> {
 
     @Override
     public Class<TInt32> type() {
@@ -100,6 +102,11 @@ public final class TInt32Mapper extends TensorMapper<TInt32> {
     @Override
     public void close() {
       tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
     }
 
     @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TInt64Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TInt64Mapper.java
@@ -16,6 +16,7 @@
  */
 package org.tensorflow.internal.types;
 
+import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.RawTensor;
 import org.tensorflow.SparseTensor;
 import org.tensorflow.TensorMapper;
@@ -39,8 +40,8 @@ public final class TInt64Mapper extends TensorMapper<TInt64> {
   }
 
   @Override
-  protected SparseTensor<TInt64> mapSparse(TInt64 indices, TInt64 values, TInt64 denseShape) {
-    return new TInt64Mapper.SparseTInt64(indices, values, denseShape);
+  protected SparseTensor<TInt64> mapSparse(TInt64 indices, TInt64 values, TInt64 denseShape, PointerScope tensorScope) {
+    return new TInt64Mapper.SparseTInt64(indices, values, denseShape, tensorScope);
   }
 
   private static final class DenseTInt64 extends LongDenseNdArray implements TInt64 {
@@ -97,7 +98,7 @@ public final class TInt64Mapper extends TensorMapper<TInt64> {
 
     @Override
     public void close() {
-      // sparse tensors do not own the dense tensors that compose them, nothing to close
+      tensorScope.close();
     }
 
     @Override
@@ -115,11 +116,13 @@ public final class TInt64Mapper extends TensorMapper<TInt64> {
       return denseShape;
     }
 
-    SparseTInt64(TInt64 indices, TInt64 values, TInt64 denseShape) {
+    SparseTInt64(TInt64 indices, TInt64 values, TInt64 denseShape, PointerScope tensorScope) {
       super(indices, values, 0L, SparseHelpers.toDimensionalSpace(denseShape));
       this.denseShape = denseShape;
+      this.tensorScope = tensorScope.extend();
     }
 
     private final TInt64 denseShape;
+    private final PointerScope tensorScope;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TInt64Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TInt64Mapper.java
@@ -28,8 +28,8 @@ import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.types.TInt64;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_INT64} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_INT64} tensors to a
+ * n-dimensional data space.
  */
 public final class TInt64Mapper extends TensorMapper<TInt64> {
 
@@ -40,7 +40,8 @@ public final class TInt64Mapper extends TensorMapper<TInt64> {
   }
 
   @Override
-  protected SparseTensor<TInt64> mapSparse(TInt64 indices, TInt64 values, TInt64 denseShape, PointerScope tensorScope) {
+  protected SparseTensor<TInt64> mapSparse(
+      TInt64 indices, TInt64 values, TInt64 denseShape, PointerScope tensorScope) {
     return new TInt64Mapper.SparseTInt64(indices, values, denseShape, tensorScope);
   }
 
@@ -79,7 +80,8 @@ public final class TInt64Mapper extends TensorMapper<TInt64> {
     }
   }
 
-  private static final class SparseTInt64 extends LongSparseNdArray implements TInt64, SparseTensor<TInt64> {
+  private static final class SparseTInt64 extends LongSparseNdArray
+      implements TInt64, SparseTensor<TInt64> {
 
     @Override
     public Class<TInt64> type() {
@@ -99,6 +101,11 @@ public final class TInt64Mapper extends TensorMapper<TInt64> {
     @Override
     public void close() {
       tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
     }
 
     @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TStringMapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TStringMapper.java
@@ -37,8 +37,8 @@ import org.tensorflow.types.TInt64;
 import org.tensorflow.types.TString;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_STRING} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_STRING} tensors to a
+ * n-dimensional data space.
  */
 public final class TStringMapper extends TensorMapper<TString> {
 
@@ -47,19 +47,18 @@ public final class TStringMapper extends TensorMapper<TString> {
 
   @Override
   protected TString mapDense(RawTensor tensor) {
-    ByteSequenceTensorBuffer buffer = TensorBuffers.toStrings(nativeHandle(tensor), tensor.shape().size());
+    ByteSequenceTensorBuffer buffer =
+        TensorBuffers.toStrings(nativeHandle(tensor), tensor.shape().size());
     return new DenseTString(tensor, buffer, UTF_8_LAYOUT);
   }
 
   @Override
-  protected SparseTensor<TString> mapSparse(TInt64 indices, TString values, TInt64 denseShape,
-      PointerScope tensorScope) {
+  protected SparseTensor<TString> mapSparse(
+      TInt64 indices, TString values, TInt64 denseShape, PointerScope tensorScope) {
     return new SparseTString(indices, values, denseShape, tensorScope);
   }
 
-  /**
-   * Adds package-private methods to all instances of {@code TString}
-   */
+  /** Adds package-private methods to all instances of {@code TString} */
   interface TStringInternal extends TString {
 
     /**
@@ -119,15 +118,15 @@ public final class TStringMapper extends TensorMapper<TString> {
     DenseTString(
         RawTensor rawTensor,
         ByteSequenceTensorBuffer buffer,
-        DataLayout<DataBuffer<byte[]>, String> layout
-    ) {
+        DataLayout<DataBuffer<byte[]>, String> layout) {
       super(layout.applyTo(buffer), rawTensor.shape());
       this.rawTensor = rawTensor;
       this.buffer = buffer;
     }
   }
 
-  private static final class SparseTString extends SparseNdArray<String, TString> implements TString, SparseTensor<TString> {
+  private static final class SparseTString extends SparseNdArray<String, TString>
+      implements TString, SparseTensor<TString> {
 
     @Override
     public Class<TString> type() {
@@ -150,6 +149,11 @@ public final class TStringMapper extends TensorMapper<TString> {
     }
 
     @Override
+    public boolean isSparse() {
+      return true;
+    }
+
+    @Override
     public TInt64 indices() {
       return (TInt64) getIndices();
     }
@@ -166,7 +170,8 @@ public final class TStringMapper extends TensorMapper<TString> {
 
     @Override
     public TString using(Charset charset) {
-      return new SparseTString(indices(), values().using(charset), denseShape(), tensorScope, false);
+      return new SparseTString(
+          indices(), values().using(charset), denseShape(), tensorScope, false);
     }
 
     @Override
@@ -178,7 +183,12 @@ public final class TStringMapper extends TensorMapper<TString> {
       this(indices, values, denseShape, tensorScope, true);
     }
 
-    private SparseTString(TInt64 indices, TString values, TInt64 denseShape, PointerScope tensorScope, boolean extendScope) {
+    private SparseTString(
+        TInt64 indices,
+        TString values,
+        TInt64 denseShape,
+        PointerScope tensorScope,
+        boolean extendScope) {
       super(String.class, indices, values, "", SparseHelpers.toDimensionalSpace(denseShape));
       this.denseShape = denseShape;
       this.tensorScope = extendScope ? tensorScope.extend() : tensorScope;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TUint8Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TUint8Mapper.java
@@ -29,8 +29,8 @@ import org.tensorflow.types.TInt64;
 import org.tensorflow.types.TUint8;
 
 /**
- * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_UINT8} tensors
- * to a n-dimensional data space.
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_UINT8} tensors to a
+ * n-dimensional data space.
  */
 public final class TUint8Mapper extends TensorMapper<TUint8> {
 
@@ -41,7 +41,8 @@ public final class TUint8Mapper extends TensorMapper<TUint8> {
   }
 
   @Override
-  protected SparseTensor<TUint8> mapSparse(TInt64 indices, TUint8 values, TInt64 denseShape, PointerScope tensorScope) {
+  protected SparseTensor<TUint8> mapSparse(
+      TInt64 indices, TUint8 values, TInt64 denseShape, PointerScope tensorScope) {
     return new TUint8Mapper.SparseTUint8(indices, values, denseShape, tensorScope);
   }
 
@@ -80,7 +81,8 @@ public final class TUint8Mapper extends TensorMapper<TUint8> {
     }
   }
 
-  private static final class SparseTUint8 extends ByteSparseNdArray implements TUint8, SparseTensor<TUint8> {
+  private static final class SparseTUint8 extends ByteSparseNdArray
+      implements TUint8, SparseTensor<TUint8> {
 
     @Override
     public Class<TUint8> type() {
@@ -100,6 +102,11 @@ public final class TUint8Mapper extends TensorMapper<TUint8> {
     @Override
     public void close() {
       tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
     }
 
     @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TUint8Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TUint8Mapper.java
@@ -16,6 +16,7 @@
  */
 package org.tensorflow.internal.types;
 
+import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.RawTensor;
 import org.tensorflow.SparseTensor;
 import org.tensorflow.TensorMapper;
@@ -40,8 +41,8 @@ public final class TUint8Mapper extends TensorMapper<TUint8> {
   }
 
   @Override
-  protected SparseTensor<TUint8> mapSparse(TInt64 indices, TUint8 values, TInt64 denseShape) {
-    return new TUint8Mapper.SparseTUint8(indices, values, denseShape);
+  protected SparseTensor<TUint8> mapSparse(TInt64 indices, TUint8 values, TInt64 denseShape, PointerScope tensorScope) {
+    return new TUint8Mapper.SparseTUint8(indices, values, denseShape, tensorScope);
   }
 
   private static final class DenseTUint8 extends ByteDenseNdArray implements TUint8 {
@@ -98,7 +99,7 @@ public final class TUint8Mapper extends TensorMapper<TUint8> {
 
     @Override
     public void close() {
-      // sparse tensors do not own the dense tensors that compose them, nothing to close
+      tensorScope.close();
     }
 
     @Override
@@ -116,11 +117,13 @@ public final class TUint8Mapper extends TensorMapper<TUint8> {
       return denseShape;
     }
 
-    SparseTUint8(TInt64 indices, TUint8 values, TInt64 denseShape) {
+    SparseTUint8(TInt64 indices, TUint8 values, TInt64 denseShape, PointerScope tensorScope) {
       super(indices, values, (byte) 0, SparseHelpers.toDimensionalSpace(denseShape));
       this.denseShape = denseShape;
+      this.tensorScope = tensorScope.extend();
     }
 
     private final TInt64 denseShape;
+    private final PointerScope tensorScope;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
@@ -127,15 +127,16 @@ public interface TBfloat16 extends FloatNdArray, TFloating {
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
   static TBfloat16 sparseTensorOf(TInt64 indices, TBfloat16 values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
@@ -18,6 +18,7 @@
 package org.tensorflow.types;
 
 import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TBfloat16Mapper;
@@ -40,7 +41,7 @@ import org.tensorflow.types.family.TFloating;
  * <p>Since there is no floating-point type that fits in 16 bits in Java, a conversion (with
  * potentially a precision loss) is required for each 32 bits value written or read on a tensor of
  * this type from the JVM. Therefore, if a lot of I/O operations are to be expected on a tensor,
- * performances will be improved by working with {@link TFloat32} or {@link TFloat64} data types
+ * performances will be improved by working with {@link TFloat32} or {@link TBfloat16} data types
  * whenever possible.
  *
  * <p>Note that some CPUs support the bfloat16 format natively, which can result in faster
@@ -115,6 +116,29 @@ public interface TBfloat16 extends FloatNdArray, TFloating {
    */
   static TBfloat16 tensorOf(Shape shape, Consumer<TBfloat16> dataInit) {
     return Tensor.of(TBfloat16.class, shape, dataInit);
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of zero.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TBfloat16>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TBfloat16 sparseTensorOf(TInt64 indices, TBfloat16 values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
@@ -70,7 +70,8 @@ public interface TBfloat16 extends FloatNdArray, TFloating {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(TBfloat16.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
+    return Tensor.of(
+        TBfloat16.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**
@@ -119,20 +120,20 @@ public interface TBfloat16 extends FloatNdArray, TFloating {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of zero.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of zero.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TBfloat16>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TBfloat16>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
-   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
-   *     {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value
+   *     of {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
    *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
@@ -142,4 +143,3 @@ public interface TBfloat16 extends FloatNdArray, TFloating {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }
-

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
@@ -18,6 +18,7 @@
 package org.tensorflow.types;
 
 import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TBoolMapper;
@@ -107,5 +108,28 @@ public interface TBool extends BooleanNdArray, TType {
    */
   static TBool tensorOf(Shape shape, Consumer<TBool> dataInit) {
     return Tensor.of(TBool.class, shape, dataInit);
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of {@code false}.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TBool>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[true, true]} specifies that both elements at {@code [1,3]} and {@code [2,3]} of the
+   *     sparse tensor have a value of {@code true}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TBool sparseTensorOf(TInt64 indices, TBool values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
@@ -119,15 +119,16 @@ public interface TBool extends BooleanNdArray, TType {
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[true, true]} specifies that both elements at {@code [1,3]} and {@code [2,3]} of the
-   *     sparse tensor have a value of {@code true}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[true, true]} specifies that element {@code [1,3,1]} and element {@code [2,4,0]} of the
+   *     tensor have a value of {@code true}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
   static TBool sparseTensorOf(TInt64 indices, TBool values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
@@ -111,20 +111,20 @@ public interface TBool extends BooleanNdArray, TType {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of {@code false}.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of {@code false}.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TBool>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TBool>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
-   *     values=[true, true]} specifies that element {@code [1,3,1]} and element {@code [2,4,0]} of the
-   *     tensor have a value of {@code true}.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[true, true]} specifies that element {@code [1,3,1]} and element {@code [2,4,0]} of
+   *     the tensor have a value of {@code true}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
    *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
@@ -124,15 +124,16 @@ public interface TFloat16 extends FloatNdArray, TFloating {
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
   static TFloat16 sparseTensorOf(TInt64 indices, TFloat16 values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
@@ -18,6 +18,7 @@
 package org.tensorflow.types;
 
 import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TFloat16Mapper;
@@ -36,7 +37,7 @@ import org.tensorflow.types.family.TFloating;
  * <p>Since there is no floating-point type that fits in 16 bits in Java, a conversion (with
  * potentially a precision loss) is required for each 32 bits value written or read on a tensor of
  * this type from the JVM. Therefore, if a lot of I/O operations are to be expected on a tensor,
- * performances will be improved by working with {@link TFloat32} or {@link TFloat64} data types
+ * performances will be improved by working with {@link TFloat32} or {@link TFloat16} data types
  * whenever possible.
  *
  * <p>Also, {@code TFloat16} tensors normally perform better if they are located in GPU memory since
@@ -112,5 +113,28 @@ public interface TFloat16 extends FloatNdArray, TFloating {
    */
   static TFloat16 tensorOf(Shape shape, Consumer<TFloat16> dataInit) {
     return Tensor.of(TFloat16.class, shape, dataInit);
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of zero.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TFloat16>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TFloat16 sparseTensorOf(TInt64 indices, TFloat16 values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
@@ -67,7 +67,8 @@ public interface TFloat16 extends FloatNdArray, TFloating {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(TFloat16.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
+    return Tensor.of(
+        TFloat16.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**
@@ -116,20 +117,20 @@ public interface TFloat16 extends FloatNdArray, TFloating {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of zero.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of zero.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TFloat16>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TFloat16>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
-   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
-   *     {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value
+   *     of {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
    *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
@@ -18,6 +18,7 @@
 package org.tensorflow.types;
 
 import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TFloat32Mapper;
@@ -100,5 +101,28 @@ public interface TFloat32 extends FloatNdArray, TFloating {
    */
   static TFloat32 tensorOf(Shape shape, Consumer<TFloat32> dataInit) {
     return Tensor.of(TFloat32.class, shape, dataInit);
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of zero.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TFloat16>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TFloat16 sparseTensorOf(TInt64 indices, TFloat16 values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
@@ -107,22 +107,23 @@ public interface TFloat32 extends FloatNdArray, TFloating {
    * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
    * a default value of zero.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TFloat16>} interface, allowing
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TFloat32>} interface, allowing
    * a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
-  static TFloat16 sparseTensorOf(TInt64 indices, TFloat16 values, TInt64 denseShape) {
+  static TFloat32 sparseTensorOf(TInt64 indices, TFloat32 values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
@@ -55,7 +55,8 @@ public interface TFloat32 extends FloatNdArray, TFloating {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(TFloat32.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
+    return Tensor.of(
+        TFloat32.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**
@@ -104,20 +105,20 @@ public interface TFloat32 extends FloatNdArray, TFloating {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of zero.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of zero.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TFloat32>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TFloat32>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
-   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
-   *     {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18f, 3.8f]} specifies that element {@code [1,3,1]} of the sparse tensor has a value
+   *     of {@code 18f}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8f}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
    *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
@@ -31,7 +31,6 @@ import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.types.annotation.TensorType;
 import org.tensorflow.types.family.TFloating;
 
-
 /** IEEE-754 double-precision 64-bit float tensor type. */
 @TensorType(dataType = DataType.DT_DOUBLE, byteSize = 8, mapperClass = TFloat64Mapper.class)
 public interface TFloat64 extends DoubleNdArray, TFloating {
@@ -56,7 +55,8 @@ public interface TFloat64 extends DoubleNdArray, TFloating {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(TFloat64.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
+    return Tensor.of(
+        TFloat64.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**
@@ -105,20 +105,20 @@ public interface TFloat64 extends DoubleNdArray, TFloating {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of zero.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of zero.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TFloat64>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TFloat64>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
-   *     values=[18, 3.8]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8}.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3,1]} of the sparse tensor has a value
+   *     of {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
    *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
@@ -18,6 +18,7 @@
 package org.tensorflow.types;
 
 import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TFloat64Mapper;
@@ -101,5 +102,28 @@ public interface TFloat64 extends DoubleNdArray, TFloating {
    */
   static TFloat64 tensorOf(Shape shape, Consumer<TFloat64> dataInit) {
     return Tensor.of(TFloat64.class, shape, dataInit);
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of zero.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TFloat64>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TFloat64 sparseTensorOf(TInt64 indices, TFloat64 values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
@@ -113,15 +113,16 @@ public interface TFloat64 extends DoubleNdArray, TFloating {
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3.8}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
   static TFloat64 sparseTensorOf(TInt64 indices, TFloat64 values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
@@ -18,6 +18,7 @@
 package org.tensorflow.types;
 
 import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.internal.types.TInt32Mapper;
 import org.tensorflow.ndarray.IntNdArray;
@@ -100,5 +101,27 @@ public interface TInt32 extends IntNdArray, TIntegral {
   static TInt32 tensorOf(Shape shape, Consumer<TInt32> dataInit) {
     return Tensor.of(TInt32.class, shape, dataInit);
   }
-}
 
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of zero.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TInt32>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TInt32 sparseTensorOf(TInt64 indices, TInt32 values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
@@ -111,15 +111,16 @@ public interface TInt32 extends IntNdArray, TIntegral {
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3]} specifies that element {@code [1,3]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18, 3]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
   static TInt32 sparseTensorOf(TInt64 indices, TInt32 values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
@@ -103,18 +103,18 @@ public interface TInt32 extends IntNdArray, TIntegral {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of zero.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of zero.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TInt32>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TInt32>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
    *     values=[18, 3]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
    *     {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
@@ -18,6 +18,7 @@
 package org.tensorflow.types;
 
 import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TInt64Mapper;
@@ -100,5 +101,28 @@ public interface TInt64 extends LongNdArray, TIntegral {
    */
   static TInt64 tensorOf(Shape shape, Consumer<TInt64> dataInit) {
     return Tensor.of(TInt64.class, shape, dataInit);
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of zero.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TInt64>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TInt64 sparseTensorOf(TInt64 indices, TInt64 values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
@@ -104,20 +104,20 @@ public interface TInt64 extends LongNdArray, TIntegral {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of zero.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of zero.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TInt64>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TInt64>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
-   *     values=[18L, 3L]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
-   *     {@code 18L}, and element {@code [2,4,0]} of the tensor has a value of {@code 3L}.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18L, 3L]} specifies that element {@code [1,3,1]} of the sparse tensor has a value
+   *     of {@code 18L}, and element {@code [2,4,0]} of the tensor has a value of {@code 3L}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
    *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
@@ -112,15 +112,16 @@ public interface TInt64 extends LongNdArray, TIntegral {
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3]} specifies that element {@code [1,3]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18L, 3L]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code 18L}, and element {@code [2,4,0]} of the tensor has a value of {@code 3L}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
   static TInt64 sparseTensorOf(TInt64 indices, TInt64 values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
@@ -20,6 +20,7 @@ package org.tensorflow.types;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.internal.types.TStringInitializer;
 import org.tensorflow.internal.types.TStringMapper;
@@ -188,6 +189,29 @@ public interface TString extends NdArray<String>, TType {
    */
   static TString tensorOfBytes(Shape shape, DataBuffer<byte[]> data) {
     return tensorOfBytes(NdArrays.wrap(shape, data));
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of null.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TString>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TString sparseTensorOf(TInt64 indices, TString values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
@@ -193,22 +193,23 @@ public interface TString extends NdArray<String>, TType {
 
   /**
    * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of null.
+   * an empty string as the default value.
    *
    * The returned instance also implements the {@link SparseTensor SparseTensor<TString>} interface, allowing
    * a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.8]} specifies that element {@code [1,3]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3.8}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=["one", "two"]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code "one"}, and element {@code [2,4,0]} of the tensor has a value of {@code "two"}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
   static TString sparseTensorOf(TInt64 indices, TString values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
@@ -106,7 +106,8 @@ public interface TString extends NdArray<String>, TType {
    * @return the new tensor
    */
   static TString tensorOf(Charset charset, NdArray<String> src) {
-    TStringInitializer<String> initializer = new TStringInitializer<>(src, s -> s.getBytes(charset));
+    TStringInitializer<String> initializer =
+        new TStringInitializer<>(src, s -> s.getBytes(charset));
     return Tensor.of(TString.class, src.shape(), initializer.computeRequiredSize(), initializer);
   }
 
@@ -192,20 +193,21 @@ public interface TString extends NdArray<String>, TType {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * an empty string as the default value.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with an empty string as the default value.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TString>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TString>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
-   *     values=["one", "two"]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
-   *     {@code "one"}, and element {@code [2,4,0]} of the tensor has a value of {@code "two"}.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=["one", "two"]} specifies that element {@code [1,3,1]} of the sparse tensor has a
+   *     value of {@code "one"}, and element {@code [2,4,0]} of the tensor has a value of {@code
+   *     "two"}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
    *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
@@ -104,18 +104,18 @@ public interface TUint8 extends ByteNdArray, TIntegral {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
-   * a default value of zero.
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of zero.
    *
-   * The returned instance also implements the {@link SparseTensor SparseTensor<TUint8>} interface, allowing
-   * a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TUint8>}
+   * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
    *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
    *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
-   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
    *     values=[18, 3]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
    *     {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
@@ -18,6 +18,7 @@
 package org.tensorflow.types;
 
 import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TUint8Mapper;
@@ -100,5 +101,28 @@ public interface TUint8 extends ByteNdArray, TIntegral {
    */
   static TUint8 tensorOf(Shape shape, Consumer<TUint8> dataInit) {
     return Tensor.of(TUint8.class, shape, dataInit);
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense tensors, with
+   * a default value of zero.
+   *
+   * The returned instance also implements the {@link SparseTensor SparseTensor<TUint8>} interface, allowing
+   * a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3]} specifies that element {@code [1,3]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   */
+  static TUint8 sparseTensorOf(TInt64 indices, TUint8 values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
@@ -112,15 +112,16 @@ public interface TUint8 extends ByteNdArray, TIntegral {
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
    * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3]} specifies that element {@code [1,3]} of the sparse tensor has a value of
-   *     {@code 18}, and element {@code [2,4]} of the tensor has a value of {@code 3}.
+   *     element in indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18, 3]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3}.
    * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
-   *     represents to total number of element in dimension {@code i} in a dense version of that tensor.
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
    * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
    */
   static TUint8 sparseTensorOf(TInt64 indices, TUint8 values, TInt64 denseShape) {
     return SparseTensor.of(indices, values, denseShape).asTypedTensor();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/family/TType.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/family/TType.java
@@ -23,11 +23,11 @@ import org.tensorflow.Tensor;
  * Common interface for all typed tensors.
  *
  * <p>Typed tensors wrap a {@link org.tensorflow.RawTensor RawTensor} by mapping their native memory
- * to a n-dimensional data space allowing direct I/O access from the JVM.</p>
+ * to a n-dimensional data space allowing direct I/O access from the JVM.
  *
  * <p>Subinterfaces of {@code TType} are propagated as a generic parameter to various entities of
- * TensorFlow to identify the type of the tensor they carry. For example, a
- * {@link org.tensorflow.Operand Operand&lt;TFloat32&gt;} is an operand which outputs a 32-bit floating
+ * TensorFlow to identify the type of the tensor they carry. For example, a {@link
+ * org.tensorflow.Operand Operand&lt;TFloat32&gt;} is an operand which outputs a 32-bit floating
  * point tensor. This parameter ensure type-compatibility between operands of a computation at
  * compile-time. For example:
  *
@@ -42,26 +42,24 @@ import org.tensorflow.Tensor;
  * tf.math.add(c1, c3);  // Compilation failure
  * }</pre>
  *
- * <p>Even if all typed tensors implements somehow {@link org.tensorflow.ndarray.NdArray NdArray}
- * to provide access to their data, {@code TType} deliberately does not extend directly from this
+ * <p>Even if all typed tensors implements somehow {@link org.tensorflow.ndarray.NdArray NdArray} to
+ * provide access to their data, {@code TType} deliberately does not extend directly from this
  * interface, for the following reasons:
+ *
  * <ul>
  *   <li>Implementing {@code NdArray} at this level could only expose boxed-type accessors, which
- *   are less performant than their primitive equivalent, only exposed by subinterfaces of
- *   {@code NdArray} (e.g. {@code FloatNdArray}).
- *   </li>
+ *       are less performant than their primitive equivalent, only exposed by subinterfaces of
+ *       {@code NdArray} (e.g. {@code FloatNdArray}).
  *   <li>{@code TType} would need to carry a new generic parameter for typing the {@code NdArray},
- *   which will increase the verbosity in the signature of any method accepting or returning
- *   an instance of this interface, which is very common.
- *   </li>
+ *       which will increase the verbosity in the signature of any method accepting or returning an
+ *       instance of this interface, which is very common.
  * </ul>
- * Therefore, enforcing the user to cast a reference of {@code TType} in a concrete tensor type before
- * accessing its data guarantees better performance and improves readability.
+ *
+ * Therefore, enforcing the user to cast a reference of {@code TType} in a concrete tensor type
+ * before accessing its data guarantees better performance and improves readability.
  */
 public interface TType extends Tensor {
 
-  /**
-   * Returns the type of this tensor as a registered subclass of {@code TType}
-   */
+  /** Returns the type of this tensor as a registered subclass of {@code TType} */
   Class<? extends TType> type();
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/family/TType.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/family/TType.java
@@ -18,7 +18,6 @@
 package org.tensorflow.types.family;
 
 import org.tensorflow.Tensor;
-import org.tensorflow.proto.framework.DataType;
 
 /**
  * Common interface for all typed tensors.
@@ -65,19 +64,4 @@ public interface TType extends Tensor {
    * Returns the type of this tensor as a registered subclass of {@code TType}
    */
   Class<? extends TType> type();
-
-  @Override
-  default DataType dataType() {
-    return asRawTensor().dataType();
-  }
-
-  @Override
-  default long numBytes() {
-    return asRawTensor().numBytes();
-  }
-
-  @Override
-  default void close() {
-    asRawTensor().close();
-  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SparseTensorTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SparseTensorTest.java
@@ -38,9 +38,7 @@ public class SparseTensorTest {
 
   @Test
   public void createSparseTensor() {
-    long[][] indicesArray = new long[][]{
-        {0, 0, 3}, {0, 2, 3}, {1, 0, 0}, {2, 2, 1}
-    };
+    long[][] indicesArray = new long[][] {{0, 0, 3}, {0, 2, 3}, {1, 0, 0}, {2, 2, 1}};
     try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(indicesArray));
         TFloat64 values = TFloat64.vectorOf(10.0, 20.0, 30.0, 40.0);
         TInt64 denseShape = TInt64.vectorOf(3, 3, 4);
@@ -49,19 +47,22 @@ public class SparseTensorTest {
       assertNotNull(tensor);
       assertEquals(Shape.of(3, 3, 4), tensor.shape());
 
-      tensor.scalars().forEachIndexed((coords, scalar) -> {
-        if (Arrays.equals(coords, indicesArray[0])) {
-          assertEquals(10.0, scalar.getDouble());
-        } else if (Arrays.equals(coords, indicesArray[1])) {
-          assertEquals(20.0, scalar.getDouble());
-        } else if (Arrays.equals(coords, indicesArray[2])) {
-          assertEquals(30.0, scalar.getDouble());
-        } else if (Arrays.equals(coords, indicesArray[3])) {
-          assertEquals(40.0, scalar.getDouble());
-        } else {
-          assertEquals(0.0, scalar.getDouble());
-        }
-      });
+      tensor
+          .scalars()
+          .forEachIndexed(
+              (coords, scalar) -> {
+                if (Arrays.equals(coords, indicesArray[0])) {
+                  assertEquals(10.0, scalar.getDouble());
+                } else if (Arrays.equals(coords, indicesArray[1])) {
+                  assertEquals(20.0, scalar.getDouble());
+                } else if (Arrays.equals(coords, indicesArray[2])) {
+                  assertEquals(30.0, scalar.getDouble());
+                } else if (Arrays.equals(coords, indicesArray[3])) {
+                  assertEquals(40.0, scalar.getDouble());
+                } else {
+                  assertEquals(0.0, scalar.getDouble());
+                }
+              });
 
       assertTrue(SparseTensor.class.isAssignableFrom(tensor.getClass()));
       SparseTensor<TFloat64> sparseTensor = (SparseTensor<TFloat64>) tensor;
@@ -74,9 +75,8 @@ public class SparseTensorTest {
   @Test
   public void splitSparseTensor() {
     Ops tf = Ops.create();
-    LongNdArray indicesArray = StdArrays.ndCopyOf(new long[][]{
-        {0, 0}, {0, 2}, {1, 0}, {1, 1}, {1, 3}, {2, 2}
-    });
+    LongNdArray indicesArray =
+        StdArrays.ndCopyOf(new long[][] {{0, 0}, {0, 2}, {1, 0}, {1, 1}, {1, 3}, {2, 2}});
     try (TInt64 indices = TInt64.tensorOf(indicesArray);
         TFloat64 values = TFloat64.vectorOf(10.0, 20.0, 30.0, 40.0, 50.0, 60.0);
         TInt64 dimensions = TInt64.vectorOf(3, 4);
@@ -85,13 +85,13 @@ public class SparseTensorTest {
       // [10.0   0.0  20.0   0.0]        [10.0   0.0]     [20.0   0.0]
       // [30.0  40.0   0.0  50.0]   ==>  [30.0  40.0]  +  [ 0.0  50.0]
       // [ 0.0   0.0  60.0   0.0]        [ 0.0   0.0]     [60.0   0.0]
-      SparseSplit<TFloat64> split = tf.sparse.sparseSplit(
-          tf.constant(1L),
-          tf.constant(sparseTensor.indices()),
-          tf.constant(sparseTensor.values()),
-          tf.constant(sparseTensor.denseShape()),
-          2L
-      );
+      SparseSplit<TFloat64> split =
+          tf.sparse.sparseSplit(
+              tf.constant(1L),
+              tf.constant(sparseTensor.indices()),
+              tf.constant(sparseTensor.values()),
+              tf.constant(sparseTensor.denseShape()),
+              2L);
       List<Output<TInt64>> splitIndices = split.outputIndices();
       List<Output<TFloat64>> splitValues = split.outputValues();
       List<Output<TInt64>> splitDenseShape = split.outputShape();
@@ -100,21 +100,23 @@ public class SparseTensorTest {
       assertEquals(2, splitValues.size());
       assertEquals(2, splitDenseShape.size());
 
-      SparseTensor<TFloat64> sparsePart1 = SparseTensor.of(
-          splitIndices.get(0).asTensor(),
-          splitValues.get(0).asTensor(),
-          splitDenseShape.get(0).asTensor()
-      );
-      assertEquals(StdArrays.ndCopyOf(new long[][]{{0, 0}, {1, 0}, {1, 1}}), sparsePart1.indices());
+      SparseTensor<TFloat64> sparsePart1 =
+          SparseTensor.of(
+              splitIndices.get(0).asTensor(),
+              splitValues.get(0).asTensor(),
+              splitDenseShape.get(0).asTensor());
+      assertEquals(
+          StdArrays.ndCopyOf(new long[][] {{0, 0}, {1, 0}, {1, 1}}), sparsePart1.indices());
       assertEquals(NdArrays.vectorOf(10.0, 30.0, 40.0), sparsePart1.values());
       assertEquals(NdArrays.vectorOf(3L, 2L), sparsePart1.denseShape());
 
-      SparseTensor<TFloat64> sparsePart2 = SparseTensor.of(
-          splitIndices.get(1).asTensor(),
-          splitValues.get(1).asTensor(),
-          splitDenseShape.get(1).asTensor()
-      );
-      assertEquals(StdArrays.ndCopyOf(new long[][]{{0, 0}, {1, 1}, {2, 0}}), sparsePart2.indices());
+      SparseTensor<TFloat64> sparsePart2 =
+          SparseTensor.of(
+              splitIndices.get(1).asTensor(),
+              splitValues.get(1).asTensor(),
+              splitDenseShape.get(1).asTensor());
+      assertEquals(
+          StdArrays.ndCopyOf(new long[][] {{0, 0}, {1, 1}, {2, 0}}), sparsePart2.indices());
       assertEquals(NdArrays.vectorOf(20.0, 50.0, 60.0), sparsePart2.values());
       assertEquals(NdArrays.vectorOf(3L, 2L), sparsePart2.denseShape());
     }
@@ -124,7 +126,7 @@ public class SparseTensorTest {
   void releaseSparseTensorBeforeTensors() {
     TensorState state = null;
 
-    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][]{{3}, {6}, {9}}));
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][] {{3}, {6}, {9}}));
         TFloat64 values = TFloat64.vectorOf(30.0, 60.0, 90.0);
         TInt64 denseShape = TInt64.vectorOf(10);
         TFloat64 sparseTensor = TFloat64.sparseTensorOf(indices, values, denseShape)) {
@@ -133,7 +135,7 @@ public class SparseTensorTest {
     }
     assertTrue(state.isClosed());
 
-    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][]{{3}, {6}, {9}}));
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][] {{3}, {6}, {9}}));
         TFloat64 values = TFloat64.vectorOf(30.0, 60.0, 90.0);
         TInt64 denseShape = TInt64.vectorOf(10)) {
       try (TFloat64 sparseTensor = TFloat64.sparseTensorOf(indices, values, denseShape)) {
@@ -156,7 +158,7 @@ public class SparseTensorTest {
     assertTrue(state.isClosed());
 
     TFloat64 sparseTensor;
-    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][]{{3}, {6}, {9}}));
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][] {{3}, {6}, {9}}));
         TFloat64 values = TFloat64.vectorOf(30.0, 60.0, 90.0);
         TInt64 denseShape = TInt64.vectorOf(10)) {
       sparseTensor = TFloat64.sparseTensorOf(indices, values, denseShape);
@@ -169,14 +171,14 @@ public class SparseTensorTest {
   }
 
   private TFloat64 createSparseTensorForTest() {
-    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][]{{3}, {6}, {9}}));
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][] {{3}, {6}, {9}}));
         TFloat64 values = TFloat64.vectorOf(30.0, 60.0, 90.0);
         TInt64 denseShape = TInt64.vectorOf(10)) {
       return TFloat64.sparseTensorOf(indices, values, denseShape);
     }
   }
 
-  private final static class TensorState {
+  private static final class TensorState {
 
     <T extends TType> TensorState(TFloat64 tensor) {
       SparseTensor<TFloat64> sparseTensor = (SparseTensor<TFloat64>) tensor;

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SparseTensorTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SparseTensorTest.java
@@ -1,0 +1,101 @@
+package org.tensorflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.tensorflow.ndarray.NdArrays;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.StdArrays;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.sparse.SparseSplit;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt64;
+
+public class SparseTensorTest {
+
+  @Test
+  public void createSparseTensor() {
+    long[][] indicesArray = new long[][] {
+        {0, 0, 3}, {0, 2, 3}, {1, 0, 0}, {2, 2, 1}
+    };
+    TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(indicesArray));
+    TFloat64 values = TFloat64.vectorOf(10.0, 20.0, 30.0, 40.0);
+    TInt64 denseShape = TInt64.vectorOf(3, 3, 4);
+
+    TFloat64 tensor = TFloat64.sparseTensorOf(indices, values, denseShape);
+    assertNotNull(tensor);
+    assertEquals(Shape.of(3, 3, 4), tensor.shape());
+
+    tensor.scalars().forEachIndexed((coords, scalar) -> {
+      if (Arrays.equals(coords, indicesArray[0])) {
+        assertEquals(10.0, scalar.getDouble());
+      } else if (Arrays.equals(coords, indicesArray[1])) {
+        assertEquals(20.0, scalar.getDouble());
+      } else if (Arrays.equals(coords, indicesArray[2])) {
+        assertEquals(30.0, scalar.getDouble());
+      } else if (Arrays.equals(coords, indicesArray[3])) {
+        assertEquals(40.0, scalar.getDouble());
+      } else {
+        assertEquals(0.0, scalar.getDouble());
+      }
+    });
+
+    assertTrue(SparseTensor.class.isAssignableFrom(tensor.getClass()));
+    SparseTensor<TFloat64> sparseTensor = (SparseTensor<TFloat64>) tensor;
+    assertEquals(indices, sparseTensor.indices());
+    assertEquals(values, sparseTensor.values());
+    assertEquals(denseShape, sparseTensor.denseShape());
+  }
+
+  @Test
+  public void splitSparseTensor() {
+    Ops tf = Ops.create();
+    TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][] {
+        {0, 0}, {0, 2}, {1, 0}, {1, 1}, {1, 3}, {2, 2}
+    }));
+    TFloat64 values = TFloat64.vectorOf(10.0, 20.0, 30.0, 40.0, 50.0, 60.0);
+    TInt64 dimensions = TInt64.vectorOf(3, 4);
+
+    SparseTensor<TFloat64> sparseTensor = SparseTensor.of(indices, values, dimensions);
+
+    // [10.0   0.0  20.0   0.0]        [10.0   0.0]     [20.0   0.0]
+    // [30.0  40.0   0.0  50.0]   ==>  [30.0  40.0]  +  [ 0.0  50.0]
+    // [ 0.0   0.0  60.0   0.0]        [ 0.0   0.0]     [60.0   0.0]
+    SparseSplit<TFloat64> split = tf.sparse.sparseSplit(
+        tf.constant(1L),
+        tf.constant(sparseTensor.indices()),
+        tf.constant(sparseTensor.values()),
+        tf.constant(sparseTensor.denseShape()),
+        2L
+    );
+    List<Output<TInt64>> splitIndices = split.outputIndices();
+    List<Output<TFloat64>> splitValues = split.outputValues();
+    List<Output<TInt64>> splitDenseShape = split.outputShape();
+
+    assertEquals(2, splitIndices.size());
+    assertEquals(2, splitValues.size());
+    assertEquals(2, splitDenseShape.size());
+
+    SparseTensor<TFloat64> sparsePart1 = SparseTensor.of(
+        splitIndices.get(0).asTensor(),
+        splitValues.get(0).asTensor(),
+        splitDenseShape.get(0).asTensor()
+    );
+    assertEquals(StdArrays.ndCopyOf(new long[][] {{0, 0}, {1, 0}, {1, 1}}), sparsePart1.indices());
+    assertEquals(NdArrays.vectorOf(10.0, 30.0, 40.0), sparsePart1.values());
+    assertEquals(NdArrays.vectorOf(3L, 2L), sparsePart1.denseShape());
+
+    SparseTensor<TFloat64> sparsePart2 = SparseTensor.of(
+        splitIndices.get(1).asTensor(),
+        splitValues.get(1).asTensor(),
+        splitDenseShape.get(1).asTensor()
+    );
+    assertEquals(StdArrays.ndCopyOf(new long[][] {{0, 0}, {1, 1}, {2, 0}}), sparsePart2.indices());
+    assertEquals(NdArrays.vectorOf(20.0, 50.0, 60.0), sparsePart2.values());
+    assertEquals(NdArrays.vectorOf(3L, 2L), sparsePart2.denseShape());
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SparseTensorTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SparseTensorTest.java
@@ -1,12 +1,30 @@
+/*
+ *  Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  =======================================================================
+ */
 package org.tensorflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.tensorflow.ndarray.LongNdArray;
 import org.tensorflow.ndarray.NdArrays;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.StdArrays;
@@ -14,88 +32,174 @@ import org.tensorflow.op.Ops;
 import org.tensorflow.op.sparse.SparseSplit;
 import org.tensorflow.types.TFloat64;
 import org.tensorflow.types.TInt64;
+import org.tensorflow.types.family.TType;
 
 public class SparseTensorTest {
 
   @Test
   public void createSparseTensor() {
-    long[][] indicesArray = new long[][] {
+    long[][] indicesArray = new long[][]{
         {0, 0, 3}, {0, 2, 3}, {1, 0, 0}, {2, 2, 1}
     };
-    TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(indicesArray));
-    TFloat64 values = TFloat64.vectorOf(10.0, 20.0, 30.0, 40.0);
-    TInt64 denseShape = TInt64.vectorOf(3, 3, 4);
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(indicesArray));
+        TFloat64 values = TFloat64.vectorOf(10.0, 20.0, 30.0, 40.0);
+        TInt64 denseShape = TInt64.vectorOf(3, 3, 4);
+        TFloat64 tensor = TFloat64.sparseTensorOf(indices, values, denseShape)) {
 
-    TFloat64 tensor = TFloat64.sparseTensorOf(indices, values, denseShape);
-    assertNotNull(tensor);
-    assertEquals(Shape.of(3, 3, 4), tensor.shape());
+      assertNotNull(tensor);
+      assertEquals(Shape.of(3, 3, 4), tensor.shape());
 
-    tensor.scalars().forEachIndexed((coords, scalar) -> {
-      if (Arrays.equals(coords, indicesArray[0])) {
-        assertEquals(10.0, scalar.getDouble());
-      } else if (Arrays.equals(coords, indicesArray[1])) {
-        assertEquals(20.0, scalar.getDouble());
-      } else if (Arrays.equals(coords, indicesArray[2])) {
-        assertEquals(30.0, scalar.getDouble());
-      } else if (Arrays.equals(coords, indicesArray[3])) {
-        assertEquals(40.0, scalar.getDouble());
-      } else {
-        assertEquals(0.0, scalar.getDouble());
-      }
-    });
+      tensor.scalars().forEachIndexed((coords, scalar) -> {
+        if (Arrays.equals(coords, indicesArray[0])) {
+          assertEquals(10.0, scalar.getDouble());
+        } else if (Arrays.equals(coords, indicesArray[1])) {
+          assertEquals(20.0, scalar.getDouble());
+        } else if (Arrays.equals(coords, indicesArray[2])) {
+          assertEquals(30.0, scalar.getDouble());
+        } else if (Arrays.equals(coords, indicesArray[3])) {
+          assertEquals(40.0, scalar.getDouble());
+        } else {
+          assertEquals(0.0, scalar.getDouble());
+        }
+      });
 
-    assertTrue(SparseTensor.class.isAssignableFrom(tensor.getClass()));
-    SparseTensor<TFloat64> sparseTensor = (SparseTensor<TFloat64>) tensor;
-    assertEquals(indices, sparseTensor.indices());
-    assertEquals(values, sparseTensor.values());
-    assertEquals(denseShape, sparseTensor.denseShape());
+      assertTrue(SparseTensor.class.isAssignableFrom(tensor.getClass()));
+      SparseTensor<TFloat64> sparseTensor = (SparseTensor<TFloat64>) tensor;
+      assertEquals(indices, sparseTensor.indices());
+      assertEquals(values, sparseTensor.values());
+      assertEquals(denseShape, sparseTensor.denseShape());
+    }
   }
 
   @Test
   public void splitSparseTensor() {
     Ops tf = Ops.create();
-    TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][] {
+    LongNdArray indicesArray = StdArrays.ndCopyOf(new long[][]{
         {0, 0}, {0, 2}, {1, 0}, {1, 1}, {1, 3}, {2, 2}
-    }));
-    TFloat64 values = TFloat64.vectorOf(10.0, 20.0, 30.0, 40.0, 50.0, 60.0);
-    TInt64 dimensions = TInt64.vectorOf(3, 4);
+    });
+    try (TInt64 indices = TInt64.tensorOf(indicesArray);
+        TFloat64 values = TFloat64.vectorOf(10.0, 20.0, 30.0, 40.0, 50.0, 60.0);
+        TInt64 dimensions = TInt64.vectorOf(3, 4);
+        SparseTensor<TFloat64> sparseTensor = SparseTensor.of(indices, values, dimensions)) {
 
-    SparseTensor<TFloat64> sparseTensor = SparseTensor.of(indices, values, dimensions);
+      // [10.0   0.0  20.0   0.0]        [10.0   0.0]     [20.0   0.0]
+      // [30.0  40.0   0.0  50.0]   ==>  [30.0  40.0]  +  [ 0.0  50.0]
+      // [ 0.0   0.0  60.0   0.0]        [ 0.0   0.0]     [60.0   0.0]
+      SparseSplit<TFloat64> split = tf.sparse.sparseSplit(
+          tf.constant(1L),
+          tf.constant(sparseTensor.indices()),
+          tf.constant(sparseTensor.values()),
+          tf.constant(sparseTensor.denseShape()),
+          2L
+      );
+      List<Output<TInt64>> splitIndices = split.outputIndices();
+      List<Output<TFloat64>> splitValues = split.outputValues();
+      List<Output<TInt64>> splitDenseShape = split.outputShape();
 
-    // [10.0   0.0  20.0   0.0]        [10.0   0.0]     [20.0   0.0]
-    // [30.0  40.0   0.0  50.0]   ==>  [30.0  40.0]  +  [ 0.0  50.0]
-    // [ 0.0   0.0  60.0   0.0]        [ 0.0   0.0]     [60.0   0.0]
-    SparseSplit<TFloat64> split = tf.sparse.sparseSplit(
-        tf.constant(1L),
-        tf.constant(sparseTensor.indices()),
-        tf.constant(sparseTensor.values()),
-        tf.constant(sparseTensor.denseShape()),
-        2L
-    );
-    List<Output<TInt64>> splitIndices = split.outputIndices();
-    List<Output<TFloat64>> splitValues = split.outputValues();
-    List<Output<TInt64>> splitDenseShape = split.outputShape();
+      assertEquals(2, splitIndices.size());
+      assertEquals(2, splitValues.size());
+      assertEquals(2, splitDenseShape.size());
 
-    assertEquals(2, splitIndices.size());
-    assertEquals(2, splitValues.size());
-    assertEquals(2, splitDenseShape.size());
+      SparseTensor<TFloat64> sparsePart1 = SparseTensor.of(
+          splitIndices.get(0).asTensor(),
+          splitValues.get(0).asTensor(),
+          splitDenseShape.get(0).asTensor()
+      );
+      assertEquals(StdArrays.ndCopyOf(new long[][]{{0, 0}, {1, 0}, {1, 1}}), sparsePart1.indices());
+      assertEquals(NdArrays.vectorOf(10.0, 30.0, 40.0), sparsePart1.values());
+      assertEquals(NdArrays.vectorOf(3L, 2L), sparsePart1.denseShape());
 
-    SparseTensor<TFloat64> sparsePart1 = SparseTensor.of(
-        splitIndices.get(0).asTensor(),
-        splitValues.get(0).asTensor(),
-        splitDenseShape.get(0).asTensor()
-    );
-    assertEquals(StdArrays.ndCopyOf(new long[][] {{0, 0}, {1, 0}, {1, 1}}), sparsePart1.indices());
-    assertEquals(NdArrays.vectorOf(10.0, 30.0, 40.0), sparsePart1.values());
-    assertEquals(NdArrays.vectorOf(3L, 2L), sparsePart1.denseShape());
+      SparseTensor<TFloat64> sparsePart2 = SparseTensor.of(
+          splitIndices.get(1).asTensor(),
+          splitValues.get(1).asTensor(),
+          splitDenseShape.get(1).asTensor()
+      );
+      assertEquals(StdArrays.ndCopyOf(new long[][]{{0, 0}, {1, 1}, {2, 0}}), sparsePart2.indices());
+      assertEquals(NdArrays.vectorOf(20.0, 50.0, 60.0), sparsePart2.values());
+      assertEquals(NdArrays.vectorOf(3L, 2L), sparsePart2.denseShape());
+    }
+  }
 
-    SparseTensor<TFloat64> sparsePart2 = SparseTensor.of(
-        splitIndices.get(1).asTensor(),
-        splitValues.get(1).asTensor(),
-        splitDenseShape.get(1).asTensor()
-    );
-    assertEquals(StdArrays.ndCopyOf(new long[][] {{0, 0}, {1, 1}, {2, 0}}), sparsePart2.indices());
-    assertEquals(NdArrays.vectorOf(20.0, 50.0, 60.0), sparsePart2.values());
-    assertEquals(NdArrays.vectorOf(3L, 2L), sparsePart2.denseShape());
+  @Test
+  void releaseSparseTensorBeforeTensors() {
+    TensorState state = null;
+
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][]{{3}, {6}, {9}}));
+        TFloat64 values = TFloat64.vectorOf(30.0, 60.0, 90.0);
+        TInt64 denseShape = TInt64.vectorOf(10);
+        TFloat64 sparseTensor = TFloat64.sparseTensorOf(indices, values, denseShape)) {
+      state = new TensorState(sparseTensor);
+      assertFalse(state.isClosed());
+    }
+    assertTrue(state.isClosed());
+
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][]{{3}, {6}, {9}}));
+        TFloat64 values = TFloat64.vectorOf(30.0, 60.0, 90.0);
+        TInt64 denseShape = TInt64.vectorOf(10)) {
+      try (TFloat64 sparseTensor = TFloat64.sparseTensorOf(indices, values, denseShape)) {
+        state = new TensorState(sparseTensor);
+        assertFalse(state.isClosed());
+      }
+      assertFalse(state.isClosed());
+    }
+    assertTrue(state.isClosed());
+  }
+
+  @Test
+  void releaseTensorsBeforeSparseTensor() {
+    TensorState state = null;
+
+    try (TFloat64 sparseTensor = createSparseTensorForTest()) {
+      state = new TensorState(sparseTensor);
+      assertFalse(state.isClosed());
+    }
+    assertTrue(state.isClosed());
+
+    TFloat64 sparseTensor;
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][]{{3}, {6}, {9}}));
+        TFloat64 values = TFloat64.vectorOf(30.0, 60.0, 90.0);
+        TInt64 denseShape = TInt64.vectorOf(10)) {
+      sparseTensor = TFloat64.sparseTensorOf(indices, values, denseShape);
+      state = new TensorState(sparseTensor);
+      assertFalse(state.isClosed());
+    }
+    assertFalse(state.isClosed()); // Not closing the sparse tensor would leak
+    sparseTensor.close();
+    assertTrue(state.isClosed());
+  }
+
+  private TFloat64 createSparseTensorForTest() {
+    try (TInt64 indices = TInt64.tensorOf(StdArrays.ndCopyOf(new long[][]{{3}, {6}, {9}}));
+        TFloat64 values = TFloat64.vectorOf(30.0, 60.0, 90.0);
+        TInt64 denseShape = TInt64.vectorOf(10)) {
+      return TFloat64.sparseTensorOf(indices, values, denseShape);
+    }
+  }
+
+  private final static class TensorState {
+
+    <T extends TType> TensorState(TFloat64 tensor) {
+      SparseTensor<TFloat64> sparseTensor = (SparseTensor<TFloat64>) tensor;
+      this.indicesRef = sparseTensor.indices();
+      this.valuesRef = sparseTensor.values();
+      this.denseShapeRef = sparseTensor.denseShape();
+    }
+
+    boolean isClosed() {
+      try {
+        // nativeHandle() will throw if the tensor has been closed
+        indicesRef.asRawTensor().nativeHandle();
+        valuesRef.asRawTensor().nativeHandle();
+        denseShapeRef.asRawTensor().nativeHandle();
+        return false;
+
+      } catch (IllegalStateException e) {
+        return true;
+      }
+    }
+
+    private TInt64 indicesRef = null;
+    private TFloat64 valuesRef = null;
+    private TInt64 denseShapeRef = null;
   }
 }


### PR DESCRIPTION
Add minimal support for sparse tensors in TensorFlow Java. 

New factories like `TFloat32.sparseTensorOf(indices, values, denseShape)` allow users to get a typed reference to a sparse tensor so visit its data similarly to how it's done with dense tensors (with the exception that sparse tensors are read-only).

After this pull request, more will come to integrate sparse tensors within the TFJava ecosystem, including feeding sparse tensors to sessions/functions, creating constants, etc. The ultimate goal is that the user does not have to handle manually the individual dense tensors that compose a sparse one (i.e. the indices, the values and the dense shape) but right now as it is required, users can access them by casting back the returned reference to a `SparseTensor<T>`.

Requires https://github.com/tensorflow/java-ndarray/pull/5 to be merged first

CC\ @JimClarke5 