### PR TITLE
Adding a control dependency on the gradients to the gradient optimizers

### DIFF
--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/AdaDelta.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/AdaDelta.java
@@ -20,6 +20,7 @@ import org.tensorflow.Graph;
 import org.tensorflow.Operand;
 import org.tensorflow.Output;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.train.ApplyAdadelta;
 import org.tensorflow.types.family.TType;
@@ -150,16 +151,16 @@ public class AdaDelta extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
     Variable<T> accumSlot = getSlot(variable, ACCUMULATOR).get();
     Variable<T> accumUpdateSlot = getSlot(variable, ACCUMULATOR_UPDATE).get();
-    return tf.train.applyAdadelta(
+    return deps.train.applyAdadelta(
         variable,
         accumSlot,
         accumUpdateSlot,
-        tf.dtypes.cast(tf.constant(learningRate), gradient.type()),
-        tf.dtypes.cast(tf.constant(rho), gradient.type()),
-        tf.dtypes.cast(tf.constant(epsilon), gradient.type()),
+        deps.dtypes.cast(deps.constant(learningRate), gradient.type()),
+        deps.dtypes.cast(deps.constant(rho), gradient.type()),
+        deps.dtypes.cast(deps.constant(epsilon), gradient.type()),
         gradient,
         ApplyAdadelta.useLocking(true));
   }

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/AdaGrad.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/AdaGrad.java
@@ -20,6 +20,7 @@ import org.tensorflow.Graph;
 import org.tensorflow.Operand;
 import org.tensorflow.Output;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.train.ApplyAdagrad;
 import org.tensorflow.types.family.TType;
@@ -140,10 +141,10 @@ public class AdaGrad extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
     Variable<T> slot = getSlot(variable, ACCUMULATOR).get();
-    return tf.train.applyAdagrad(
-        variable, slot, tf.dtypes.cast(tf.constant(learningRate), gradient.type()), gradient, opts);
+    return deps.train.applyAdagrad(
+        variable, slot, deps.dtypes.cast(deps.constant(learningRate), gradient.type()), gradient, opts);
   }
 
   /** {@inheritDoc} */

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/AdaGradDA.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/AdaGradDA.java
@@ -22,6 +22,7 @@ import org.tensorflow.Operand;
 import org.tensorflow.Output;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.train.ApplyAdagradDa;
 import org.tensorflow.types.TInt64;
@@ -209,17 +210,17 @@ public class AdaGradDA extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
     Variable<T> gradSlot = getSlot(variable, ACCUMULATOR).get();
     Variable<T> gradSquaredSlot = getSlot(variable, SQUARED_ACCUMULATOR).get();
-    return tf.train.applyAdagradDa(
+    return deps.train.applyAdagradDa(
         variable,
         gradSlot,
         gradSquaredSlot,
         gradient,
-        tf.dtypes.cast(tf.constant(learningRate), gradient.type()),
-        tf.dtypes.cast(tf.constant(l1Strength), gradient.type()),
-        tf.dtypes.cast(tf.constant(l2Strength), gradient.type()),
+        deps.dtypes.cast(deps.constant(learningRate), gradient.type()),
+        deps.dtypes.cast(deps.constant(l1Strength), gradient.type()),
+        deps.dtypes.cast(deps.constant(l2Strength), gradient.type()),
         globalStep,
         ApplyAdagradDa.useLocking(true));
   }

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Adam.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Adam.java
@@ -22,6 +22,7 @@ import org.tensorflow.Operand;
 import org.tensorflow.Output;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.Scope;
 import org.tensorflow.op.annotation.Endpoint;
 import org.tensorflow.op.annotation.Operator;
@@ -223,19 +224,19 @@ public class Adam extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
     Variable<T> firstMomentSlot = getSlot(variable, FIRST_MOMENT).get();
     Variable<T> secondMomentSlot = getSlot(variable, SECOND_MOMENT).get();
