### PR TITLE
Fix metric test failures

### DIFF
--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -43,7 +43,7 @@
     
     Bumped to newer version to patch a CVE only present in protobuf-java
     -->
-    <protobuf.version>3.19.2</protobuf.version>
+    <protobuf.version>3.19.4</protobuf.version>
 
     <native.classifier>${javacpp.platform}${javacpp.platform.extension}</native.classifier>
     <javacpp.build.skip>false</javacpp.build.skip>       <!-- To skip execution of build.sh: -Djavacpp.build.skip=true -->

--- a/tensorflow-framework/pom.xml
+++ b/tensorflow-framework/pom.xml
@@ -93,7 +93,7 @@
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <argLine>-Xmx2G -XX:MaxPermSize=256m</argLine>
+          <argLine>-Xmx2G</argLine>
           <includes>
             <include>**/*Test.java</include>
           </includes>

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/PrecisionAtRecallTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/PrecisionAtRecallTest.java
@@ -24,7 +24,6 @@ import org.tensorflow.framework.utils.TestSession;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
 import org.tensorflow.op.Ops;
-import org.tensorflow.op.random.RandomUniform;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt64;
 
@@ -39,11 +38,11 @@ public class PrecisionAtRecallTest {
       PrecisionAtRecall<TFloat32> instance = new PrecisionAtRecall<>(0.7f, 1001L, TFloat32.class);
 
       Operand<TFloat32> predictions =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
       Operand<TFloat32> labels =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
 
       Op update = instance.updateState(tf, labels, predictions, null);
 

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/PrecisionTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/PrecisionTest.java
@@ -22,7 +22,6 @@ import org.tensorflow.framework.utils.TestSession;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
 import org.tensorflow.op.Ops;
-import org.tensorflow.op.random.RandomUniform;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TFloat64;
 import org.tensorflow.types.TInt32;
@@ -39,11 +38,11 @@ public class PrecisionTest {
       Precision<TFloat64> instance =
           new Precision<>(new float[] {0.3f, 0.72f}, 1001L, TFloat64.class);
       Operand<TFloat32> predictions =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1001L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1001L, 0L}), TFloat32.class);
       Operand<TFloat32> labels =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1001L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1001L, 0L}), TFloat32.class);
 
       Op update = instance.updateState(tf, labels, predictions, null);
 
@@ -81,7 +80,7 @@ public class PrecisionTest {
       Precision<TFloat32> instance = new Precision<>(0.5f, 1001L, TFloat32.class);
 
       Operand<TInt32> predictions =
-          tf.random.randomUniformInt(tf.constant(Shape.of(100, 1)), tf.constant(0), tf.constant(2));
+          tf.random.statelessMultinomial(tf.constant(new float[][]{{0.5f,0.5f}}), tf.constant(100), tf.constant(new long[]{1001L,0L}), TInt32.class);
       Operand<TInt32> labels = tf.math.sub(tf.constant(1), predictions);
       Op update = instance.updateState(tf, labels, predictions, null);
       session.run(update);

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/RecallAtPrecisionTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/RecallAtPrecisionTest.java
@@ -24,7 +24,6 @@ import org.tensorflow.framework.utils.TestSession;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
 import org.tensorflow.op.Ops;
-import org.tensorflow.op.random.RandomUniform;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt64;
 
@@ -39,11 +38,11 @@ public class RecallAtPrecisionTest {
       RecallAtPrecision<TFloat32> instance = new RecallAtPrecision<>(0.7f, 1001L, TFloat32.class);
 
       Operand<TFloat32> predictions =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
       Operand<TFloat32> labels =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
       labels = tf.math.mul(labels, tf.constant(2.0f));
 
       Op update = instance.updateState(tf, labels, predictions);

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/RecallTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/RecallTest.java
@@ -36,9 +36,11 @@ public class RecallTest {
       Recall<TFloat32> instance = new Recall<>(new float[] {0.3f, 0.72f}, 1001L, TFloat32.class);
 
       Operand<TFloat32> predictions =
-          tf.random.randomUniform(tf.constant(Shape.of(10, 3)), TFloat32.class);
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
       Operand<TFloat32> labels =
-          tf.random.randomUniform(tf.constant(Shape.of(10, 3)), TFloat32.class);
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
       Op update = instance.updateState(tf, labels, predictions, null);
 
       for (int i = 0; i < 10; i++) session.run(update);

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/SensitivityAtSpecificityTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/SensitivityAtSpecificityTest.java
@@ -24,7 +24,6 @@ import org.tensorflow.framework.utils.TestSession;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
 import org.tensorflow.op.Ops;
-import org.tensorflow.op.random.RandomUniform;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TFloat64;
 import org.tensorflow.types.TInt64;
@@ -40,11 +39,11 @@ public class SensitivityAtSpecificityTest {
       SensitivityAtSpecificity<TFloat32> instance =
           new SensitivityAtSpecificity<>(0.7f, 1001L, TFloat32.class);
       Operand<TFloat32> predictions =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
       Operand<TFloat32> labels =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
       labels = tf.math.mul(labels, tf.constant(2.0f));
 
       // instance.setDebug(session.getGraphSession());

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/SpecificityAtSensitivityTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/SpecificityAtSensitivityTest.java
@@ -42,11 +42,11 @@ public class SpecificityAtSensitivityTest {
           new SpecificityAtSensitivity<>(0.7f, 1001L, TFloat32.class);
 
       Operand<TFloat32> predictions =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
       Operand<TFloat32> labels =
-          tf.random.randomUniform(
-              tf.constant(Shape.of(10, 3)), TFloat32.class, RandomUniform.seed(1L));
+          tf.random.statelessRandomUniform(
+              tf.constant(Shape.of(10, 3)), tf.constant(new long[]{1L, 0L}), TFloat32.class);
 
       // instance.setDebug(session.getGraphSession());
       Op update = instance.updateState(tf, labels, predictions, null);


### PR DESCRIPTION
The TF 2.7.1 upgrade seems to have broken the behaviour of `tf.random.randomUniform` and friends. This causes several metric tests which used random inputs to fail due to incorrect shapes being passed in. I've replaced them all with `tf.random.statelessRandomUniform` which works correctly.

I'm not sure what the real root cause is here, as the [TF 2.7.1 release notes](https://github.com/tensorflow/tensorflow/releases/tag/v2.7.1) don't mention any RNG changes. TF 2.8 is moving away from those RNG ops though, so maybe a backported security fix was a little too broad.

This PR also actually bumps to protobuf 3.19.4 (which is identical to 3.19.2 in the Java side of things, but is the latest version), and removes `-XX:MaxPermSize=256m` from the test command line arguments. The perm gen was removed in Java 8, the option is removed in Java 17 and so supplying it causes the test JVM to error out on startup.