### PR TITLE
Use JDK 11 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,53 +20,63 @@ jobs:
     runs-on: ubuntu-latest
     container: centos:7
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v1
       - name: Install environment
         run: |
           yum -y update
           yum -y install centos-release-scl-rh epel-release
-          yum -y install java-11-openjdk-devel devtoolset-9
+          yum -y install devtoolset-9
           echo Downloading Maven
           curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -o $HOME/apache-maven-3.6.3-bin.tar.gz
           tar xzf $HOME/apache-maven-3.6.3-bin.tar.gz -C /opt/
           ln -sf /opt/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
+      - name: Configure Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+      - name: Checkout repository
+        uses: actions/checkout@v1
       - name: Build project
         run: |
           source scl_source enable devtoolset-9 || true 
           export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
           echo $JAVA_HOME
           mvn -version
-          mvn clean install -Pdev,jdk11 -B -U -e -Dlint.skip=true
+          mvn clean install -Pdev,jdk17 -B -U -e -Dlint.skip=true
       - name: Run lint checks
         run: |
-          mvn compiler:compile -Pdev,jdk11 -B -U -e
+          mvn compiler:compile -Pdev,jdk17 -B -U -e
   check-format:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container: centos:7
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v1
       - name: Install environment
         run: |
           yum -y update
           yum -y install centos-release-scl-rh epel-release
-          yum -y install java-11-openjdk-devel devtoolset-9
+          yum -y install devtoolset-9
           echo Downloading Maven
           curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -o $HOME/apache-maven-3.6.3-bin.tar.gz
           tar xzf $HOME/apache-maven-3.6.3-bin.tar.gz -C /opt/
           ln -sf /opt/apache-maven-3.6.3/bin/mvn /usr/bin/mvn
+      - name: Configure Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+      - name: Checkout repository
+        uses: actions/checkout@v1
       - name: Build project
         run: |
           source scl_source enable devtoolset-9 || true
           export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
           echo $JAVA_HOME
           mvn -version
-          mvn clean install -Pdev,jdk11 -B -U -e -Dlint.skip=true -Dmaven.test.skip=true
+          mvn clean install -Pdev,jdk17 -B -U -e -Dlint.skip=true -Dmaven.test.skip=true
       - name: Run format checks
         run: |
-          mvn spotless:check -Pdev,jdk11 -B -U -e
+          mvn spotless:check -Pdev,jdk17 -B -U -e
   prepare:
     runs-on: ubuntu-latest
     outputs:
@@ -99,7 +109,7 @@ jobs:
           yum --disablerepo updates -y install $GLIBC
           yum -x "$GLIBC" -y update
           yum -x "$GLIBC" -y install centos-release-scl-rh epel-release
-          yum -x "$GLIBC" -y install java-1.8.0-openjdk-devel devtoolset-9 rh-git218 patch perl-Data-Dumper python36-devel python36-numpy python36-pip python36-six
+          yum -x "$GLIBC" -y install devtoolset-9 rh-git218 patch perl-Data-Dumper python36-devel python36-numpy python36-pip python36-six
           echo Downloading Maven
           curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -o $HOME/apache-maven-3.6.3-bin.tar.gz
           tar xzf $HOME/apache-maven-3.6.3-bin.tar.gz -C /opt/
@@ -124,6 +134,11 @@ jobs:
           rm -f $(find /usr/local/cuda/ -name '*.a' -and -not -name libcudart_static.a -and -not -name libcudadevrt.a)
           rm -rf /usr/local/cuda/doc* /usr/local/cuda/libnvvp* /usr/local/cuda/nsight* /usr/local/cuda/samples*
           fi
+      - name: Configure Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Build project
@@ -163,6 +178,11 @@ jobs:
           curl -L https://github.com/bazelbuild/bazel/releases/download/3.7.2/bazel-3.7.2-installer-darwin-x86_64.sh -o bazel.sh --retry 10
           bash bazel.sh
           brew install libomp perl
+      - name: Configure Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Build project
@@ -223,6 +243,11 @@ jobs:
             cp.exe -a cuda/include cuda/lib cuda/bin "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.2/"
           )
           echo %JAVA_HOME%
+      - name: Configure Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Build project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
           df -h
   windows-x86_64:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: prepare
     strategy:
        matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Build project
         run: |
           source scl_source enable devtoolset-9 || true 
-          export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
           echo $JAVA_HOME
           mvn -version
           mvn clean install -Pdev,jdk17 -B -U -e -Dlint.skip=true
