### PR TITLE
Simplify graph initializers

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -8131,34 +8131,16 @@ public final class Ops {
   }
 
   /**
-   * Returns an API that builds init operations.  {@link #liftToInitScope(Operand)} will be called for all created operations.
+   * Returns an API that builds init operations.
    * <p>
    * Init operations will be initialized at session creation, will have their inputs (and control inputs) made init ops as well,
    * and are ignored when used as control dependencies.
    * Additionally, this scope ignores any control dependencies.
    * <p>
    * If an input can not be made an init op (i.e. a Placeholder), will throw an {@link IllegalStateException} on op creation.
-   * @see #liftToInitScope(Operand)
    */
   public Ops withInitScope() {
     return new Ops(scope.withInitScope());
-  }
-
-  /**
-   * Make {@code op} an init operation, doing the same for all of it's inputs (and control inputs).
-   * <p>
-   * Init operations will be initialized at session creation, will have their inputs (and control inputs) made init ops as well,
-   * and are ignored when used as control dependencies.
-   * Additionally, this scope ignores any control dependencies.
-   * <p>
-   * If an input can not be made an init op (i.e. a Placeholder), will throw an {@link IllegalStateException} on op creation.
-   * @see ExecutionEnvironment#registerInitOp(Operation)
-   *
-   * @throws IllegalStateException if the op or one of its inputs can't be made an init op.
-   */
-  public <T extends Operand> T liftToInitScope(T op) {
-    scope.env().registerInitOp(op.op());
-    return op;
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerOperationBuilder.java
@@ -75,9 +75,7 @@ final class EagerOperationBuilder implements OperationBuilder {
   public EagerOperation build() {
     scope.apply(this);
     TFE_TensorHandle[] tensorHandles = execute(opHandle, session);
-    EagerOperation op = new EagerOperation(session, opHandle, tensorHandles, type, name);
-    scope.onOpCreated(op);
-    return op;
+    return new EagerOperation(session, opHandle, tensorHandles, type, name);
   }
 
   @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
@@ -335,13 +335,9 @@ public final class EagerSession implements ExecutionEnvironment, AutoCloseable {
 
   /** Noop, initialization is meaningless for eager sessions */
   @Override
-  public boolean isInitOp(Operation op) {
+  public boolean isInitializer(Operation op) {
     return false;
   }
-
-  /** Noop, initialization is meaningless for eager sessions */
-  @Override
-  public void registerInitOp(Operation op) {}
 
   TFE_Context nativeHandle() {
     checkSession();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/ExecutionEnvironment.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/ExecutionEnvironment.java
@@ -102,28 +102,9 @@ public interface ExecutionEnvironment {
   Scope baseScope();
 
   /**
-   * Get the execution environment to use for initialization. In most cases is {@code this}.
-   *
-   * <p><b>Should generally only be used internally.</b>
-   */
-  default ExecutionEnvironment initEnv() {
-    return this;
-  }
-
-  /**
-   * Register an op and all of its inputs (and control inputs) as an initialization op.
-   *
-   * <p><b>Should generally only be used internally, prefer {@link
-   * org.tensorflow.op.Ops#withInitScope()}.</b>
-   *
-   * @throws IllegalStateException if the op or one of its inputs can't be made an init op.
-   */
-  void registerInitOp(Operation op);
-
-  /**
    * Get whether an op is an initialization op.
    *
    * <p><b>Should generally only be used internally.</b>
    */
-  boolean isInitOp(Operation op);
+  boolean isInitializer(Operation op);
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
@@ -516,7 +516,7 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
     importGraphDef(graphDef, "");
   }
 
-  static final String INIT_OP_BASE_NAME = "Init";
+  static final String INIT_OP_NAME = "Init";
 
   /**
    * Import a representation of a TensorFlow graph.
@@ -539,12 +539,12 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
     String initPrefix;
     if (!prefix.isEmpty()) {
       if (prefix.endsWith("/")) {
-        initPrefix = prefix + INIT_OP_BASE_NAME;
+        initPrefix = prefix + INIT_OP_NAME;
       } else {
-        initPrefix = prefix + "/" + INIT_OP_BASE_NAME;
+        initPrefix = prefix + "/" + INIT_OP_NAME;
       }
     } else {
-      initPrefix = INIT_OP_BASE_NAME;
+      initPrefix = INIT_OP_NAME;
     }
 
     operations()
@@ -1065,8 +1065,8 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
       return graphDef;
     }
     var graphDefWithInitBuilder = graphDef.toBuilder();
-    var initNode = graphDefWithInitBuilder.getNodeBuilderList().stream().filter(n -> n.getName().startsWith(INIT_OP_BASE_NAME)).findFirst().orElseGet(() -> {
-      return graphDefWithInitBuilder.addNodeBuilder().setName(INIT_OP_BASE_NAME).setOp(NoOp.OP_NAME);
+    var initNode = graphDefWithInitBuilder.getNodeBuilderList().stream().filter(n -> n.getName().equals(INIT_OP_NAME)).findFirst().orElseGet(() -> {
+      return graphDefWithInitBuilder.addNodeBuilder().setName(INIT_OP_NAME).setOp(NoOp.OP_NAME);
     });
     initializers.stream().skip(newInitializersMarker).forEach(op -> initNode.addInput("^" + op.name()));
     return graphDefWithInitBuilder.build();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
@@ -30,7 +30,6 @@ import static org.tensorflow.internal.c_api.global.tensorflow.TF_NewGraph;
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_NewWhile;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -392,7 +391,7 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
   @Override
   public void attachFunction(ConcreteFunction function) {
     try (Reference ref = ref();
-         PointerScope scope = new PointerScope()) {
+        PointerScope scope = new PointerScope()) {
       TF_Status status = TF_Status.newStatus();
       TF_GraphCopyFunction(ref.nativeHandle(), function.nativeHandle(), null, status);
       status.throwExceptionIfNotOK();
@@ -548,12 +547,12 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
     }
 
     operations()
-            .forEachRemaining(
-                    op -> {
-                      if (op.name().startsWith(initPrefix)) {
-                        registerInitializer(op, false);
-                      }
-                    });
+        .forEachRemaining(
+            op -> {
+              if (op.name().startsWith(initPrefix)) {
+                registerInitializer(op, false);
+              }
+            });
   }
 
   /**
@@ -1065,10 +1064,20 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
       return graphDef;
     }
     var graphDefWithInitBuilder = graphDef.toBuilder();
-    var initNode = graphDefWithInitBuilder.getNodeBuilderList().stream().filter(n -> n.getName().equals(INIT_OP_NAME)).findFirst().orElseGet(() -> {
-      return graphDefWithInitBuilder.addNodeBuilder().setName(INIT_OP_NAME).setOp(NoOp.OP_NAME);
-    });
-    initializers.stream().skip(newInitializersMarker).forEach(op -> initNode.addInput("^" + op.name()));
+    var initNode =
+        graphDefWithInitBuilder.getNodeBuilderList().stream()
+            .filter(n -> n.getName().equals(INIT_OP_NAME))
+            .findFirst()
+            .orElseGet(
+                () -> {
+                  return graphDefWithInitBuilder
+                      .addNodeBuilder()
+                      .setName(INIT_OP_NAME)
+                      .setOp(NoOp.OP_NAME);
+                });
+    initializers.stream()
+        .skip(newInitializersMarker)
+        .forEach(op -> initNode.addInput("^" + op.name()));
     return graphDefWithInitBuilder.build();
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Graph.java
@@ -1075,9 +1075,13 @@ public final class Graph implements ExecutionEnvironment, AutoCloseable {
                       .setName(INIT_OP_NAME)
                       .setOp(NoOp.OP_NAME);
                 });
+
+    // Register each initializer as a control dependency of the Init op by adding their names
+    // prefixed with the '^' symbol to the list of inputs
     initializers.stream()
         .skip(newInitializersMarker)
         .forEach(op -> initNode.addInput("^" + op.name()));
+
     return graphDefWithInitBuilder.build();
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/GraphOperationBuilder.java
@@ -101,7 +101,9 @@ public final class GraphOperationBuilder implements OperationBuilder {
       }
       GraphOperation op = new GraphOperation(graph, built);
       unsafeNativeHandle = null;
-      scope.onOpCreated(op);
+      if (scope.isInit()) {
+        graph.registerInitializer(op, true);
+      }
       return op;
     }
   }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -388,7 +388,7 @@ public class SavedModelBundle implements AutoCloseable {
     // the init signatures aren't actual functions, just markers
     return functions.values().stream()
         .map(SessionFunction::signature)
-        .filter(s-> !s.key().equals(INIT_OP_SIGNATURE_KEY))
+        .filter(s -> !s.key().equals(INIT_OP_SIGNATURE_KEY))
         .collect(Collectors.toList());
   }
 
@@ -473,7 +473,10 @@ public class SavedModelBundle implements AutoCloseable {
   private final Map<String, SessionFunction> functions;
 
   private SavedModelBundle(
-      Graph graph, Session session, MetaGraphDef metaGraphDef, Map<String, SessionFunction> functions) {
+      Graph graph,
+      Session session,
+      MetaGraphDef metaGraphDef,
+      Map<String, SessionFunction> functions) {
     this.graph = graph;
     this.session = session;
     this.metaGraphDef = metaGraphDef;
@@ -554,9 +557,13 @@ public class SavedModelBundle implements AutoCloseable {
               });
     }
 
-    return new SavedModelBundle(graph, session, metaGraphDef, functions.entrySet().stream()
-            .collect(Collectors.toMap(Entry::getKey, e -> new SessionFunction(e.getValue(), session)))
-    );
+    return new SavedModelBundle(
+        graph,
+        session,
+        metaGraphDef,
+        functions.entrySet().stream()
+            .collect(
+                Collectors.toMap(Entry::getKey, e -> new SessionFunction(e.getValue(), session))));
   }
 
   private static SavedModelBundle load(

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -48,8 +48,6 @@ import org.tensorflow.proto.framework.MetaGraphDef;
 import org.tensorflow.proto.framework.MetaGraphDef.MetaInfoDef;
 import org.tensorflow.proto.framework.RunOptions;
 import org.tensorflow.proto.framework.SavedModel;
-import org.tensorflow.proto.framework.SignatureDef;
-import org.tensorflow.proto.framework.TensorInfo;
 import org.tensorflow.proto.util.SaverDef;
 
 /**
@@ -67,9 +65,6 @@ import org.tensorflow.proto.util.SaverDef;
 public class SavedModelBundle implements AutoCloseable {
 
   public static final String DEFAULT_TAG = "serve";
-
-  /** Signature used to track Java init ops, for our init scope. */
-  private static final String JAVA_INIT_OP_SIGNATURE_KEY = "__saved_model_java_init_op_tracker";
 
   /**
    * Tensorflow init op tracking signature. Init ops are executed before loading variables, so this
@@ -285,28 +280,12 @@ public class SavedModelBundle implements AutoCloseable {
       // new ops to the graph for saving and restoring the variables.
       SaverDef saverDef = graph.saverDef();
 
-      GraphOperation initOp = null;
-      if (!functions.containsKey(JAVA_INIT_OP_SIGNATURE_KEY)) {
-        initOp = graph.addInitOp(true);
-      }
-
       MetaGraphDef.Builder metaGraphDef =
           metaGraphDefBuilder
               .setSaverDef(saverDef)
               .setGraphDef(graph.toGraphDef())
               .setMetaInfoDef(MetaInfoDef.newBuilder().addAllTags(Arrays.asList(tags)));
       functions.forEach((k, f) -> metaGraphDef.putSignatureDef(k, f.signature().asSignatureDef()));
-
-      if (!functions.containsKey(JAVA_INIT_OP_SIGNATURE_KEY)) {
-
-        metaGraphDef.putSignatureDef(
-            JAVA_INIT_OP_SIGNATURE_KEY,
-            SignatureDef.newBuilder()
-                .putOutputs(
-                    JAVA_INIT_OP_SIGNATURE_KEY,
-                    TensorInfo.newBuilder().setName(initOp.name() + ":0").build())
-                .build());
-      }
 
       // Make sure saved model directories exist
       Path variableDir = Paths.get(exportDir, "variables");
@@ -409,10 +388,7 @@ public class SavedModelBundle implements AutoCloseable {
     // the init signatures aren't actual functions, just markers
     return functions.values().stream()
         .map(SessionFunction::signature)
-        .filter(
-            signature ->
-                !signature.key().equals(INIT_OP_SIGNATURE_KEY)
-                    && !signature.key().equals(JAVA_INIT_OP_SIGNATURE_KEY))
+        .filter(s-> !s.key().equals(INIT_OP_SIGNATURE_KEY))
         .collect(Collectors.toList());
   }
 
@@ -497,14 +473,11 @@ public class SavedModelBundle implements AutoCloseable {
   private final Map<String, SessionFunction> functions;
 
   private SavedModelBundle(
-      Graph graph, Session session, MetaGraphDef metaGraphDef, Map<String, Signature> signatures) {
+      Graph graph, Session session, MetaGraphDef metaGraphDef, Map<String, SessionFunction> functions) {
     this.graph = graph;
     this.session = session;
     this.metaGraphDef = metaGraphDef;
-    this.functions =
-        signatures.entrySet().stream()
-            .collect(
-                Collectors.toMap(Entry::getKey, e -> new SessionFunction(e.getValue(), session)));
+    this.functions = functions;
   }
 
   private static GraphOperation findInitOp(
@@ -563,26 +536,12 @@ public class SavedModelBundle implements AutoCloseable {
 
     GraphOperation initOp = findInitOp(graph, functions, metaGraphDef.getCollectionDefMap());
     if (initOp != null) {
-      graph.registerInitOp(initOp);
+      graph.registerInitializer(initOp, false);
     }
 
-    // java init ops are marked as ran, since the variable restore will restore any state
-    // they mutated.
-    // Technically, init ops should be ran first, then variable restore, but that is not possible
-    // since TF_Session.loadSessionFromSavedModel does it in reverse order, so we just mark them as
-    // ran.
-    if (functions.containsKey(JAVA_INIT_OP_SIGNATURE_KEY)) {
-      String initOpName =
-          functions
-              .get(JAVA_INIT_OP_SIGNATURE_KEY)
-              .getOutputs()
-              .get(JAVA_INIT_OP_SIGNATURE_KEY)
-              .name;
-      graph.registerInitOp(graph.outputOrThrow(initOpName).op());
-    }
+    session.markAllInitializersAsRan();
 
-    session.setInitialized();
-
+    // FIXME: For Ryan, why marking all initializers as run before adding these ones?
     if (metaGraphDef.containsCollectionDef(TABLE_INITIALIZERS_COLLECTION_KEY)) {
       metaGraphDef
           .getCollectionDefMap()
@@ -591,11 +550,13 @@ public class SavedModelBundle implements AutoCloseable {
           .getValueList()
           .forEach(
               node -> {
-                graph.registerInitOp(graph.operationOrThrow(node));
+                graph.registerInitializer(graph.operationOrThrow(node), false);
               });
     }
 
-    return new SavedModelBundle(graph, session, metaGraphDef, functions);
+    return new SavedModelBundle(graph, session, metaGraphDef, functions.entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> new SessionFunction(e.getValue(), session)))
+    );
   }
 
   private static SavedModelBundle load(

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -24,7 +24,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
@@ -516,7 +515,7 @@ public final class Session implements AutoCloseable {
           initialize();
         } else {
           throw new IllegalStateException(
-                  "Graph has un-ran initializers, but the session's autoInit is false.  Run Session.initialize() before calling run().");
+              "Graph has un-ran initializers, but the session's autoInit is false.  Run Session.initialize() before calling run().");
         }
       }
     }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -22,11 +22,9 @@ import static org.tensorflow.internal.c_api.global.tensorflow.TF_SetConfig;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
@@ -183,22 +181,13 @@ public final class Session implements AutoCloseable {
    *
    * <p>This runs any ops that have been created with an init scope that have not already been ran.
    */
-  public void initialize() {
-    Runner runner = runner();
-    graph.initializers().stream().filter((x) -> !ranInits.contains(x)).forEach(runner::addTarget);
-    setInitialized();
-    if (!runner.isEmpty()) {
+  public synchronized void initialize() {
+    if (hasUnranInitializers()) {
+      Runner runner = runner();
+      graph.initializers().stream().skip(ranInitializersMarker).forEach(runner::addTarget);
       runner.runNoInit();
+      markAllInitializersAsRan();
     }
-  }
-
-  /**
-   * Set the ran initializers to all initializers in the graph, as if they had been run. <b>Does not
-   * actually ensure they are ran.</b>
-   */
-  void setInitialized() {
-    ranInits.clear();
-    ranInits.addAll(graph.initializers());
   }
 
   /**
@@ -208,15 +197,13 @@ public final class Session implements AutoCloseable {
    *
    * @return this
    */
-  public Session forceInitialize() {
-    Set<Operation> initializers = graph.initializers();
-    if (!initializers.isEmpty()) {
-      Runner runner = runner();
-      initializers.forEach(runner::addTarget);
+  public synchronized Session forceInitialize() {
+    Runner runner = runner();
+    graph.initializers().stream().forEach(runner::addTarget);
+    if (!runner.isEmpty()) {
       runner.runNoInit();
     }
-    ranInits.clear();
-    ranInits.addAll(graph.initializers());
+    markAllInitializersAsRan();
     return this;
   }
 
@@ -477,21 +464,6 @@ public final class Session implements AutoCloseable {
       return targets.isEmpty() && outputs.isEmpty();
     }
 
-    private void doInit() {
-      if (autoInit) {
-        initialize();
-      } else {
-        graph
-            .initializers()
-            .forEach(
-                x -> {
-                  if (!ranInits.contains(x))
-                    throw new IllegalStateException(
-                        "Graph has un-ran initializers, but the session's autoInit is false.  Run Session.initialize() before calling run().");
-                });
-      }
-    }
-
     /**
      * Execute the graph fragments necessary to compute all requested fetches.
      *
@@ -510,11 +482,7 @@ public final class Session implements AutoCloseable {
      * @return list of resulting tensors fetched by this session runner
      */
     public Result run() {
-      doInit();
-      return runNoInit();
-    }
-
-    Result runNoInit() {
+      verifyInit();
       return runHelper(false);
     }
 
@@ -529,8 +497,28 @@ public final class Session implements AutoCloseable {
      * @return list of resulting tensors fetched by this session runner, with execution metadata
      */
     public Result runAndFetchMetadata() {
-      doInit();
+      verifyInit();
       return runHelper(true);
+    }
+
+    /**
+     * Link {@link #run()} but without trying to initialize the session if it's not
+     *
+     * @return list of resulting tensors fetched by this session runner
+     */
+    Result runNoInit() {
+      return runHelper(false);
+    }
+
+    private void verifyInit() {
+      if (hasUnranInitializers()) {
+        if (autoInit) {
+          initialize();
+        } else {
+          throw new IllegalStateException(
+                  "Graph has un-ran initializers, but the session's autoInit is false.  Run Session.initialize() before calling run().");
+        }
+      }
     }
 
     private Result runHelper(boolean wantMetadata) {
@@ -684,7 +672,7 @@ public final class Session implements AutoCloseable {
    *
    * @param prefix prefix to the variable files to save
    */
-  public void save(String prefix) {
+  public synchronized void save(String prefix) {
     SaverDef saverDef = graph.saverDef();
     runner()
         .addTarget(saverDef.getSaveTensorName())
@@ -706,14 +694,14 @@ public final class Session implements AutoCloseable {
    *
    * @param prefix prefix to restore from
    */
-  public void restore(String prefix) {
+  public synchronized void restore(String prefix) {
     SaverDef saverDef = graph.saverDef();
     runner()
         .addTarget(saverDef.getRestoreOpName())
         .feed(saverDef.getFilenameTensorName(), TString.scalarOf(prefix))
         .runNoInit();
     // TODO better way of doing this, only count as ran assignments to the restored variables.
-    setInitialized();
+    markAllInitializersAsRan();
   }
 
   Graph graph() {
@@ -728,7 +716,7 @@ public final class Session implements AutoCloseable {
   private int numActiveRuns;
 
   private final boolean autoInit;
-  private final Set<Operation> ranInits = Collections.synchronizedSet(new LinkedHashSet<>());
+  private int ranInitializersMarker = 0;
 
   private static void requireHandle(Pointer handle) {
     if (handle == null || handle.isNull()) {
@@ -857,5 +845,13 @@ public final class Session implements AutoCloseable {
         throw new TensorFlowException("Cannot parse RunMetadata protocol buffer", e);
       }
     }
+  }
+
+  private boolean hasUnranInitializers() {
+    return ranInitializersMarker < graph.initializers().size();
+  }
+
+  void markAllInitializersAsRan() {
+    ranInitializersMarker = graph.initializers().size();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/GradientScope.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/GradientScope.java
@@ -124,9 +124,6 @@ public final class GradientScope implements Scope {
   }
 
   @Override
-  public void onOpCreated(Operation op) {}
-
-  @Override
   public String getDeviceString() {
     if (device == null) {
       throw new UnsupportedOperationException(

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/OpScope.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/OpScope.java
@@ -70,7 +70,7 @@ public final class OpScope implements Scope {
 
   @Override
   public OpScope withInitScope() {
-    return new OpScope(env.initEnv(), nameScope, new ArrayList<>(), deviceSpec, true);
+    return new OpScope(env, nameScope, new ArrayList<>(), deviceSpec, true);
   }
 
   @Override
@@ -106,10 +106,10 @@ public final class OpScope implements Scope {
     ArrayList<Operation> toAdd = new ArrayList<>();
     for (Operation control : controls) {
       env.checkInput(control);
-      if (isInit && !env.isInitOp(control)) {
+      if (isInit && !env.isInitializer(control)) {
         throw new IllegalArgumentException("Init scope can not have non-init control dependency.");
       }
-      if (isInit || !env.isInitOp(control)) {
+      if (isInit || !env.isInitializer(control)) {
         toAdd.add(control);
       }
     }
@@ -121,18 +121,11 @@ public final class OpScope implements Scope {
   public OperationBuilder apply(OperationBuilder builder) {
     builder.setDevice(deviceSpec.toString());
     for (Operation control : controlDependencies) {
-      if (isInit || !env.isInitOp(control)) {
+      if (isInit || !env.isInitializer(control)) {
         builder.addControlInput(control);
       }
     }
     return builder;
-  }
-
-  @Override
-  public void onOpCreated(Operation op) {
-    if (isInit) {
-      env.registerInitOp(op);
-    }
   }
 
   @Override

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/Scope.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/Scope.java
@@ -239,13 +239,6 @@ public interface Scope {
    */
   OperationBuilder apply(OperationBuilder builder);
 
-  /**
-   * Handle op creation, like registering it as an init op if the scope is init.
-   *
-   * <p><b>FOR INTERNAL USE ONLY</b>
-   */
-  void onOpCreated(Operation op);
-
   /** Returns device string from the scope. */
   String getDeviceString();
 

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/GraphTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/GraphTest.java
@@ -34,7 +34,6 @@ import org.tensorflow.op.Ops;
 import org.tensorflow.op.linalg.MatMul;
 import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.proto.framework.GraphDef;
-import org.tensorflow.proto.framework.NodeDef;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt32;
 
@@ -74,10 +73,10 @@ public class GraphTest {
       Ops init = tf.withInitScope();
 
       Operand<TInt32> variable = init.variable(init.constant(4));
-      Operand<TInt32> result = tf.withName("result").math.add(variable, tf.constant(2));
+      tf.withName("result").math.add(variable, tf.constant(2));
       graphDef = g.toGraphDef();
 
-      var initNode = graphDef.getNodeList().stream().filter(n -> n.getName().equals(Graph.INIT_OP_BASE_NAME)).collect(Collectors.toList());
+      var initNode = graphDef.getNodeList().stream().filter(n -> n.getName().equals(Graph.INIT_OP_NAME)).collect(Collectors.toList());
       assertEquals(1, initNode.size());
       assertEquals(3, initNode.get(0).getInputCount());
     }
@@ -88,10 +87,10 @@ public class GraphTest {
       Ops tf = Ops.create(g);
       Ops init = tf.withInitScope();
 
-      Operand<TInt32> variable2 = init.withName("var2").variable(init.constant(4));
-
+      init.withName("var2").variable(init.constant(4));
       graphDef = g.toGraphDef();
-      var initNode = graphDef.getNodeList().stream().filter(n -> n.getName().equals(Graph.INIT_OP_BASE_NAME)).collect(Collectors.toList());
+
+      var initNode = graphDef.getNodeList().stream().filter(n -> n.getName().equals(Graph.INIT_OP_NAME)).collect(Collectors.toList());
       assertEquals(1, initNode.size());
       assertEquals(6, initNode.get(0).getInputCount());
 

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/GraphTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/GraphTest.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 import org.tensorflow.exceptions.TFInvalidArgumentException;
 import org.tensorflow.op.Ops;
@@ -76,7 +75,10 @@ public class GraphTest {
       tf.withName("result").math.add(variable, tf.constant(2));
       graphDef = g.toGraphDef();
 
-      var initNode = graphDef.getNodeList().stream().filter(n -> n.getName().equals(Graph.INIT_OP_NAME)).collect(Collectors.toList());
+      var initNode =
+          graphDef.getNodeList().stream()
+              .filter(n -> n.getName().equals(Graph.INIT_OP_NAME))
+              .collect(Collectors.toList());
       assertEquals(1, initNode.size());
       assertEquals(3, initNode.get(0).getInputCount());
     }
@@ -90,7 +92,10 @@ public class GraphTest {
       init.withName("var2").variable(init.constant(4));
       graphDef = g.toGraphDef();
 
-      var initNode = graphDef.getNodeList().stream().filter(n -> n.getName().equals(Graph.INIT_OP_NAME)).collect(Collectors.toList());
+      var initNode =
+          graphDef.getNodeList().stream()
+              .filter(n -> n.getName().equals(Graph.INIT_OP_NAME))
+              .collect(Collectors.toList());
       assertEquals(1, initNode.size());
       assertEquals(6, initNode.get(0).getInputCount());
 

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SavedModelBundleTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SavedModelBundleTest.java
@@ -179,7 +179,7 @@ public class SavedModelBundleTest {
       assertEquals("save/control_dependency", saverDef.getSaveTensorName());
       assertEquals("save/restore_all", saverDef.getRestoreOpName());
 
-      assertEquals(2, savedModel.metaGraphDef().getSignatureDefCount());
+      assertEquals(1, savedModel.metaGraphDef().getSignatureDefCount());
       assertTrue(savedModel.metaGraphDef().getSignatureDefMap().containsKey(Signature.DEFAULT_KEY));
 
       TensorFunction function = savedModel.function(Signature.DEFAULT_KEY);

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
@@ -562,25 +562,7 @@ public final class OperatorProcessor extends AbstractProcessor {
             .returns(Names.Ops)
             .addStatement("return new $T(scope.withInitScope())", Names.Ops)
             .addJavadoc(
-                "Returns an API that builds init operations.  {@link #liftToInitScope(Operand)} will be called for all created operations.\n"
-                    + initScopeComment
-                    + "\n@see #liftToInitScope(Operand)")
-            .build());
-
-    TypeVariableName T = TypeVariableName.get("T").withBounds(Names.Operand);
-    opsBuilder.addMethod(
-        MethodSpec.methodBuilder("liftToInitScope")
-            .addTypeVariable(T)
-            .addModifiers(Modifier.PUBLIC)
-            .addParameter(T, "op")
-            .returns(T)
-            .addStatement("scope.env().registerInitOp(op.op())")
-            .addStatement("return op")
-            .addJavadoc(
-                "Make {@code op} an init operation, doing the same for all of it's inputs (and control inputs).\n"
-                    + initScopeComment
-                    + "\n@see ExecutionEnvironment#registerInitOp(Operation)\n"
-                    + "\n@throws IllegalStateException if the op or one of its inputs can't be made an init op.")
+                "Returns an API that builds init operations.\n" + initScopeComment)
             .build());
 
     opsBuilder.addMethod(

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/processor/operator/OperatorProcessor.java
@@ -561,8 +561,7 @@ public final class OperatorProcessor extends AbstractProcessor {
             .addModifiers(Modifier.PUBLIC)
             .returns(Names.Ops)
             .addStatement("return new $T(scope.withInitScope())", Names.Ops)
-            .addJavadoc(
-                "Returns an API that builds init operations.\n" + initScopeComment)
+            .addJavadoc("Returns an API that builds init operations.\n" + initScopeComment)
             .build());
 
     opsBuilder.addMethod(

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/activations/SELU.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/activations/SELU.java
@@ -34,8 +34,8 @@ import org.tensorflow.types.family.TNumber;
  * <p>where {@code alpha} and {@code scale} are pre-defined constants ({@code alpha=1.67326324} and
  * {@code scale=1.05070098}).
  *
- * <p>Basically, the SELU activation function multiplies {@code scale} (&gt; 1) with the output of the
- * elu function to ensure a slope larger than one for positive inputs.
+ * <p>Basically, the SELU activation function multiplies {@code scale} (&gt; 1) with the output of
+ * the elu function to ensure a slope larger than one for positive inputs.
  *
  * <p>The values of {@code alpha} and {@code scale} are chosen so that the mean and variance of the
  * inputs are preserved between two consecutive layers as long as the weights are initialized

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/activations/Sigmoid.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/activations/Sigmoid.java
@@ -24,9 +24,8 @@ import org.tensorflow.types.family.TNumber;
 /**
  * Sigmoid activation. {@code sigmoid(x) = 1 / (1 + exp(-x))}.
  *
- * <p>Applies the sigmoid activation function. For small values (&lt;-5), {@code sigmoid}
- * returns a value close to zero, and for large values (&gt;5) the result of the function gets close to
- * 1.
+ * <p>Applies the sigmoid activation function. For small values (&lt;-5), {@code sigmoid} returns a
+ * value close to zero, and for large values (&gt;5) the result of the function gets close to 1.
  *
  * <p>Sigmoid is equivalent to a 2-element Softmax, where the second element is assumed to be zero.
  * The sigmoid function always returns a value between 0 and 1.

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/data/Dataset.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/data/Dataset.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
+
 import org.tensorflow.Operand;
 import org.tensorflow.framework.data.impl.BatchDataset;
 import org.tensorflow.framework.data.impl.MapDataset;
@@ -263,8 +264,7 @@ public abstract class Dataset implements Iterable<List<Operand<?>>> {
    */
   public DatasetIterator makeOneShotIterator() {
     DatasetIterator iterator = makeInitializeableIterator();
-    // TODO should pass the scope instead
-    tf.scope().env().registerInitOp(iterator.makeInitializer(this).op());
+    iterator.makeInitializer(this);
     return iterator;
   }
 

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/data/Dataset.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/data/Dataset.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
-
 import org.tensorflow.Operand;
 import org.tensorflow.framework.data.impl.BatchDataset;
 import org.tensorflow.framework.data.impl.MapDataset;

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/data/DatasetIterator.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/data/DatasetIterator.java
@@ -15,15 +15,14 @@
  */
 package org.tensorflow.framework.data;
 
-import org.tensorflow.Graph;
-import org.tensorflow.Operand;
-import org.tensorflow.op.Op;
-import org.tensorflow.op.Ops;
-import org.tensorflow.ndarray.Shape;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import org.tensorflow.Graph;
+import org.tensorflow.Operand;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.types.family.TType;
 
 /**
@@ -115,8 +114,8 @@ public class DatasetIterator implements Iterable<List<Operand<?>>> {
    * @param iteratorResource An Operand representing the iterator (e.g. constructed from
    *     `tf.data.iterator` or `tf.data.anonymousIterator`)
    * @param initializer An `Op` that should be run to initialize this iterator
-   * @param outputTypes A list of classes corresponding to the tensor type of each component of
-   *     a dataset element.
+   * @param outputTypes A list of classes corresponding to the tensor type of each component of a
+   *     dataset element.
    * @param outputShapes A list of `Shape` objects corresponding to the shapes of each component of
    *     a dataset element.
    */
@@ -221,7 +220,8 @@ public class DatasetIterator implements Iterable<List<Operand<?>>> {
           "Dataset structure (types, " + "output shapes) must match this iterator.");
     }
 
-    this.initializer = tf.withInitScope().data.makeIterator(dataset.getVariant(), getIteratorResource());
+    this.initializer =
+        tf.withInitScope().data.makeIterator(dataset.getVariant(), getIteratorResource());
     return this.initializer;
   }
 
@@ -229,8 +229,8 @@ public class DatasetIterator implements Iterable<List<Operand<?>>> {
    * Creates a new iterator from a "structure" defined by `outputShapes` and `outputTypes`.
    *
    * @param tf Ops accessor
-   * @param outputTypes A list of classes repesenting the tensor type of each component of a
-   *     dataset element.
+   * @param outputTypes A list of classes repesenting the tensor type of each component of a dataset
+   *     element.
    * @param outputShapes A list of Shape objects representing the shape of each component of a
    *     dataset element.
    * @return A new DatasetIterator

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/data/DatasetIterator.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/data/DatasetIterator.java
@@ -221,7 +221,7 @@ public class DatasetIterator implements Iterable<List<Operand<?>>> {
           "Dataset structure (types, " + "output shapes) must match this iterator.");
     }
 
-    this.initializer = tf.data.makeIterator(dataset.getVariant(), getIteratorResource());
+    this.initializer = tf.withInitScope().data.makeIterator(dataset.getVariant(), getIteratorResource());
     return this.initializer;
   }
 


### PR DESCRIPTION
This PR simplifies how TF Java handles automatic graph initialization. Actual implementation might be too complex for what users need and, as we see in https://github.com/tensorflow/java/issues/461, might also be a cause of additional latency when running model inference.

In a nutshell, the refactoring consists of:
- removing endpoints or functionalities that we do not judge essential for the users
- preserve a single 'Init' op for running all initializations, by creating or mutating its protodef on export
- limit overhead of checking the initialization state of a session when running inference

CC\ @rnett 