### PR TITLE
chore: add macosx-arm_64 deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,48 @@ jobs:
           echo Executing Maven $MAVEN_PHASE
           mvn clean $MAVEN_PHASE -B -U -e -Djavacpp.platform=macosx-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }} -pl $NATIVE_BUILD_PROJECTS -am -DstagingRepositoryId=${{ needs.prepare.outputs.stagingRepositoryId }} "-Dnative.build.flags=$BAZEL_CACHE"
           df -h
+  macosx-arm_64:
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
+    runs-on: macos-13-xlarge
+    needs: prepare
+    strategy:
+      matrix:
+        ext: [""] # , -mkl]
+    steps:
+      - name: Install environment
+        run: |
+          python3 -m pip install numpy six setuptools
+          echo Downloading Bazel
+          curl -L https://github.com/bazelbuild/bazel/releases/download/5.1.1/bazel-5.1.1-installer-darwin-arm_64.sh -o bazel.sh --retry 10
+          bash bazel.sh
+          brew install libomp perl
+      - name: Configure Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Build project
+        run: |
+          python -V
+          git --version
+          clang --version
+          mvn -version
+          bazel version
+          mkdir -p $HOME/.m2
+          [[ "${{ github.event_name }}" == "push" ]] && MAVEN_PHASE=deploy || MAVEN_PHASE=install
+          echo "<settings><servers><server><id>ossrh</id><username>${{ secrets.CI_DEPLOY_USERNAME }}</username><password>${{ secrets.CI_DEPLOY_PASSWORD }}</password></server></servers></settings>" > $HOME/.m2/settings.xml
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.repository }}" == "tensorflow/java" ]]; then
+            printf '%s\n' "${GCP_CREDS}" > $HOME/gcp_creds.json
+            export BAZEL_CACHE="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-jvm --remote_upload_local_results=true --google_credentials=$HOME/gcp_creds.json"
+          else
+            export BAZEL_CACHE="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-jvm --remote_upload_local_results=false"
+          fi
+          df -h
+          echo Executing Maven $MAVEN_PHASE
+          mvn clean $MAVEN_PHASE -B -U -e -Djavacpp.platform=macosx-arm_64 -Djavacpp.platform.extension=${{ matrix.ext }} -pl $NATIVE_BUILD_PROJECTS -am -DstagingRepositoryId=${{ needs.prepare.outputs.stagingRepositoryId }} "-Dnative.build.flags=$BAZEL_CACHE"
+          df -h
   windows-x86_64:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: windows-2019
@@ -287,7 +329,7 @@ jobs:
           wmic pagefile list /format:list
   deploy:
     if: github.event_name == 'push' && contains(github.ref, 'master')
-    needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
+    needs: [linux-x86_64, macosx-x86_64, macosx-arm_64, windows-x86_64]
     runs-on: ubuntu-20.04
     steps:
       - name: Configure Java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
           echo Executing Maven $MAVEN_PHASE
           mvn clean $MAVEN_PHASE -B -U -e -Djavacpp.platform=macosx-x86_64 -Djavacpp.platform.extension=${{ matrix.ext }} -pl $NATIVE_BUILD_PROJECTS -am -DstagingRepositoryId=${{ needs.prepare.outputs.stagingRepositoryId }} "-Dnative.build.flags=$BAZEL_CACHE"
           df -h
-  macosx-arm_64:
+  macosx-arm64:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
     runs-on: macos-13-xlarge
     needs: prepare
@@ -215,7 +215,7 @@ jobs:
         run: |
           python3 -m pip install numpy six setuptools
           echo Downloading Bazel
-          curl -L https://github.com/bazelbuild/bazel/releases/download/5.1.1/bazel-5.1.1-installer-darwin-arm_64.sh -o bazel.sh --retry 10
+          curl -L https://github.com/bazelbuild/bazel/releases/download/5.1.1/bazel-5.1.1-installer-darwin-arm64.sh -o bazel.sh --retry 10
           bash bazel.sh
           brew install libomp perl
       - name: Configure Java
@@ -243,7 +243,7 @@ jobs:
           fi
           df -h
           echo Executing Maven $MAVEN_PHASE
-          mvn clean $MAVEN_PHASE -B -U -e -Djavacpp.platform=macosx-arm_64 -Djavacpp.platform.extension=${{ matrix.ext }} -pl $NATIVE_BUILD_PROJECTS -am -DstagingRepositoryId=${{ needs.prepare.outputs.stagingRepositoryId }} "-Dnative.build.flags=$BAZEL_CACHE"
+          mvn clean $MAVEN_PHASE -B -U -e -Djavacpp.platform=macosx-arm64 -Djavacpp.platform.extension=${{ matrix.ext }} -pl $NATIVE_BUILD_PROJECTS -am -DstagingRepositoryId=${{ needs.prepare.outputs.stagingRepositoryId }} "-Dnative.build.flags=$BAZEL_CACHE"
           df -h
   windows-x86_64:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI build')
@@ -329,7 +329,7 @@ jobs:
           wmic pagefile list /format:list
   deploy:
     if: github.event_name == 'push' && contains(github.ref, 'master')
-    needs: [linux-x86_64, macosx-x86_64, macosx-arm_64, windows-x86_64]
+    needs: [linux-x86_64, macosx-x86_64, macosx-arm64, windows-x86_64]
     runs-on: ubuntu-20.04
     steps:
       - name: Configure Java


### PR DESCRIPTION
As Apple silicon m1 github runner are now available, enable the deployment of binary for this platform.

https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/

See issue #515 