-    return tf.train.applyAdam(
+    return deps.train.applyAdam(
         variable,
         firstMomentSlot,
         secondMomentSlot,
-        tf.dtypes.cast(betaOnePower, gradient.type()),
-        tf.dtypes.cast(betaTwoPower, gradient.type()),
-        tf.dtypes.cast(learningRateConst, gradient.type()),
-        tf.dtypes.cast(betaOneConst, gradient.type()),
-        tf.dtypes.cast(betaTwoConst, gradient.type()),
-        tf.dtypes.cast(epsilonConst, gradient.type()),
+        deps.dtypes.cast(betaOnePower, gradient.type()),
+        deps.dtypes.cast(betaTwoPower, gradient.type()),
+        deps.dtypes.cast(learningRateConst, gradient.type()),
+        deps.dtypes.cast(betaOneConst, gradient.type()),
+        deps.dtypes.cast(betaTwoConst, gradient.type()),
+        deps.dtypes.cast(epsilonConst, gradient.type()),
         gradient,
         ApplyAdam.useLocking(true));
   }

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Adamax.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Adamax.java
@@ -7,6 +7,7 @@ import org.tensorflow.Operand;
 import org.tensorflow.Output;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Constant;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.train.ApplyAdaMax;
@@ -155,19 +156,19 @@ public class Adamax extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
     Variable<T> firstMomentSlot = getSlot(variable, FIRST_MOMENT).get();
     Variable<T> secondMomentSlot = getSlot(variable, SECOND_MOMENT).get();
     return ApplyAdaMax.create(
-        this.tf.scope(),
+        deps.scope(),
         variable,
         firstMomentSlot,
         secondMomentSlot,
-        tf.dtypes.cast(betaOnePower, gradient.type()),
-        tf.dtypes.cast(learningRateConst, gradient.type()),
-        tf.dtypes.cast(betaOneConst, gradient.type()),
-        tf.dtypes.cast(betaTwoConst, gradient.type()),
-        tf.dtypes.cast(epsilonConst, gradient.type()),
+        deps.dtypes.cast(betaOnePower, gradient.type()),
+        deps.dtypes.cast(learningRateConst, gradient.type()),
+        deps.dtypes.cast(betaOneConst, gradient.type()),
+        deps.dtypes.cast(betaTwoConst, gradient.type()),
+        deps.dtypes.cast(epsilonConst, gradient.type()),
         gradient,
         ApplyAdaMax.useLocking(true));
   }

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Ftrl.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Ftrl.java
@@ -5,6 +5,7 @@ import org.tensorflow.Graph;
 import org.tensorflow.Operand;
 import org.tensorflow.Output;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.train.ApplyFtrl;
 import org.tensorflow.types.family.TType;
@@ -238,21 +239,21 @@ public class Ftrl extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
     Variable<T> accumSlot = getSlot(variable, ACCUMULATOR).get();
     Variable<T> linearSlot = getSlot(variable, LINEAR_ACCUMULATOR).get();
     ApplyFtrl.Options options = ApplyFtrl.useLocking(true);
-    return this.tf.train.applyFtrl(
+    return deps.train.applyFtrl(
         variable,
         accumSlot, // accum
         linearSlot, // linear
         gradient, // gradient
-        tf.dtypes.cast(tf.constant(learningRate), gradient.type()), // lr
-        tf.dtypes.cast(tf.constant(l1RegularizationStrength), gradient.type()), // l1
-        tf.dtypes.cast(tf.constant(l2RegularizationStrength), gradient.type()), // l2
-        tf.dtypes.cast(
-            tf.constant(l2ShrinkageRegularizationStrength), gradient.type()), // l2Shrinkage
-        tf.dtypes.cast(tf.constant(learningRatePower), gradient.type()), // lrPower
+        deps.dtypes.cast(deps.constant(learningRate), gradient.type()), // lr
+        deps.dtypes.cast(deps.constant(l1RegularizationStrength), gradient.type()), // l1
+        deps.dtypes.cast(deps.constant(l2RegularizationStrength), gradient.type()), // l2
+        deps.dtypes.cast(
+            deps.constant(l2ShrinkageRegularizationStrength), gradient.type()), // l2Shrinkage
+        deps.dtypes.cast(deps.constant(learningRatePower), gradient.type()), // lrPower
         options);
   }
 

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/GradientDescent.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/GradientDescent.java
@@ -18,6 +18,7 @@ package org.tensorflow.framework.optimizers;
 import org.tensorflow.Graph;
 import org.tensorflow.Output;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.train.ApplyGradientDescent;
 import org.tensorflow.types.family.TType;
 
