### PR TITLE
Revert Conv2d backprop to V1

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/api/api_def_Conv2DBackpropFilter.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/api/api_def_Conv2DBackpropFilter.pbtxt
@@ -1,4 +1,7 @@
 op {
   graph_op_name: "Conv2DBackpropFilter"
-  visibility: SKIP
+  visibility: VISIBLE
+  endpoint {
+    name: "nn.Conv2dBackpropFilter"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/api/api_def_Conv2DBackpropFilterV2.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/api/api_def_Conv2DBackpropFilterV2.pbtxt
@@ -1,6 +1,7 @@
 op {
   graph_op_name: "Conv2DBackpropFilterV2"
+  visibility: HIDDEN
   endpoint {
-    name: "nn.Conv2dBackpropFilter"
+    name: "nn.Conv2dBackpropFilterV2"
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/api/api_def_Conv2DBackpropInput.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/api/api_def_Conv2DBackpropInput.pbtxt
@@ -1,4 +1,7 @@
 op {
   graph_op_name: "Conv2DBackpropInput"
-  visibility: SKIP
+  visibility: VISIBLE
+  endpoint {
+    name: "nn.Conv2dBackpropInput"
+  }
 }

--- a/tensorflow-core/tensorflow-core-api/src/api/api_def_Conv2DBackpropInputV2.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/api/api_def_Conv2DBackpropInputV2.pbtxt
@@ -1,6 +1,7 @@
 op {
   graph_op_name: "Conv2DBackpropInputV2"
+  visibility: HIDDEN
   endpoint {
-    name: "nn.Conv2dBackpropInput"
+    name: "nn.Conv2dBackpropInputV2"
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnOps.java
@@ -355,8 +355,9 @@ public final class NnOps {
    *
    * @param <T> data type for {@code output} output
    * @param input 4-D with shape {@code [batch, in_height, in_width, in_channels]}.
-   * @param filter 4-D with shape {@code [filter_height, filter_width, in_channels, out_channels]}.
-   *  Only shape of tensor is used.
+   * @param filterSizes An integer vector representing the tensor shape of {@code filter},
+   *  where {@code filter} is a 4-D
+   *  {@code [filter_height, filter_width, in_channels, out_channels]} tensor.
    * @param outBackprop 4-D with shape {@code [batch, out_height, out_width, out_channels]}.
    *  Gradients w.r.t. the output of the convolution.
    * @param strides The stride of the sliding window for each dimension of the input
@@ -364,21 +365,21 @@ public final class NnOps {
    *  format.
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attribute values
-   * @param <T> data type for {@code Conv2DBackpropFilterV2} output and operands
+   * @param <T> data type for {@code Conv2DBackpropFilter} output and operands
    * @return a new instance of Conv2dBackpropFilter
    */
   public <T extends TNumber> Conv2dBackpropFilter<T> conv2dBackpropFilter(Operand<T> input,
-      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, String padding,
+      Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides, String padding,
       Conv2dBackpropFilter.Options... options) {
-    return Conv2dBackpropFilter.create(scope, input, filter, outBackprop, strides, padding, options);
+    return Conv2dBackpropFilter.create(scope, input, filterSizes, outBackprop, strides, padding, options);
   }
 
   /**
    * Computes the gradients of convolution with respect to the input.
    *
    * @param <T> data type for {@code output} output
-   * @param input 4-D with shape {@code [batch, in_height, in_width, in_channels]}.
-   *  Only shape of tensor is used.
+   * @param inputSizes An integer vector representing the shape of {@code input},
+   *  where {@code input} is a 4-D {@code [batch, height, width, channels]} tensor.
    * @param filter 4-D with shape
    *  {@code [filter_height, filter_width, in_channels, out_channels]}.
    * @param outBackprop 4-D with shape {@code [batch, out_height, out_width, out_channels]}.
@@ -388,13 +389,13 @@ public final class NnOps {
    *  format.
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attribute values
-   * @param <T> data type for {@code Conv2DBackpropInputV2} output and operands
+   * @param <T> data type for {@code Conv2DBackpropInput} output and operands
    * @return a new instance of Conv2dBackpropInput
    */
-  public <T extends TNumber> Conv2dBackpropInput<T> conv2dBackpropInput(Operand<T> input,
+  public <T extends TNumber> Conv2dBackpropInput<T> conv2dBackpropInput(Operand<TInt32> inputSizes,
       Operand<T> filter, Operand<T> outBackprop, List<Long> strides, String padding,
       Conv2dBackpropInput.Options... options) {
-    return Conv2dBackpropInput.create(scope, input, filter, outBackprop, strides, padding, options);
+    return Conv2dBackpropInput.create(scope, inputSizes, filter, outBackprop, strides, padding, options);
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/nn/Conv2dBackpropFilterV2.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/nn/Conv2dBackpropFilterV2.java
@@ -30,9 +30,7 @@ import org.tensorflow.op.Scope;
 import org.tensorflow.op.annotation.Endpoint;
 import org.tensorflow.op.annotation.OpInputsMetadata;
 import org.tensorflow.op.annotation.OpMetadata;
-import org.tensorflow.op.annotation.Operator;
 import org.tensorflow.proto.DataType;
-import org.tensorflow.types.TInt32;
 import org.tensorflow.types.family.TNumber;
 
 /**
@@ -41,34 +39,30 @@ import org.tensorflow.types.family.TNumber;
  * @param <T> data type for {@code output} output
  */
 @OpMetadata(
-    opType = Conv2dBackpropFilter.OP_NAME,
-    inputsClass = Conv2dBackpropFilter.Inputs.class
+    opType = Conv2dBackpropFilterV2.OP_NAME,
+    inputsClass = Conv2dBackpropFilterV2.Inputs.class
 )
-@Operator(
-    group = "nn"
-)
-public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp implements Operand<T> {
+public final class Conv2dBackpropFilterV2<T extends TNumber> extends RawOp implements Operand<T> {
   /**
    * The name of this op, as known by TensorFlow core engine
    */
-  public static final String OP_NAME = "Conv2DBackpropFilter";
+  public static final String OP_NAME = "Conv2DBackpropFilterV2";
 
   private Output<T> output;
 
-  public Conv2dBackpropFilter(Operation operation) {
+  public Conv2dBackpropFilterV2(Operation operation) {
     super(operation, OP_NAME);
     int outputIdx = 0;
     output = operation.output(outputIdx++);
   }
 
   /**
-   * Factory method to create a class wrapping a new Conv2DBackpropFilter operation.
+   * Factory method to create a class wrapping a new Conv2DBackpropFilterV2 operation.
    *
    * @param scope current scope
    * @param input 4-D with shape {@code [batch, in_height, in_width, in_channels]}.
-   * @param filterSizes An integer vector representing the tensor shape of {@code filter},
-   * where {@code filter} is a 4-D
-   * {@code [filter_height, filter_width, in_channels, out_channels]} tensor.
+   * @param filter 4-D with shape {@code [filter_height, filter_width, in_channels, out_channels]}.
+   * Only shape of tensor is used.
    * @param outBackprop 4-D with shape {@code [batch, out_height, out_width, out_channels]}.
    * Gradients w.r.t. the output of the convolution.
    * @param strides The stride of the sliding window for each dimension of the input
@@ -76,18 +70,18 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
    * format.
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attribute values
-   * @param <T> data type for {@code Conv2DBackpropFilter} output and operands
-   * @return a new instance of Conv2dBackpropFilter
+   * @param <T> data type for {@code Conv2DBackpropFilterV2} output and operands
+   * @return a new instance of Conv2dBackpropFilterV2
    */
   @Endpoint(
       describeByClass = true
   )
-  public static <T extends TNumber> Conv2dBackpropFilter<T> create(Scope scope, Operand<T> input,
-      Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides, String padding,
+  public static <T extends TNumber> Conv2dBackpropFilterV2<T> create(Scope scope, Operand<T> input,
+      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, String padding,
       Options... options) {
-    OperationBuilder opBuilder = scope.opBuilder(OP_NAME, "Conv2dBackpropFilter");
+    OperationBuilder opBuilder = scope.opBuilder(OP_NAME, "Conv2dBackpropFilterV2");
     opBuilder.addInput(input.asOutput());
-    opBuilder.addInput(filterSizes.asOutput());
+    opBuilder.addInput(filter.asOutput());
     opBuilder.addInput(outBackprop.asOutput());
     long[] stridesArray = new long[strides.size()];
     for (int i = 0 ; i < stridesArray.length ; i++) {
@@ -119,7 +113,7 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
         }
       }
     }
-    return new Conv2dBackpropFilter<>(opBuilder.build());
+    return new Conv2dBackpropFilterV2<>(opBuilder.build());
   }
 
   /**
@@ -217,7 +211,7 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
   }
 
   /**
-   * Optional attributes for {@link org.tensorflow.op.nn.Conv2dBackpropFilter}
+   * Optional attributes for {@link org.tensorflow.op.nn.Conv2dBackpropFilterV2}
    */
   public static class Options {
     private Boolean useCudnnOnGpu;
@@ -317,20 +311,19 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
   }
 
   @OpInputsMetadata(
-      outputsClass = Conv2dBackpropFilter.class
+      outputsClass = Conv2dBackpropFilterV2.class
   )
-  public static class Inputs<T extends TNumber> extends RawOpInputs<Conv2dBackpropFilter<T>> {
+  public static class Inputs<T extends TNumber> extends RawOpInputs<Conv2dBackpropFilterV2<T>> {
     /**
      * 4-D with shape {@code [batch, in_height, in_width, in_channels]}.
      */
     public final Operand<T> input;
 
     /**
-     * An integer vector representing the tensor shape of {@code filter},
-     * where {@code filter} is a 4-D
-     * {@code [filter_height, filter_width, in_channels, out_channels]} tensor.
+     * 4-D with shape {@code [filter_height, filter_width, in_channels, out_channels]}.
+     * Only shape of tensor is used.
      */
-    public final Operand<TInt32> filterSizes;
+    public final Operand<T> filter;
 
     /**
      * 4-D with shape {@code [batch, out_height, out_width, out_channels]}.
@@ -387,10 +380,10 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
     public final long[] dilations;
 
     public Inputs(GraphOperation op) {
-      super(new Conv2dBackpropFilter<>(op), op, Arrays.asList("T", "strides", "use_cudnn_on_gpu", "padding", "explicit_paddings", "data_format", "dilations"));
+      super(new Conv2dBackpropFilterV2<>(op), op, Arrays.asList("T", "strides", "use_cudnn_on_gpu", "padding", "explicit_paddings", "data_format", "dilations"));
       int inputIndex = 0;
       input = (Operand<T>) op.input(inputIndex++);
-      filterSizes = (Operand<TInt32>) op.input(inputIndex++);
+      filter = (Operand<T>) op.input(inputIndex++);
       outBackprop = (Operand<T>) op.input(inputIndex++);
       T = op.attributes().getAttrType("T");
       strides = op.attributes().getAttrIntList("strides");

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/nn/Conv2dBackpropInput.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/nn/Conv2dBackpropInput.java
@@ -32,6 +32,7 @@ import org.tensorflow.op.annotation.OpInputsMetadata;
 import org.tensorflow.op.annotation.OpMetadata;
 import org.tensorflow.op.annotation.Operator;
 import org.tensorflow.proto.DataType;
+import org.tensorflow.types.TInt32;
 import org.tensorflow.types.family.TNumber;
 
 /**
@@ -50,7 +51,7 @@ public final class Conv2dBackpropInput<T extends TNumber> extends RawOp implemen
   /**
    * The name of this op, as known by TensorFlow core engine
    */
-  public static final String OP_NAME = "Conv2DBackpropInputV2";
+  public static final String OP_NAME = "Conv2DBackpropInput";
 
   private Output<T> output;
 
@@ -61,11 +62,11 @@ public final class Conv2dBackpropInput<T extends TNumber> extends RawOp implemen
   }
 
   /**
-   * Factory method to create a class wrapping a new Conv2DBackpropInputV2 operation.
+   * Factory method to create a class wrapping a new Conv2DBackpropInput operation.
    *
    * @param scope current scope
-   * @param input 4-D with shape {@code [batch, in_height, in_width, in_channels]}.
-   * Only shape of tensor is used.
+   * @param inputSizes An integer vector representing the shape of {@code input},
+   * where {@code input} is a 4-D {@code [batch, height, width, channels]} tensor.
    * @param filter 4-D with shape
    * {@code [filter_height, filter_width, in_channels, out_channels]}.
    * @param outBackprop 4-D with shape {@code [batch, out_height, out_width, out_channels]}.
@@ -75,17 +76,17 @@ public final class Conv2dBackpropInput<T extends TNumber> extends RawOp implemen
    * format.
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attribute values
-   * @param <T> data type for {@code Conv2DBackpropInputV2} output and operands
+   * @param <T> data type for {@code Conv2DBackpropInput} output and operands
    * @return a new instance of Conv2dBackpropInput
    */
   @Endpoint(
       describeByClass = true
   )
-  public static <T extends TNumber> Conv2dBackpropInput<T> create(Scope scope, Operand<T> input,
-      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, String padding,
-      Options... options) {
+  public static <T extends TNumber> Conv2dBackpropInput<T> create(Scope scope,
+      Operand<TInt32> inputSizes, Operand<T> filter, Operand<T> outBackprop, List<Long> strides,
+      String padding, Options... options) {
     OperationBuilder opBuilder = scope.opBuilder(OP_NAME, "Conv2dBackpropInput");
-    opBuilder.addInput(input.asOutput());
+    opBuilder.addInput(inputSizes.asOutput());
     opBuilder.addInput(filter.asOutput());
     opBuilder.addInput(outBackprop.asOutput());
     long[] stridesArray = new long[strides.size()];
@@ -319,10 +320,10 @@ public final class Conv2dBackpropInput<T extends TNumber> extends RawOp implemen
   )
   public static class Inputs<T extends TNumber> extends RawOpInputs<Conv2dBackpropInput<T>> {
     /**
-     * 4-D with shape {@code [batch, in_height, in_width, in_channels]}.
-     * Only shape of tensor is used.
+     * An integer vector representing the shape of {@code input},
+     * where {@code input} is a 4-D {@code [batch, height, width, channels]} tensor.
      */
-    public final Operand<T> input;
+    public final Operand<TInt32> inputSizes;
 
     /**
      * 4-D with shape
@@ -387,7 +388,7 @@ public final class Conv2dBackpropInput<T extends TNumber> extends RawOp implemen
     public Inputs(GraphOperation op) {
       super(new Conv2dBackpropInput<>(op), op, Arrays.asList("T", "strides", "use_cudnn_on_gpu", "padding", "explicit_paddings", "data_format", "dilations"));
       int inputIndex = 0;
-      input = (Operand<T>) op.input(inputIndex++);
+      inputSizes = (Operand<TInt32>) op.input(inputIndex++);
       filter = (Operand<T>) op.input(inputIndex++);
       outBackprop = (Operand<T>) op.input(inputIndex++);
       T = op.attributes().getAttrType("T");

--- a/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/nn/Conv2dBackpropInputV2.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/java/org/tensorflow/op/nn/Conv2dBackpropInputV2.java
@@ -30,45 +30,40 @@ import org.tensorflow.op.Scope;
 import org.tensorflow.op.annotation.Endpoint;
 import org.tensorflow.op.annotation.OpInputsMetadata;
 import org.tensorflow.op.annotation.OpMetadata;
-import org.tensorflow.op.annotation.Operator;
 import org.tensorflow.proto.DataType;
-import org.tensorflow.types.TInt32;
 import org.tensorflow.types.family.TNumber;
 
 /**
- * Computes the gradients of convolution with respect to the filter.
+ * Computes the gradients of convolution with respect to the input.
  *
  * @param <T> data type for {@code output} output
  */
 @OpMetadata(
-    opType = Conv2dBackpropFilter.OP_NAME,
-    inputsClass = Conv2dBackpropFilter.Inputs.class
+    opType = Conv2dBackpropInputV2.OP_NAME,
+    inputsClass = Conv2dBackpropInputV2.Inputs.class
 )
-@Operator(
-    group = "nn"
-)
-public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp implements Operand<T> {
+public final class Conv2dBackpropInputV2<T extends TNumber> extends RawOp implements Operand<T> {
   /**
    * The name of this op, as known by TensorFlow core engine
    */
-  public static final String OP_NAME = "Conv2DBackpropFilter";
+  public static final String OP_NAME = "Conv2DBackpropInputV2";
 
   private Output<T> output;
 
-  public Conv2dBackpropFilter(Operation operation) {
+  public Conv2dBackpropInputV2(Operation operation) {
     super(operation, OP_NAME);
     int outputIdx = 0;
     output = operation.output(outputIdx++);
   }
 
   /**
-   * Factory method to create a class wrapping a new Conv2DBackpropFilter operation.
+   * Factory method to create a class wrapping a new Conv2DBackpropInputV2 operation.
    *
    * @param scope current scope
    * @param input 4-D with shape {@code [batch, in_height, in_width, in_channels]}.
-   * @param filterSizes An integer vector representing the tensor shape of {@code filter},
-   * where {@code filter} is a 4-D
-   * {@code [filter_height, filter_width, in_channels, out_channels]} tensor.
+   * Only shape of tensor is used.
+   * @param filter 4-D with shape
+   * {@code [filter_height, filter_width, in_channels, out_channels]}.
    * @param outBackprop 4-D with shape {@code [batch, out_height, out_width, out_channels]}.
    * Gradients w.r.t. the output of the convolution.
    * @param strides The stride of the sliding window for each dimension of the input
@@ -76,18 +71,18 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
    * format.
    * @param padding The type of padding algorithm to use.
    * @param options carries optional attribute values
-   * @param <T> data type for {@code Conv2DBackpropFilter} output and operands
-   * @return a new instance of Conv2dBackpropFilter
+   * @param <T> data type for {@code Conv2DBackpropInputV2} output and operands
+   * @return a new instance of Conv2dBackpropInputV2
    */
   @Endpoint(
       describeByClass = true
   )
-  public static <T extends TNumber> Conv2dBackpropFilter<T> create(Scope scope, Operand<T> input,
-      Operand<TInt32> filterSizes, Operand<T> outBackprop, List<Long> strides, String padding,
+  public static <T extends TNumber> Conv2dBackpropInputV2<T> create(Scope scope, Operand<T> input,
+      Operand<T> filter, Operand<T> outBackprop, List<Long> strides, String padding,
       Options... options) {
-    OperationBuilder opBuilder = scope.opBuilder(OP_NAME, "Conv2dBackpropFilter");
+    OperationBuilder opBuilder = scope.opBuilder(OP_NAME, "Conv2dBackpropInputV2");
     opBuilder.addInput(input.asOutput());
-    opBuilder.addInput(filterSizes.asOutput());
+    opBuilder.addInput(filter.asOutput());
     opBuilder.addInput(outBackprop.asOutput());
     long[] stridesArray = new long[strides.size()];
     for (int i = 0 ; i < stridesArray.length ; i++) {
@@ -119,7 +114,7 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
         }
       }
     }
-    return new Conv2dBackpropFilter<>(opBuilder.build());
+    return new Conv2dBackpropInputV2<>(opBuilder.build());
   }
 
   /**
@@ -202,9 +197,8 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
 
   /**
    * Gets output.
-   * 4-D with shape
-   * {@code [filter_height, filter_width, in_channels, out_channels]}.  Gradient w.r.t.
-   * the {@code filter} input of the convolution.
+   * 4-D with shape {@code [batch, in_height, in_width, in_channels]}.  Gradient
+   * w.r.t. the input of the convolution.
    * @return output.
    */
   public Output<T> output() {
@@ -217,7 +211,7 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
   }
 
   /**
-   * Optional attributes for {@link org.tensorflow.op.nn.Conv2dBackpropFilter}
+   * Optional attributes for {@link org.tensorflow.op.nn.Conv2dBackpropInputV2}
    */
   public static class Options {
     private Boolean useCudnnOnGpu;
@@ -317,20 +311,20 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
   }
 
   @OpInputsMetadata(
-      outputsClass = Conv2dBackpropFilter.class
+      outputsClass = Conv2dBackpropInputV2.class
   )
-  public static class Inputs<T extends TNumber> extends RawOpInputs<Conv2dBackpropFilter<T>> {
+  public static class Inputs<T extends TNumber> extends RawOpInputs<Conv2dBackpropInputV2<T>> {
     /**
      * 4-D with shape {@code [batch, in_height, in_width, in_channels]}.
+     * Only shape of tensor is used.
      */
     public final Operand<T> input;
 
     /**
-     * An integer vector representing the tensor shape of {@code filter},
-     * where {@code filter} is a 4-D
-     * {@code [filter_height, filter_width, in_channels, out_channels]} tensor.
+     * 4-D with shape
+     * {@code [filter_height, filter_width, in_channels, out_channels]}.
      */
-    public final Operand<TInt32> filterSizes;
+    public final Operand<T> filter;
 
     /**
      * 4-D with shape {@code [batch, out_height, out_width, out_channels]}.
@@ -387,10 +381,10 @@ public final class Conv2dBackpropFilter<T extends TNumber> extends RawOp impleme
     public final long[] dilations;
 
     public Inputs(GraphOperation op) {
-      super(new Conv2dBackpropFilter<>(op), op, Arrays.asList("T", "strides", "use_cudnn_on_gpu", "padding", "explicit_paddings", "data_format", "dilations"));
+      super(new Conv2dBackpropInputV2<>(op), op, Arrays.asList("T", "strides", "use_cudnn_on_gpu", "padding", "explicit_paddings", "data_format", "dilations"));
       int inputIndex = 0;
       input = (Operand<T>) op.input(inputIndex++);
-      filterSizes = (Operand<TInt32>) op.input(inputIndex++);
+      filter = (Operand<T>) op.input(inputIndex++);
       outBackprop = (Operand<T>) op.input(inputIndex++);
       T = op.attributes().getAttrType("T");
       strides = op.attributes().getAttrIntList("strides");


### PR DESCRIPTION
V2 versions of Conv2dBackprop* operations adds unnecessary complexities to the API and seem to not be used (yet) by the Python API, so we'll make again the V1 version as the main API for these operations.