### PR TITLE
Add TUint16 type

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TUint16Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TUint16Mapper.java
@@ -1,0 +1,136 @@
+/*
+ *  Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  =======================================================================
+ */
+package org.tensorflow.internal.types;
+
+import org.bytedeco.javacpp.PointerScope;
+import org.tensorflow.RawTensor;
+import org.tensorflow.SparseTensor;
+import org.tensorflow.TensorMapper;
+import org.tensorflow.internal.buffer.TensorBuffers;
+import org.tensorflow.ndarray.buffer.ByteDataBuffer;
+import org.tensorflow.ndarray.impl.dense.ByteDenseNdArray;
+import org.tensorflow.ndarray.impl.sparse.ByteSparseNdArray;
+import org.tensorflow.proto.framework.DataType;
+import org.tensorflow.types.TInt64;
+import org.tensorflow.types.TUint16;
+
+/**
+ * Maps memory of {@link org.tensorflow.proto.framework.DataType#DT_Uint16} tensors to a
+ * n-dimensional data space.
+ */
+public final class TUint16Mapper extends TensorMapper<TUint16> {
+
+  @Override
+  protected TUint16 mapDense(RawTensor tensor) {
+    ByteDataBuffer buffer = TensorBuffers.toBytes(nativeHandle(tensor));
+    return new DenseTUint16(tensor, buffer);
+  }
+
+  @Override
+  protected SparseTensor<TUint16> mapSparse(
+      TInt64 indices, TUint16 values, TInt64 denseShape, PointerScope tensorScope) {
+    return new TUint16Mapper.SparseTUint16(indices, values, denseShape, tensorScope);
+  }
+
+  private static final class DenseTUint16 extends ByteDenseNdArray implements TUint16 {
+
+    @Override
+    public Class<TUint16> type() {
+      return TUint16.class;
+    }
+
+    @Override
+    public DataType dataType() {
+      return asRawTensor().dataType();
+    }
+
+    @Override
+    public long numBytes() {
+      return asRawTensor().numBytes();
+    }
+
+    @Override
+    public void close() {
+      asRawTensor().close();
+    }
+
+    @Override
+    public RawTensor asRawTensor() {
+      return rawTensor;
+    }
+
+    final RawTensor rawTensor;
+
+    DenseTUint16(RawTensor rawTensor, ByteDataBuffer buffer) {
+      super(buffer, rawTensor.shape());
+      this.rawTensor = rawTensor;
+    }
+  }
+
+  private static final class SparseTUint16 extends ByteSparseNdArray
+      implements TUint16, SparseTensor<TUint16> {
+
+    @Override
+    public Class<TUint16> type() {
+      return TUint16.class;
+    }
+
+    @Override
+    public DataType dataType() {
+      return values().dataType();
+    }
+
+    @Override
+    public long numBytes() {
+      return SparseHelpers.numBytes(this);
+    }
+
+    @Override
+    public void close() {
+      tensorScope.close();
+    }
+
+    @Override
+    public boolean isSparse() {
+      return true;
+    }
+
+    @Override
+    public TInt64 indices() {
+      return (TInt64) getIndices();
+    }
+
+    @Override
+    public TUint16 values() {
+      return (TUint16) getValues();
+    }
+
+    @Override
+    public TInt64 denseShape() {
+      return denseShape;
+    }
+
+    SparseTUint16(TInt64 indices, TUint16 values, TInt64 denseShape, PointerScope tensorScope) {
+      super(indices, values, (byte) 0, SparseHelpers.toDimensionalSpace(denseShape));
+      this.denseShape = denseShape;
+      this.tensorScope = tensorScope.extend();
+    }
+
+    private final TInt64 denseShape;
+    private final PointerScope tensorScope;
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TUint16Mapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/TUint16Mapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2022 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import org.tensorflow.RawTensor;
 import org.tensorflow.SparseTensor;
 import org.tensorflow.TensorMapper;
 import org.tensorflow.internal.buffer.TensorBuffers;
-import org.tensorflow.ndarray.buffer.ByteDataBuffer;
-import org.tensorflow.ndarray.impl.dense.ByteDenseNdArray;
-import org.tensorflow.ndarray.impl.sparse.ByteSparseNdArray;
+import org.tensorflow.ndarray.buffer.ShortDataBuffer;
+import org.tensorflow.ndarray.impl.dense.ShortDenseNdArray;
+import org.tensorflow.ndarray.impl.sparse.ShortSparseNdArray;
 import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.types.TInt64;
 import org.tensorflow.types.TUint16;
@@ -36,7 +36,7 @@ public final class TUint16Mapper extends TensorMapper<TUint16> {
 
   @Override
   protected TUint16 mapDense(RawTensor tensor) {
-    ByteDataBuffer buffer = TensorBuffers.toBytes(nativeHandle(tensor));
+    ShortDataBuffer buffer = TensorBuffers.toShorts(nativeHandle(tensor));
     return new DenseTUint16(tensor, buffer);
   }
 
@@ -46,7 +46,7 @@ public final class TUint16Mapper extends TensorMapper<TUint16> {
     return new TUint16Mapper.SparseTUint16(indices, values, denseShape, tensorScope);
   }
 
-  private static final class DenseTUint16 extends ByteDenseNdArray implements TUint16 {
+  private static final class DenseTUint16 extends ShortDenseNdArray implements TUint16 {
 
     @Override
     public Class<TUint16> type() {
@@ -75,13 +75,13 @@ public final class TUint16Mapper extends TensorMapper<TUint16> {
 
     final RawTensor rawTensor;
 
-    DenseTUint16(RawTensor rawTensor, ByteDataBuffer buffer) {
+    DenseTUint16(RawTensor rawTensor, ShortDataBuffer buffer) {
       super(buffer, rawTensor.shape());
       this.rawTensor = rawTensor;
     }
   }
 
-  private static final class SparseTUint16 extends ByteSparseNdArray
+  private static final class SparseTUint16 extends ShortSparseNdArray
       implements TUint16, SparseTensor<TUint16> {
 
     @Override
@@ -125,7 +125,7 @@ public final class TUint16Mapper extends TensorMapper<TUint16> {
     }
 
     SparseTUint16(TInt64 indices, TUint16 values, TInt64 denseShape, PointerScope tensorScope) {
-      super(indices, values, (byte) 0, SparseHelpers.toDimensionalSpace(denseShape));
+      super(indices, values, (short) 0, SparseHelpers.toDimensionalSpace(denseShape));
       this.denseShape = denseShape;
       this.tensorScope = tensorScope.extend();
     }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/registry/TensorTypeRegistry.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/registry/TensorTypeRegistry.java
@@ -29,6 +29,7 @@ import org.tensorflow.types.TInt32;
 import org.tensorflow.types.TInt64;
 import org.tensorflow.types.TString;
 import org.tensorflow.types.TUint8;
+import org.tensorflow.types.TUint16;
 import org.tensorflow.types.annotation.TensorType;
 import org.tensorflow.types.family.TType;
 
@@ -100,6 +101,7 @@ public final class TensorTypeRegistry {
     register(TInt64.class);
     register(TString.class);
     register(TUint8.class);
+    register(TUint16.class);
     register(TBfloat16.class);
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/registry/TensorTypeRegistry.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/internal/types/registry/TensorTypeRegistry.java
@@ -28,14 +28,12 @@ import org.tensorflow.types.TFloat64;
 import org.tensorflow.types.TInt32;
 import org.tensorflow.types.TInt64;
 import org.tensorflow.types.TString;
-import org.tensorflow.types.TUint8;
 import org.tensorflow.types.TUint16;
+import org.tensorflow.types.TUint8;
 import org.tensorflow.types.annotation.TensorType;
 import org.tensorflow.types.family.TType;
 
-/**
- * Repository of all registered tensor types.
- */
+/** Repository of all registered tensor types. */
 public final class TensorTypeRegistry {
 
   /**
@@ -48,9 +46,10 @@ public final class TensorTypeRegistry {
   public static <T extends TType> TensorTypeInfo<T> find(DataType dataType) {
     TensorTypeInfo<?> typeInfo = TYPES_BY_CODE.get(dataType.getNumber());
     if (typeInfo == null) {
-      throw new IllegalArgumentException("No tensor type has been registered for data type " + dataType);
+      throw new IllegalArgumentException(
+          "No tensor type has been registered for data type " + dataType);
     }
-    return (TensorTypeInfo<T>)typeInfo;
+    return (TensorTypeInfo<T>) typeInfo;
   }
 
   /**
@@ -63,28 +62,37 @@ public final class TensorTypeRegistry {
   public static <T extends TType> TensorTypeInfo<T> find(Class<T> type) {
     TensorTypeInfo<?> typeInfo = TYPES_BY_CLASS.get(type);
     if (typeInfo == null) {
-      throw new IllegalArgumentException("Class \"" + type.getName() + "\" is not registered as a tensor type");
+      throw new IllegalArgumentException(
+          "Class \"" + type.getName() + "\" is not registered as a tensor type");
     }
-    return (TensorTypeInfo<T>)typeInfo;
+    return (TensorTypeInfo<T>) typeInfo;
   }
 
   private static final Map<Integer, TensorTypeInfo<?>> TYPES_BY_CODE = new HashMap<>();
-  private static final Map<Class<? extends TType>, TensorTypeInfo<?>> TYPES_BY_CLASS = new HashMap<>();
+  private static final Map<Class<? extends TType>, TensorTypeInfo<?>> TYPES_BY_CLASS =
+      new HashMap<>();
 
   private static <T extends TType> void register(Class<T> type) {
     TensorType typeAnnot = type.getDeclaredAnnotation(TensorType.class);
     if (typeAnnot == null) {
-      throw new IllegalArgumentException("Class \"" + type.getName() + "\" must be annotated "
-          + "with @TensorType to be registered as a tensor type");
+      throw new IllegalArgumentException(
+          "Class \""
+              + type.getName()
+              + "\" must be annotated "
+              + "with @TensorType to be registered as a tensor type");
     }
     TensorMapper<T> mapper;
     try {
-      mapper = (TensorMapper<T>)typeAnnot.mapperClass().newInstance();
+      mapper = (TensorMapper<T>) typeAnnot.mapperClass().newInstance();
     } catch (ReflectiveOperationException e) {
-      throw new IllegalArgumentException("Class \"" + type.getName() + "\" must have a public "
-          + "parameter-less constructor to be used as a tensor mapper");
+      throw new IllegalArgumentException(
+          "Class \""
+              + type.getName()
+              + "\" must have a public "
+              + "parameter-less constructor to be used as a tensor mapper");
     }
-    TensorTypeInfo<T> typeInfo = new TensorTypeInfo<>(type, typeAnnot.dataType(), typeAnnot.byteSize(), mapper);
+    TensorTypeInfo<T> typeInfo =
+        new TensorTypeInfo<>(type, typeAnnot.dataType(), typeAnnot.byteSize(), mapper);
     TYPES_BY_CLASS.put(type, typeInfo);
     TYPES_BY_CODE.put(typeInfo.dataType().getNumber(), typeInfo);
     TYPES_BY_CODE.put(typeInfo.dataType().getNumber() + 100, typeInfo);

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2022 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,36 +22,36 @@ import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TUint16Mapper;
-import org.tensorflow.ndarray.ByteNdArray;
+import org.tensorflow.ndarray.ShortNdArray;
 import org.tensorflow.ndarray.NdArray;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.StdArrays;
-import org.tensorflow.ndarray.buffer.ByteDataBuffer;
+import org.tensorflow.ndarray.buffer.ShortDataBuffer;
 import org.tensorflow.proto.framework.DataType;
 import org.tensorflow.types.annotation.TensorType;
 import org.tensorflow.types.family.TIntegral;
 
 /** 16-bit unsigned integer tensor type. */
 @TensorType(dataType = DataType.DT_UINT16, byteSize = 2, mapperClass = TUint16Mapper.class)
-public interface TUint16 extends ByteNdArray, TIntegral {
+public interface TUint16 extends ShortNdArray, TIntegral {
 
   /**
-   * Allocates a new tensor for storing a single byte value.
+   * Allocates a new tensor for storing a single short value.
    *
-   * @param value byte to store in the new tensor
+   * @param value short to store in the new tensor
    * @return the new tensor
    */
-  static TUint16 scalarOf(byte value) {
-    return Tensor.of(TUint16.class, Shape.scalar(), data -> data.setByte(value));
+  static TUint16 scalarOf(short value) {
+    return Tensor.of(TUint16.class, Shape.scalar(), data -> data.setShort(value));
   }
 
   /**
-   * Allocates a new tensor for storing a vector of bytes.
+   * Allocates a new tensor for storing a vector of shorts.
    *
-   * @param values bytes to store in the new tensor
+   * @param values short to store in the new tensor
    * @return the new tensor
    */
-  static TUint16 vectorOf(byte... values) {
+  static TUint16 vectorOf(short... values) {
     if (values == null) {
       throw new IllegalArgumentException();
     }
@@ -59,14 +59,14 @@ public interface TUint16 extends ByteNdArray, TIntegral {
   }
 
   /**
-   * Allocates a new tensor which is a copy of a given array of bytes.
+   * Allocates a new tensor which is a copy of a given array of shorts.
    *
    * <p>The tensor will have the same shape as the source array and its data will be copied.
    *
    * @param src the source array giving the shape and data to the new tensor
    * @return the new tensor
    */
-  static TUint16 tensorOf(NdArray<Byte> src) {
+  static TUint16 tensorOf(NdArray<Short> src) {
     return Tensor.of(TUint16.class, src.shape(), src::copyTo);
   }
 
@@ -84,10 +84,10 @@ public interface TUint16 extends ByteNdArray, TIntegral {
    * Allocates a new tensor of the given shape, initialized with the provided data.
    *
    * @param shape shape of the tensor to allocate
-   * @param data buffer of bytes to initialize the tensor with
+   * @param data buffer of shorts to initialize the tensor with
    * @return the new tensor
    */
-  static TUint16 tensorOf(Shape shape, ByteDataBuffer data) {
+  static TUint16 tensorOf(Shape shape, ShortDataBuffer data) {
     return Tensor.of(TUint16.class, shape, d -> d.write(data));
   }
 

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
@@ -22,9 +22,9 @@ import org.tensorflow.SparseTensor;
 import org.tensorflow.Tensor;
 import org.tensorflow.exceptions.TensorFlowException;
 import org.tensorflow.internal.types.TUint16Mapper;
-import org.tensorflow.ndarray.ShortNdArray;
 import org.tensorflow.ndarray.NdArray;
 import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.ShortNdArray;
 import org.tensorflow.ndarray.StdArrays;
 import org.tensorflow.ndarray.buffer.ShortDataBuffer;
 import org.tensorflow.proto.framework.DataType;
@@ -55,7 +55,8 @@ public interface TUint16 extends ShortNdArray, TIntegral {
     if (values == null) {
       throw new IllegalArgumentException();
     }
-    return Tensor.of(TUint16.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
+    return Tensor.of(
+        TUint16.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  =======================================================================
+ */
+
+package org.tensorflow.types;
+
+import java.util.function.Consumer;
+import org.tensorflow.SparseTensor;
+import org.tensorflow.Tensor;
+import org.tensorflow.exceptions.TensorFlowException;
+import org.tensorflow.internal.types.TUint16Mapper;
+import org.tensorflow.ndarray.ByteNdArray;
+import org.tensorflow.ndarray.NdArray;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.ndarray.StdArrays;
+import org.tensorflow.ndarray.buffer.ByteDataBuffer;
+import org.tensorflow.proto.framework.DataType;
+import org.tensorflow.types.annotation.TensorType;
+import org.tensorflow.types.family.TIntegral;
+
+/** 16-bit unsigned integer tensor type. */
+@TensorType(dataType = DataType.DT_UINT16, byteSize = 2, mapperClass = TUint16Mapper.class)
+public interface TUint16 extends ByteNdArray, TIntegral {
+
+  /**
+   * Allocates a new tensor for storing a single byte value.
+   *
+   * @param value byte to store in the new tensor
+   * @return the new tensor
+   */
+  static TUint16 scalarOf(byte value) {
+    return Tensor.of(TUint16.class, Shape.scalar(), data -> data.setByte(value));
+  }
+
+  /**
+   * Allocates a new tensor for storing a vector of bytes.
+   *
+   * @param values bytes to store in the new tensor
+   * @return the new tensor
+   */
+  static TUint16 vectorOf(byte... values) {
+    if (values == null) {
+      throw new IllegalArgumentException();
+    }
+    return Tensor.of(TUint16.class, Shape.of(values.length), data -> StdArrays.copyTo(values, data));
+  }
+
+  /**
+   * Allocates a new tensor which is a copy of a given array of bytes.
+   *
+   * <p>The tensor will have the same shape as the source array and its data will be copied.
+   *
+   * @param src the source array giving the shape and data to the new tensor
+   * @return the new tensor
+   */
+  static TUint16 tensorOf(NdArray<Byte> src) {
+    return Tensor.of(TUint16.class, src.shape(), src::copyTo);
+  }
+
+  /**
+   * Allocates a new tensor of the given shape.
+   *
+   * @param shape shape of the tensor to allocate
+   * @return the new tensor
+   */
+  static TUint16 tensorOf(Shape shape) {
+    return Tensor.of(TUint16.class, shape);
+  }
+
+  /**
+   * Allocates a new tensor of the given shape, initialized with the provided data.
+   *
+   * @param shape shape of the tensor to allocate
+   * @param data buffer of bytes to initialize the tensor with
+   * @return the new tensor
+   */
+  static TUint16 tensorOf(Shape shape, ByteDataBuffer data) {
+    return Tensor.of(TUint16.class, shape, d -> d.write(data));
+  }
+
+  /**
+   * Allocates a new tensor of the given shape and initialize its data.
+   *
+   * @param shape shape of the tensor to allocate
+   * @param dataInit tensor data initializer
+   * @return the new tensor
+   * @throws TensorFlowException if the tensor cannot be allocated or initialized
+   */
+  static TUint16 tensorOf(Shape shape, Consumer<TUint16> dataInit) {
+    return Tensor.of(TUint16.class, shape, dataInit);
+  }
+
+  /**
+   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * tensors, with a default value of zero.
+   *
+   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TUint16>}
+   * interface, allowing a user to access directly the dense tensors when needed.
+   *
+   * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3,1], [2,4,0]]} specifies that the elements with indexes of
+   *     {@code [1,3,1]} and {@code [2,4,0]} have non-default values.
+   * @param values A 1-D tensor of shape {@code [N]}, which supplies the values for each element in
+   *     indices. For example, given {@code indices=[[1,3,1], [2,4,0]]}, the parameter {@code
+   *     values=[18, 3]} specifies that element {@code [1,3,1]} of the sparse tensor has a value of
+   *     {@code 18}, and element {@code [2,4,0]} of the tensor has a value of {@code 3}.
+   * @param denseShape A 1-D tensor of shape {@code [ndims]} where each the value at index {@code i}
+   *     represents the size of dimension {@code i} in a dense version of that tensor.
+   * @return the new sparse tensor
+   * @see SparseTensor for more details on sparse tensors and how to release their memory properly
+   */
+  static TUint16 sparseTensorOf(TInt64 indices, TUint16 values, TInt64 denseShape) {
+    return SparseTensor.of(indices, values, denseShape).asTypedTensor();
+  }
+}

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/NumericTypesTestBase.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/NumericTypesTestBase.java
@@ -39,38 +39,39 @@ abstract class NumericTypesTestBase<T extends TNumber, U> {
 
     assertEquals(3, tensor.rank());
     assertEquals(12, tensor.size());
-    NdArray<U> data = (NdArray<U>)tensor;
+    NdArray<U> data = (NdArray<U>) tensor;
 
     try (EagerSession session = EagerSession.create()) {
       Ops tf = Ops.create(session);
 
       // Initialize tensor memory with zeros and take a snapshot
-      data.scalars().forEach(scalar -> ((NdArray<U>)scalar).setObject(valueOf(0)));
+      data.scalars().forEach(scalar -> ((NdArray<U>) scalar).setObject(valueOf(0)));
       Constant<T> x = tf.constantOf(tensor);
 
       // Initialize the same tensor memory with ones and take a snapshot
-      data.scalars().forEach(scalar -> ((NdArray<U>)scalar).setObject(valueOf(1)));
+      data.scalars().forEach(scalar -> ((NdArray<U>) scalar).setObject(valueOf(1)));
       Constant<T> y = tf.constantOf(tensor);
 
       // Subtract y from x and validate the result
       Sub<T> sub = tf.math.sub(x, y);
-      ((NdArray<U>)sub.asTensor()).scalars().forEach(scalar ->
-          assertEquals(valueOf(-1), scalar.getObject())
-      );
+      ((NdArray<U>) sub.asTensor())
+          .scalars()
+          .forEach(scalar -> assertEquals(valueOf(-1), scalar.getObject()));
     }
   }
 
   @Test
   public void setAndCompute() {
-    NdArray<U> heapData = allocateNdArray(Shape.of(4))
-        .setObject(valueOf(0), 0)
-        .setObject(valueOf(1), 1)
-        .setObject(valueOf(2), 2)
-        .setObject(valueOf(3), 3);
+    NdArray<U> heapData =
+        allocateNdArray(Shape.of(4))
+            .setObject(valueOf(0), 0)
+            .setObject(valueOf(1), 1)
+            .setObject(valueOf(2), 2)
+            .setObject(valueOf(3), 3);
 
     // Creates a 2x2 matrix
     try (T tensor = allocateTensor(Shape.of(2, 2))) {
-      NdArray<U> data = (NdArray<U>)tensor;
+      NdArray<U> data = (NdArray<U>) tensor;
 
       // Copy first 2 values of the vector to the first row of the matrix
       data.set(heapData.slice(Indices.range(0, 2)), 0);
@@ -94,13 +95,13 @@ abstract class NumericTypesTestBase<T extends TNumber, U> {
       try (EagerSession session = EagerSession.create()) {
         Ops tf = Ops.create(session);
 
-        Add<T> add = tf.math.add(tf.constantOf(tensor), tf.constantOf(tensor));
-        NdArray<U> result = (NdArray<U>)add.asTensor();
+        Sub<T> sub = tf.math.sub(tf.constantOf(tensor), tf.constantOf(tensor));
+        NdArray<U> result = (NdArray<U>) sub.asTensor();
 
         assertEquals(valueOf(0), result.getObject(0, 0));
-        assertEquals(valueOf(2), result.getObject(0, 1));
-        assertEquals(valueOf(2), result.getObject(1, 0));
-        assertEquals(valueOf(6), result.getObject(1, 1));
+        assertEquals(valueOf(0), result.getObject(0, 1));
+        assertEquals(valueOf(0), result.getObject(1, 0));
+        assertEquals(valueOf(0), result.getObject(1, 1));
       }
     }
   }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/NumericTypesTestBase.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/NumericTypesTestBase.java
@@ -26,7 +26,6 @@ import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.index.Indices;
 import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Constant;
-import org.tensorflow.op.math.Add;
 import org.tensorflow.op.math.Sub;
 import org.tensorflow.types.family.TNumber;
 

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TUint16Test.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TUint16Test.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2022 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.tensorflow.ndarray.NdArray;
 import org.tensorflow.ndarray.NdArrays;
 import org.tensorflow.ndarray.Shape;
 
-public class TUint16Test extends NumericTypesTestBase<TUint16, Byte> {
+public class TUint16Test extends NumericTypesTestBase<TUint16, Short> {
 
   @Override
   TUint16 allocateTensor(Shape shape) {
@@ -29,12 +29,12 @@ public class TUint16Test extends NumericTypesTestBase<TUint16, Byte> {
   }
 
   @Override
-  NdArray<Byte> allocateNdArray(Shape shape) {
-    return NdArrays.ofBytes(shape);
+  NdArray<Short> allocateNdArray(Shape shape) {
+    return NdArrays.ofShorts(shape);
   }
 
   @Override
-  Byte valueOf(Integer value) {
-    return value.byteValue();
+  Short valueOf(Integer value) {
+    return value.shortValue();
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TUint16Test.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/types/TUint16Test.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  =======================================================================
+ */
+
+package org.tensorflow.types;
+
+import org.tensorflow.ndarray.NdArray;
+import org.tensorflow.ndarray.NdArrays;
+import org.tensorflow.ndarray.Shape;
+
+public class TUint16Test extends NumericTypesTestBase<TUint16, Byte> {
+
+  @Override
+  TUint16 allocateTensor(Shape shape) {
+    return TUint16.tensorOf(shape);
+  }
+
+  @Override
+  NdArray<Byte> allocateNdArray(Shape shape) {
+    return NdArrays.ofBytes(shape);
+  }
+
+  @Override
+  Byte valueOf(Integer value) {
+    return value.byteValue();
+  }
+}


### PR DESCRIPTION
In medical imaging lots of the datatypes are Uint16, however, to decode pngs to this type we first need to add the Type definition. 

This MR adds the type definition to the core API such that users don't need to re-implement this type in their pkgs. 