### PR TITLE
Force Java architecture for MacOS ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,9 @@ jobs:
       - name: Configure Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: '17'
+          architecture: 'arm64'
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Build project


### PR DESCRIPTION
Needs to switch to `zulu`, it seems that `adopt` does not have an `arm64` distribution available (at least through that GH action).

Successful run: https://github.com/karllessard/tensorflow-java/actions/runs/7877086649