@@ -65,10 +66,10 @@ public class GradientDescent extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
-    return tf.train.applyGradientDescent(
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
+    return deps.train.applyGradientDescent(
         variable,
-        tf.dtypes.cast(tf.constant(learningRate), gradient.type()),
+        deps.dtypes.cast(deps.constant(learningRate), gradient.type()),
         gradient,
         ApplyGradientDescent.useLocking(true));
   }

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Momentum.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/Momentum.java
@@ -20,6 +20,7 @@ import org.tensorflow.Graph;
 import org.tensorflow.Operand;
 import org.tensorflow.Output;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.train.ApplyMomentum;
 import org.tensorflow.types.family.TType;
@@ -130,14 +131,14 @@ public class Momentum extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
     Variable<T> slot = getSlot(variable, MOMENTUM).get();
-    return tf.train.applyMomentum(
+    return deps.train.applyMomentum(
         variable,
         slot,
-        tf.dtypes.cast(tf.constant(learningRate), gradient.type()),
+        deps.dtypes.cast(deps.constant(learningRate), gradient.type()),
         gradient,
-        tf.dtypes.cast(tf.constant(momentum), gradient.type()),
+        deps.dtypes.cast(deps.constant(momentum), gradient.type()),
         ApplyMomentum.useNesterov(useNesterov),
         ApplyMomentum.useLocking(true));
   }

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/RMSProp.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/optimizers/RMSProp.java
@@ -20,6 +20,7 @@ import org.tensorflow.Graph;
 import org.tensorflow.Operand;
 import org.tensorflow.Output;
 import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.train.ApplyCenteredRmsProp;
 import org.tensorflow.op.train.ApplyRmsProp;
@@ -189,31 +190,31 @@ public class RMSProp extends Optimizer {
 
   /** {@inheritDoc} */
   @Override
-  protected <T extends TType> Op applyDense(Output<T> gradient, Output<T> variable) {
+  protected <T extends TType> Op applyDense(Ops deps, Output<T> gradient, Output<T> variable) {
     Variable<T> rmsSlot = getSlot(variable, RMS).get();
     Variable<T> momentumSlot = getSlot(variable, MOMENTUM).get();
     if (centered) {
       Variable<T> mgSlot = getSlot(variable, MG).get();
-      return tf.train.applyCenteredRmsProp(
+      return deps.train.applyCenteredRmsProp(
           variable,
           mgSlot,
           rmsSlot,
           momentumSlot,
-          tf.dtypes.cast(tf.constant(learningRate), gradient.type()),
-          tf.dtypes.cast(tf.constant(decay), gradient.type()),
-          tf.dtypes.cast(tf.constant(momentum), gradient.type()),
-          tf.dtypes.cast(tf.constant(epsilon), gradient.type()),
+          deps.dtypes.cast(deps.constant(learningRate), gradient.type()),
+          deps.dtypes.cast(deps.constant(decay), gradient.type()),
+          deps.dtypes.cast(deps.constant(momentum), gradient.type()),
+          deps.dtypes.cast(deps.constant(epsilon), gradient.type()),
           gradient,
           ApplyCenteredRmsProp.useLocking(true));
     }
-    return tf.train.applyRmsProp(
+    return deps.train.applyRmsProp(
         variable,
         rmsSlot,
         momentumSlot,
-        tf.dtypes.cast(tf.constant(learningRate), gradient.type()),
-        tf.dtypes.cast(tf.constant(decay), gradient.type()),
-        tf.dtypes.cast(tf.constant(momentum), gradient.type()),
-        tf.dtypes.cast(tf.constant(epsilon), gradient.type()),
+        deps.dtypes.cast(deps.constant(learningRate), gradient.type()),
+        deps.dtypes.cast(deps.constant(decay), gradient.type()),
+        deps.dtypes.cast(deps.constant(momentum), gradient.type()),
+        deps.dtypes.cast(deps.constant(epsilon), gradient.type()),
         gradient,
         ApplyRmsProp.useLocking(true));
   }

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/GradientDescentTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/optimizers/GradientDescentTest.java
@@ -110,10 +110,6 @@ public class GradientDescentTest {
     }
   }
 
-  // This test fails due to incorrect gradients being generated some of the time, when
-  // using an identical graph on identical data. It should not, but it seems to be a
-  // problem in TF-core.
-  @Disabled
   @Test
   public void testDeterminism() {
     ConfigProto config =


### PR DESCRIPTION
This improves determinism and makes the gradients be computed correctly. As it's a control dependency on all the gradients to the consumers of the gradients it's not clear why this is necessary, but it's working.

Fix developed by @nfeybesse.