### PR TITLE
Fix NullPointerException issue.

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperation.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperation.java
@@ -190,9 +190,9 @@ class EagerOperation extends AbstractOperation {
     requireTensorHandle(handle);
     try (PointerScope scope = new PointerScope()) {
       TF_Status status = TF_Status.newStatus();
-      TF_Tensor tensor = TFE_TensorHandleResolve(handle, status).withDeallocator();
+      TF_Tensor tensor = TFE_TensorHandleResolve(handle, status);
       status.throwExceptionIfNotOK();
-      return RawTensor.fromHandle(tensor, session).asTypedTensor();
+      return RawTensor.fromHandle(tensor.withDeallocator(), session).asTypedTensor();
     }
   }
 


### PR DESCRIPTION
This fixes #406, With this fix, it will throw a TFInvalidArgumentException instead of NullPointerException.

The error message looks like the following:

org.tensorflow.exceptions.TFInvalidArgumentException: padding_value must be a scalar
	Encountered when executing an operation using EagerExecutor. This error cancels all future operations and poisons their output tensors.

Before the fix, the stacktrace is quite confusing:

java.lang.NullPointerException
	at org.tensorflow.EagerOperation.resolveTensorHandle(EagerOperation.java:193)
	at org.tensorflow.EagerOperation.resolveTensor(EagerOperation.java:166)
	at org.tensorflow.EagerOperation.tensor(EagerOperation.java:152)
	at org.tensorflow.Output.asTensor(Output.java:97)
	at org.tensorflow.Operand.asTensor(Operand.java:65)