@@ -70,7 +69,6 @@ jobs:
       - name: Build project
         run: |
           source scl_source enable devtoolset-9 || true
-          export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
           echo $JAVA_HOME
           mvn -version
           mvn clean install -Pdev,jdk17 -B -U -e -Dlint.skip=true -Dmaven.test.skip=true

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/README.md
+++ b/README.md
@@ -137,19 +137,19 @@ to add Sonatype OSS repository in your pom.xml, like the following
 </dependencies>
 ```
 
-## TensorFlow Version Support
+## TensorFlow/JDK Version Support
 
-This table shows the mapping between different version of TensorFlow for Java and the core runtime libraries.
+This table shows the mapping between TensorFlow, TensorFlow Java and minimum supported Java versions.
 
-| TensorFlow Java Version  | TensorFlow Version |
-| ------------- | ------------- |
-| 0.2.0  | 2.3.1  |
-| 0.3.0  | 2.4.1  |
-| 0.3.1  | 2.4.1  |
-| 0.3.2  | 2.4.1  |
-| 0.3.3  | 2.4.1  |
-| 0.4.0  | 2.7.0  |
-| 0.5.0-SNAPSHOT  | 2.7.0 |
+| TensorFlow Java Version  | TensorFlow Version | Minimum Java Version |
+| ------------- | ------------- | --------------- |
+| 0.2.0  | 2.3.1  | 8 |
+| 0.3.0  | 2.4.1  | 8 |
+| 0.3.1  | 2.4.1  | 8 |
+| 0.3.2  | 2.4.1  | 8 |
+| 0.3.3  | 2.4.1  | 8 |
+| 0.4.0  | 2.7.0  | 8 |
+| 0.5.0-SNAPSHOT  | 2.7.0 | 11 |
 
 ## How to Contribute?
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ to add Sonatype OSS repository in your pom.xml, like the following
 </dependencies>
 ```
 
-## TensorFlow/JDK Version Support
+## TensorFlow/Java Version Support
 
 This table shows the mapping between TensorFlow, TensorFlow Java and minimum supported Java versions.
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <junit.version>5.6.2</junit.version>
     <jmh.version>1.21</jmh.version>
     <versions-plugin.version>2.7</versions-plugin.version>
@@ -174,11 +175,11 @@
     </profile>
 
     <profile>
-      <id>jdk11</id>
+      <id>jdk17</id>
       <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
       </properties>
     </profile>
 
@@ -189,8 +190,6 @@
     <profile>
       <id>lint</id>
       <activation>
-        <!-- activate lint checks only on JDK1.9+ (required by Error Prone) -->
-        <jdk>(1.9,)</jdk>
         <!-- custom property to disable link checks on command line (enabled by default) -->
         <property>
           <name>!lint.skip</name>
@@ -366,15 +365,12 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>
         <configuration>
-
           <ratchetFrom>origin/master</ratchetFrom>
-
           <lineEndings/>
           <java>
             <googleJavaFormat>
               <version>1.14.0</version>
             </googleJavaFormat>
-
             <removeUnusedImports/>
           </java>
         </configuration>
