### PR TITLE
Adding a hook for loading TF IO native libraries

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019-2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.tensorflow.internal.c_api.global.tensorflow.TF_DeleteLibraryHa
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_GetAllOpList;
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_GetOpList;
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_LoadLibrary;
+import static org.tensorflow.internal.c_api.global.tensorflow.TF_RegisterFilesystemPlugin;
 import static org.tensorflow.internal.c_api.global.tensorflow.TF_Version;
 
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -105,6 +106,20 @@ public final class TensorFlow {
       return libraryOpList(h);
     } finally {
       libraryDelete(h);
+    }
+  }
+
+  /**
+   * Loads the filesystem plugin from fielname and registers all the filesystems it supports.
+   * <p>
+   * Throws a TF runtime exception if the plugin failed to load.
+   * @param filename Path of the dynamic library containing the filesystem support.
+   */
+  public static void registerFilesystemPlugin(String filename) {
+    try (PointerScope scope = new PointerScope()) {
+      TF_Status status = TF_Status.newStatus();
+      TF_RegisterFilesystemPlugin(filename, status);
+      status.throwExceptionIfNotOK();
     }
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
@@ -111,8 +111,8 @@ public final class TensorFlow {
 
   /**
    * Loads the filesystem plugin from filename and registers all the filesystems it supports.
-   * <p>
-   * Throws a TF runtime exception if the plugin failed to load.
+   * <p>Throws a TF runtime exception if the plugin failed to load.
+   *
    * @param filename Path of the dynamic library containing the filesystem support.
    */
   public static void registerFilesystemPlugin(String filename) {

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
@@ -111,6 +111,7 @@ public final class TensorFlow {
 
   /**
    * Loads the filesystem plugin from filename and registers all the filesystems it supports.
+   *
    * <p>Throws a TF runtime exception if the plugin failed to load.
    *
    * @param filename Path of the dynamic library containing the filesystem support.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorFlow.java
@@ -110,7 +110,7 @@ public final class TensorFlow {
   }
 
   /**
-   * Loads the filesystem plugin from fielname and registers all the filesystems it supports.
+   * Loads the filesystem plugin from filename and registers all the filesystems it supports.
    * <p>
    * Throws a TF runtime exception if the plugin failed to load.
    * @param filename Path of the dynamic library containing the filesystem support.


### PR DESCRIPTION
This exposes the C API method to load in a TF IO filesystem plugin. We can't test it without adding a bunch of binaries to the build, but it seems to load TF IO 2.9 without incident. I checked it by loading `<python-3.8-venv>/lib/python3.8/site-packages/tensorflow_io/python/ops/libtensorflow_io_plugins.so`.

This will help users with issues like #429, though they'll still need to download and unpack TF IO separately.