### PR TITLE
[linux-arm64] set "mkl_aarch64" bazel config for linux-arm64 platform

### DIFF
--- a/tensorflow-core/tensorflow-core-api/build.sh
+++ b/tensorflow-core/tensorflow-core-api/build.sh
@@ -22,6 +22,11 @@ if [[ "${PLATFORM:-}" == macosx-arm64 ]]; then
   BUILD_FLAGS="$BUILD_FLAGS --config=macos_arm64"
 fi
 
+# Add platform specific flags
+if [[ "${PLATFORM:-}" == linux-arm64 ]]; then
+  BUILD_FLAGS="--config=mkl_aarch64"
+fi
+
 if [[ "${EXTENSION:-}" == *mkl* ]]; then
     BUILD_FLAGS="$BUILD_FLAGS --config=mkl"
 fi


### PR DESCRIPTION
This is to enable TensorFlow core library bazel build with mkldnn (oneDNN) backend for linux-arm64 platforms.