@@ -386,6 +382,17 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M5</version>
+          <configuration combine.children="append">
+            <includes>
+              <include>**/*Test.java</include>
+            </includes>
+            <useModulePath>false</useModulePath>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
       <activation>
         <!-- custom property to disable link checks on command line (enabled by default) -->
         <property>
-          <name>!lint.skip</name>
+          <name>lint.skip</name>
           <value>!true</value>
         </property>
       </activation>
@@ -204,13 +204,15 @@
             <version>3.8.0</version>
             <configuration>
               <showWarnings>true</showWarnings>
-              <fork>true</fork> <!-- Required for JDK16+ -->
               <compilerArgs combine.children="append">
                 <!--arg>-Werror</arg--> <!-- Disabled (temporarily?) -->
                 <arg>-Xlint:all</arg>
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne</arg>
-                <!-- Following are required on JDK16+ -->
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+
+                <!-- We need to repeat all arguments found in jvm.config here or we'll lose them -->
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
@@ -219,8 +221,6 @@
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
               </compilerArgs>
               <annotationProcessorPaths combine.children="append">
                 <path>
@@ -302,6 +302,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <fork>true</fork> <!-- Required for JDK16+ -->
+        </configuration>
+      </plugin>
       <!-- GPG signed components: http://central.sonatype.org/pages/apache-maven.html#gpg-signed-components -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -433,7 +433,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
         <executions>
           <execution>
             <!--

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -200,6 +200,7 @@
               <goal>compile</goal>
             </goals>
             <configuration>
+              <release>8</release> <!-- This prevent the plugin to automatically include module-info.java (excluding it won't work) -->
               <includes>
                 <include>org/tensorflow/internal/c_api/presets/*.java</include>
               </includes>

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -200,10 +200,12 @@
               <goal>compile</goal>
             </goals>
             <configuration>
-              <release>8</release> <!-- This prevent the plugin to automatically include module-info.java (excluding it won't work) -->
               <includes>
                 <include>org/tensorflow/internal/c_api/presets/*.java</include>
               </includes>
+              <!-- Build on Java8 to prevent the plugin to automatically include module-info.java (excluding it won't work) -->
+              <release>8</release>
+              <compilerArgs combine.self="override"></compilerArgs>
             </configuration>
           </execution>
         </executions>

--- a/tensorflow-core/tensorflow-core-api/src/main/java/module-info.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/module-info.java
@@ -1,0 +1,68 @@
+/*
+ Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ =======================================================================
+ */
+module org.tensorflow {
+  requires transitive org.tensorflow.ndarray;
+  requires org.bytedeco.javacpp;
+  requires com.google.protobuf;
+
+  exports org.tensorflow;
+  exports org.tensorflow.exceptions;
+  exports org.tensorflow.types;
+  exports org.tensorflow.types.annotation;
+  exports org.tensorflow.types.family;
+
+  exports org.tensorflow.op;
+  exports org.tensorflow.op.annotation;
+  exports org.tensorflow.op.core;
+  exports org.tensorflow.op.audio;
+  exports org.tensorflow.op.bitwise;
+  exports org.tensorflow.op.cluster;
+  exports org.tensorflow.op.collective;
+  exports org.tensorflow.op.data;
+  exports org.tensorflow.op.data.experimental;
+  exports org.tensorflow.op.debugging;
+  exports org.tensorflow.op.dtypes;
+  exports org.tensorflow.op.estimator;
+  exports org.tensorflow.op.image;
+  exports org.tensorflow.op.io;
+  exports org.tensorflow.op.linalg;
+  exports org.tensorflow.op.linalg.sparse;
+  exports org.tensorflow.op.math;
+  exports org.tensorflow.op.math.special;
+  exports org.tensorflow.op.nn;
+  exports org.tensorflow.op.quantization;
+  exports org.tensorflow.op.ragged;
+  exports org.tensorflow.op.random;
+  exports org.tensorflow.op.risc;
+  exports org.tensorflow.op.signal;
+  exports org.tensorflow.op.sparse;
+  exports org.tensorflow.op.strings;
+  exports org.tensorflow.op.summary;
+  exports org.tensorflow.op.tpu;
+  exports org.tensorflow.op.train;
+  exports org.tensorflow.op.xla;
+
+  exports org.tensorflow.proto.data;
+  exports org.tensorflow.proto.data.experimental;
+  exports org.tensorflow.proto.data.model;
+  exports org.tensorflow.proto.distruntime;
+  exports org.tensorflow.proto.example;
+  exports org.tensorflow.proto.framework;
+  exports org.tensorflow.proto.profiler;
+  exports org.tensorflow.proto.util;
+  exports org.tensorflow.proto.util.testlog;
+}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/module-info.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.tensorflow {
   requires transitive org.tensorflow.ndarray;
   requires org.bytedeco.javacpp;
   requires com.google.protobuf;
+  requires java.logging;
 
   exports org.tensorflow;
   exports org.tensorflow.exceptions;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/module-info.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/module-info.java
@@ -1,19 +1,19 @@
 /*
- Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- =======================================================================
- */
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================
+*/
 module org.tensorflow {
   requires transitive org.tensorflow.ndarray;
   requires org.bytedeco.javacpp;
@@ -25,7 +25,6 @@ module org.tensorflow {
   exports org.tensorflow.types;
   exports org.tensorflow.types.annotation;
   exports org.tensorflow.types.family;
-
   exports org.tensorflow.op;
   exports org.tensorflow.op.annotation;
   exports org.tensorflow.op.core;
@@ -56,7 +55,6 @@ module org.tensorflow {
   exports org.tensorflow.op.tpu;
   exports org.tensorflow.op.train;
   exports org.tensorflow.op.xla;
-
   exports org.tensorflow.proto.data;
   exports org.tensorflow.proto.data.experimental;
   exports org.tensorflow.proto.data.model;

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/module-info.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/module-info.java
@@ -15,10 +15,13 @@
  =======================================================================
  */
 module org.tensorflow.generator {
-  requires org.commonmark;
-  requires com.squareup.javapoet;
+  requires java.compiler;
+
+  requires com.github.javaparser.core;
   requires com.google.protobuf;
   requires com.google.common;
+  requires com.squareup.javapoet;
+  requires org.commonmark;
 
   exports org.tensorflow.processor.operator;
   exports org.tensorflow.op.generator;

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/module-info.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ =======================================================================
+ */
+module org.tensorflow.generator {
+  requires org.commonmark;
+  requires com.squareup.javapoet;
+  requires com.google.protobuf;
+  requires com.google.common;
+
+  exports org.tensorflow.processor.operator;
+  exports org.tensorflow.op.generator;
+}

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/module-info.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/module-info.java
@@ -1,22 +1,21 @@
 /*
- Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- =======================================================================
- */
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================
+*/
 module org.tensorflow.generator {
   requires java.compiler;
-
   requires com.github.javaparser.core;
   requires com.google.protobuf;
   requires com.google.common;

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/op/generator/AttributeType.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/op/generator/AttributeType.java
@@ -16,7 +16,7 @@ limitations under the License.
 */
 package org.tensorflow.op.generator;
 
-public enum AttributeType {
+enum AttributeType {
   STRING("String"),
   INT("Int"),
   FLOAT("Float"),

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/op/generator/FullOpDef.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/op/generator/FullOpDef.java
@@ -21,7 +21,7 @@ import org.tensorflow.proto.framework.ApiDef;
 import org.tensorflow.proto.framework.ApiDef.Endpoint;
 import org.tensorflow.proto.framework.OpDef;
 
-public final class FullOpDef {
+final class FullOpDef {
   public final OpDef opDef;
   public final ApiDef apiDef;
   public final String basePackage;

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/op/generator/StatefulPair.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/op/generator/StatefulPair.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.StringJoiner;
 
-public final class StatefulPair {
+final class StatefulPair {
   public final FullOpDef statefulOp;
   public final FullOpDef statelessOp;
   public final String selectorClassName;

--- a/tensorflow-framework/pom.xml
+++ b/tensorflow-framework/pom.xml
@@ -89,14 +89,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
           <argLine>-Xmx2G</argLine>
-          <includes>
-            <include>**/*Test.java</include>
-          </includes>
         </configuration>
       </plugin>
     </plugins>

--- a/tensorflow-framework/src/main/java/module-info.java
+++ b/tensorflow-framework/src/main/java/module-info.java
@@ -1,0 +1,36 @@
+/*
+ Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ =======================================================================
+ */
+module org.tensorflow.framework {
+  requires org.tensorflow;
+
+  exports org.tensorflow.framework.activations;
+  exports org.tensorflow.framework.constraints;
+  exports org.tensorflow.framework.data;
+  exports org.tensorflow.framework.initializers;
+  exports org.tensorflow.framework.losses;
+  exports org.tensorflow.framework.metrics;
+  exports org.tensorflow.framework.metrics.exceptions;
+  exports org.tensorflow.framework.optimizers;
+  exports org.tensorflow.framework.regularizers;
+  exports org.tensorflow.framework.utils;
+
+  exports org.tensorflow.framework.op;
+  exports org.tensorflow.framework.op.linalg;
+  exports org.tensorflow.framework.op.math;
+  exports org.tensorflow.framework.op.nn;
+  exports org.tensorflow.framework.op.sets;
+}

--- a/tensorflow-framework/src/main/java/module-info.java
+++ b/tensorflow-framework/src/main/java/module-info.java
@@ -1,19 +1,19 @@
 /*
- Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- =======================================================================
- */
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================
+*/
 module org.tensorflow.framework {
   requires org.tensorflow;
 
@@ -27,7 +27,6 @@ module org.tensorflow.framework {
   exports org.tensorflow.framework.optimizers;
   exports org.tensorflow.framework.regularizers;
   exports org.tensorflow.framework.utils;
-
   exports org.tensorflow.framework.op;
   exports org.tensorflow.framework.op.linalg;
   exports org.tensorflow.framework.op.math;


### PR DESCRIPTION
As it has been discussed with the SIG, minimal supported JDK version for TF Java will moved from Java8 to Java11. This PR enables JDK11 releases by default, and allows users to build with JDK17 by activating the `jdk17` Maven profile.