### PR TITLE
Adding casts to the if test so it passes on GPU

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/IfTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/IfTest.java
@@ -50,7 +50,7 @@ public class IfTest {
               // Casts around the math.neg operator as it's not implemented correctly for int32 in
               // GPUs at some point between TF 2.10 and TF 2.15.
               Operand<TInt32> y =
-                  ops.dtypes.cast(ops.math.neg(ops.dtypes.cast(a1, TFloat32.class)), TInt32.class);
+                  ops.dtypes.cast(ops.math.neg(ops.dtypes.cast(b1, TFloat32.class)), TInt32.class);
               return Signature.builder().input("a", a1).input("b", b1).output("y", y).build();
             });
 

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/IfTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/IfTest.java
@@ -27,6 +27,7 @@ import org.tensorflow.Operand;
 import org.tensorflow.Session;
 import org.tensorflow.Signature;
 import org.tensorflow.op.Ops;
+import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt32;
 
 public class IfTest {
@@ -37,7 +38,8 @@ public class IfTest {
             (ops) -> {
               Operand<TInt32> a1 = ops.placeholder(TInt32.class);
               Operand<TInt32> b1 = ops.placeholder(TInt32.class);
-              return Signature.builder().input("a", a1).input("b", b1).output("y", a1).build();
+              Operand<TInt32> y = ops.identity(a1);
+              return Signature.builder().input("a", a1).input("b", b1).output("y", y).build();
             });
 
     ConcreteFunction elseBranch =
@@ -45,7 +47,10 @@ public class IfTest {
             (ops) -> {
               Operand<TInt32> a1 = ops.placeholder(TInt32.class);
               Operand<TInt32> b1 = ops.placeholder(TInt32.class);
-              Operand<TInt32> y = ops.math.neg(b1);
+              // Casts around the math.neg operator as it's not implemented correctly for int32 in
+              // GPUs at some point between TF 2.10 and TF 2.15.
+              Operand<TInt32> y =
+                  ops.dtypes.cast(ops.math.neg(ops.dtypes.cast(a1, TFloat32.class)), TInt32.class);
               return Signature.builder().input("a", a1).input("b", b1).output("y", y).build();
             });
 


### PR DESCRIPTION
`ops.math.neg` causes eigen to segfault on GPUs now we've upgraded to TF 2.15. This PR fixes the one test where we do that so that there are casts around it. Not sure how to indicate that users shouldn't use this op on GPU as the op definition accepts ints and it's autogenerated.