### PR TITLE
Build core-platform only on deploy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ For dependencies, we can use anything compliant with [this list](https://opensou
 
 ## Building
 
-To build all the artifacts locally, simply invoke the command `mvn install -Djavacpp.platform.host` at the root of this repository (or the Maven command of your choice). It is also
+To build all the artifacts locally, simply invoke the command `mvn install` at the root of this repository (or the Maven command of your choice). It is also
 possible to build artifacts with support for CUDA® by adding the `-Djavacpp.platform.extension=-gpu` argument to the Maven command.
 
 ### JDK 16+
@@ -120,7 +120,7 @@ Once these steps have been executed, you can run `mvn install` to build the new 
 ### Generating Java Bindings
 
 After upgrading the TensorFlow library, you need to regenerate all Java bindings that depends on the native code. That includes Java protos, C API bindings (JavaCPP) and
-operator classes. You can trigger the regeneration of these bindings with the Maven command `mvn clean install -Pgenerating -Djavacpp.platform.host`.
+operator classes. You can trigger the regeneration of these bindings with the Maven command `mvn clean install -Pgenerating`.
 
 This will trigger a small Bazel build of the TensorFlow sources to regenerate the Java protos, so make sure your [environment](CONTRIBUTING.md#native-builds) is setup properly.
 

--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -34,6 +34,7 @@
     <module>tensorflow-core-native</module>
     <module>tensorflow-core-generator</module>
     <module>tensorflow-core-api</module>
+    <module>tensorflow-core-platform</module>
   </modules>
 
   <properties>
@@ -64,17 +65,6 @@
   </properties>
 
   <profiles>
-    <profile>
-      <id>deploying</id>
-      <!--
-        Build the core platform artifact only when deploying a release or snapshot, since it requires that native
-        artifacts of all supported platforms have already been built and published
-      -->
-      <modules>
-        <module>tensorflow-core-platform</module>
-      </modules>
-    </profile>
-
     <profile>
       <id>javacpp-platform-default</id>
       <activation>

--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -66,14 +66,43 @@
 
   <profiles>
     <profile>
-      <id>javacpp-platform-default</id>
+      <!--
+        When deploying, the build packages and distributes native binaries for all supported platforms. These native artifacts
+        must have already been built, tested and published priorly on their respective platform.
+      -->
+      <id>deploying</id>
+      <properties>
+        <javacpp.platform>${os.name}-${os.arch}</javacpp.platform>
+      </properties>
+    </profile>
+
+    <profile>
+      <!--
+        All supported platforms are being replaced by the current host platform, mostly useful for local builds.
+        The artifacts produced by this build can only run on the current host (or other machines of the same
+        platform). This is the default profile.
+      -->
+      <id>javacpp-platform-host</id>
       <activation>
+        <activeByDefault>true</activeByDefault>
         <property>
-          <name>!javacpp.platform</name>
+          <name>javacpp.platform.host</name>
         </property>
       </activation>
       <properties>
         <javacpp.platform>${os.name}-${os.arch}</javacpp.platform>
+        <javacpp.platform.linux-armhf>${os.name}-${os.arch}</javacpp.platform.linux-armhf>
+        <javacpp.platform.linux-arm64>${os.name}-${os.arch}</javacpp.platform.linux-arm64>
+        <javacpp.platform.linux-x86_64>${os.name}-${os.arch}</javacpp.platform.linux-x86_64>
+        <javacpp.platform.macosx-arm64>${os.name}-${os.arch}</javacpp.platform.macosx-arm64>
+        <javacpp.platform.macosx-x86_64>${os.name}-${os.arch}</javacpp.platform.macosx-x86_64>
+        <javacpp.platform.windows-x86_64>${os.name}-${os.arch}</javacpp.platform.windows-x86_64>
+        <javacpp.platform.linux-armhf.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
+        <javacpp.platform.linux-arm64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
+        <javacpp.platform.linux-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
+        <javacpp.platform.macosx-arm64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.macosx-arm64.extension>
+        <javacpp.platform.macosx-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
+        <javacpp.platform.windows-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 
@@ -103,30 +132,6 @@
         <javacpp.platform.macosx-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
         <javacpp.platform.windows-x86.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86.extension>
         <javacpp.platform.windows-x86_64.extension>${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
-      </properties>
-    </profile>
-
-    <profile>
-      <id>javacpp-platform-host</id>
-      <activation>
-        <property>
-          <name>javacpp.platform.host</name>
-        </property>
-      </activation>
-      <properties>
-        <javacpp.platform>${os.name}-${os.arch}</javacpp.platform>
-        <javacpp.platform.linux-armhf>${os.name}-${os.arch}</javacpp.platform.linux-armhf>
-        <javacpp.platform.linux-arm64>${os.name}-${os.arch}</javacpp.platform.linux-arm64>
-        <javacpp.platform.linux-x86_64>${os.name}-${os.arch}</javacpp.platform.linux-x86_64>
-        <javacpp.platform.macosx-arm64>${os.name}-${os.arch}</javacpp.platform.macosx-arm64>
-        <javacpp.platform.macosx-x86_64>${os.name}-${os.arch}</javacpp.platform.macosx-x86_64>
-        <javacpp.platform.windows-x86_64>${os.name}-${os.arch}</javacpp.platform.windows-x86_64>
-        <javacpp.platform.linux-armhf.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-armhf.extension>
-        <javacpp.platform.linux-arm64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-arm64.extension>
-        <javacpp.platform.linux-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.linux-x86_64.extension>
-        <javacpp.platform.macosx-arm64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.macosx-arm64.extension>
-        <javacpp.platform.macosx-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.macosx-x86_64.extension>
-        <javacpp.platform.windows-x86_64.extension>${os.name}-${os.arch}${javacpp.platform.extension}</javacpp.platform.windows-x86_64.extension>
       </properties>
     </profile>
 

--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -34,7 +34,6 @@
     <module>tensorflow-core-native</module>
     <module>tensorflow-core-generator</module>
     <module>tensorflow-core-api</module>
-    <module>tensorflow-core-platform</module>
   </modules>
 
   <properties>
@@ -65,6 +64,17 @@
   </properties>
 
   <profiles>
+    <profile>
+      <id>deploying</id>
+      <!--
+        Build the core platform artifact only when deploying a release or snapshot, since it requires that native
+        artifacts of all supported platforms have already been built and published
+      -->
+      <modules>
+        <module>tensorflow-core-platform</module>
+      </modules>
+    </profile>
+
     <profile>
       <id>javacpp-platform-default</id>
       <activation>

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -15,7 +15,6 @@
   <description>Platform-dependent native code and pure-Java code for the TensorFlow machine intelligence library.</description>
 
   <properties>
-    <java.module.name>org.tensorflow.core.api</java.module.name>
     <ndarray.version>0.4.0</ndarray.version>
     <truth.version>1.1.5</truth.version>
     <test.download.skip>false</test.download.skip>

--- a/tensorflow-core/tensorflow-core-generator/pom.xml
+++ b/tensorflow-core/tensorflow-core-generator/pom.xml
@@ -13,10 +13,6 @@
   <name>TensorFlow Generators</name>
   <description>Code generators for TensorFlow Java client</description>
 
-  <properties>
-    <java.module.name>org.tensorflow.core.generator</java.module.name>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.tensorflow</groupId>
@@ -70,17 +66,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>${java.module.name}</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>

--- a/tensorflow-core/tensorflow-core-native/pom.xml
+++ b/tensorflow-core/tensorflow-core-native/pom.xml
@@ -24,7 +24,6 @@
     <dist.download.skip>false</dist.download.skip>
     <dist.download.url/>
     <dist.download.folder>${project.build.directory}/dist/</dist.download.folder>
-    <java.module.name>org.tensorflow.core.native</java.module.name>
     <nativeSourceDirectory>${project.basedir}/src/main/native</nativeSourceDirectory>
   </properties>
 

--- a/tensorflow-core/tensorflow-core-platform/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform/pom.xml
@@ -31,56 +31,29 @@
     <java.module.name>tensorflow.platform</java.module.name>
   </properties>
 
-  <profiles>
-    <!--
-      Include native artifacts of all available platforms only when deploying to Sonatype. When just building locally,
-      we only need the native artifact of the current host platform.
-    -->
-    <profile>
-      <id>deploying</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.tensorflow</groupId>
-          <artifactId>tensorflow-core-native</artifactId>
-          <version>${project.version}</version>
-          <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
-        </dependency>
-        <dependency>
-          <groupId>org.tensorflow</groupId>
-          <artifactId>tensorflow-core-native</artifactId>
-          <version>${project.version}</version>
-          <classifier>${javacpp.platform.macosx-x86_64.extension}</classifier>
-        </dependency>
-        <dependency>
-          <groupId>org.tensorflow</groupId>
-          <artifactId>tensorflow-core-native</artifactId>
-          <version>${project.version}</version>
-          <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>host-only</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.tensorflow</groupId>
-          <artifactId>tensorflow-core-native</artifactId>
-          <version>${project.version}</version>
-          <classifier>${native.classifier}</classifier>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow-core-api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-core-native</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-core-native</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.macosx-x86_64.extension}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-core-native</artifactId>
+      <version>${project.version}</version>
+      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
     </dependency>
   </dependencies>
 

--- a/tensorflow-core/tensorflow-core-platform/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform/pom.xml
@@ -28,32 +28,59 @@
   <name>TensorFlow API Platform</name>
 
   <properties>
-    <java.module.name>org.tensorflow.core.platform</java.module.name>
+    <java.module.name>tensorflow.platform</java.module.name>
   </properties>
+
+  <profiles>
+    <!--
+      Include native artifacts of all available platforms only when deploying to Sonatype. When just building locally,
+      we only need the native artifact of the current host platform.
+    -->
+    <profile>
+      <id>deploying</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-native</artifactId>
+          <version>${project.version}</version>
+          <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
+        </dependency>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-native</artifactId>
+          <version>${project.version}</version>
+          <classifier>${javacpp.platform.macosx-x86_64.extension}</classifier>
+        </dependency>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-native</artifactId>
+          <version>${project.version}</version>
+          <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>host-only</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.tensorflow</groupId>
+          <artifactId>tensorflow-core-native</artifactId>
+          <version>${project.version}</version>
+          <classifier>${native.classifier}</classifier>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <dependencies>
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow-core-api</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.tensorflow</groupId>
-      <artifactId>tensorflow-core-native</artifactId>
-      <version>${project.version}</version>
-      <classifier>${javacpp.platform.linux-x86_64.extension}</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.tensorflow</groupId>
-      <artifactId>tensorflow-core-native</artifactId>
-      <version>${project.version}</version>
-      <classifier>${javacpp.platform.macosx-x86_64.extension}</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.tensorflow</groupId>
-      <artifactId>tensorflow-core-native</artifactId>
-      <version>${project.version}</version>
-      <classifier>${javacpp.platform.windows-x86_64.extension}</classifier>
     </dependency>
   </dependencies>
 

--- a/tensorflow-framework/pom.xml
+++ b/tensorflow-framework/pom.xml
@@ -35,7 +35,6 @@
 
   <properties>
     <javacpp.platform.extension></javacpp.platform.extension>
-    <java.module.name>org.tensorflow.framework</java.module.name>
   </properties>
 
   <dependencies>
@@ -76,17 +75,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>${java.module.name}</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Small PR to build `tensorflow-core-platform` only when the `deploying` profile is active (i.e. when building and pushing artifacts to Sonatype). This way, users can intuitively run `mvn install` locally and they won't get error that some artifacts are missing (right now the "patch" is to pass the `-Djava.platform.host` parameter to get rid of this error).