### PR TITLE
Fix fail when a variable receives zero gradient  #482

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
@@ -147,7 +147,10 @@ public final class Output<T extends TType> implements Operand<T> {
     return operation.getUnsafeNativeHandle(index);
   }
 
-  /** Returns whether the underlying operation has no valid handle. Makes the opposite check as GraphOperation.requireHandle **/
+  /**
+   * Returns whether the underlying operation has no valid handle. Makes the opposite check as
+   * GraphOperation.requireHandle *
+   */
   public boolean isClosed() {
     Pointer handle = operation.getUnsafeNativeHandle(index);
     return handle == null || handle.isNull();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
@@ -149,7 +149,7 @@ public final class Output<T extends TType> implements Operand<T> {
 
   public boolean isClosed() {
     Pointer handle = operation.getUnsafeNativeHandle(index);
-    return handle== null || handle.isNull() ;
+    return handle == null || handle.isNull();
   }
 
   private final AbstractOperation operation;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
@@ -147,6 +147,7 @@ public final class Output<T extends TType> implements Operand<T> {
     return operation.getUnsafeNativeHandle(index);
   }
 
+  /** Returns whether the underlying operation has no valid handle. Makes the opposite check as GraphOperation.requireHandle **/
   public boolean isClosed() {
     Pointer handle = operation.getUnsafeNativeHandle(index);
     return handle == null || handle.isNull();

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Output.java
@@ -147,6 +147,11 @@ public final class Output<T extends TType> implements Operand<T> {
     return operation.getUnsafeNativeHandle(index);
   }
 
+  public boolean isClosed() {
+    Pointer handle = operation.getUnsafeNativeHandle(index);
+    return handle== null || handle.isNull() ;
+  }
+
   private final AbstractOperation operation;
   private final int index;
 }

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Optimizer.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Optimizer.java
@@ -174,7 +174,9 @@ public abstract class Optimizer {
     List<Op> updateOps = new ArrayList<>();
     prepOp.ifPresent(updateOps::add);
     for (GradAndVar<? extends TType> pair : gradsAndVars) {
-      updateOps.add(applyDense(pair));
+      if (!pair.gradient.isClosed()) {
+        updateOps.add(applyDense(pair));
+      }
     }
 
     return finish(updateOps, name);


### PR DESCRIPTION
Fixes bug #482 . A check is added in the optimizer code that the gradient of a variable is valid, and otherwise it is left out.