### PR TITLE
Fix broken @see blocks.

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/DeviceSpec.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/DeviceSpec.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  *
  * <p>This is a Java port from python device_spec.py.
  *
- * @see <a href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/device_spec.py">device_spec.py</a>.
+ * See also: <a href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/device_spec.py">device_spec.py</a>.
  */
 public final class DeviceSpec {
   private static final String JOB_PREFIX = "/job:";

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
@@ -114,7 +114,7 @@ public final class EagerSession implements ExecutionEnvironment, AutoCloseable {
      * Configures the session based on the data found in the provided configuration.
      *
      * @param config a config protocol buffer
-     * @see <a
+     * See also: <a
      *     href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/config.proto">config.proto</a></a>
      */
     public Options config(ConfigProto config) {


### PR DESCRIPTION
@see lines try to link the whole line to the name, it tries to lookup these URLs as names in the API and fails:

`@see name description`


https://www.tensorflow.org/jvm/api_docs/java/org/tensorflow/DeviceSpec