### PR TITLE
Fixing the native build so it can find the TSL headers

### DIFF
--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/javadoc/JavaDocNodeRendererContext.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/javadoc/JavaDocNodeRendererContext.java
@@ -9,6 +9,8 @@ import org.commonmark.renderer.html.UrlSanitizer;
 public interface JavaDocNodeRendererContext {
 
   /**
+   * Encode a URL into a String.
+   *
    * @param url to be encoded
    * @return an encoded URL (depending on the configuration)
    */
@@ -26,11 +28,15 @@ public interface JavaDocNodeRendererContext {
   Map<String, String> extendAttributes(Node node, String tagName, Map<String, String> attributes);
 
   /**
+   * Gets the HTML writer.
+   *
    * @return the HTML writer to use
    */
   JavaDocWriter getWriter();
 
   /**
+   * The HTML for a line break.
+   *
    * @return HTML that should be rendered for a soft line break
    */
   String getSoftbreak();
@@ -45,17 +51,23 @@ public interface JavaDocNodeRendererContext {
   void render(Node node);
 
   /**
+   * Should HTML be escaped?
+   *
    * @return whether HTML blocks and tags should be escaped or not
    */
   boolean shouldEscapeHtml();
 
   /**
+   * Should URLs be sanitized?
+   *
    * @return true if the {@link UrlSanitizer} should be used.
    * @since 0.14.0
    */
   boolean shouldSanitizeUrls();
 
   /**
+   * Gets the URL sanitizer.
+   *
    * @return Sanitizer to use for securing {@link Link} href and {@link Image} src if {@link
    *     #shouldSanitizeUrls()} is true.
    * @since 0.14.0

--- a/tensorflow-core/tensorflow-core-native/pom.xml
+++ b/tensorflow-core/tensorflow-core-native/pom.xml
@@ -318,6 +318,7 @@
             <includePath>${native.source.directory}/org/tensorflow/internal/c_api/</includePath>
             <!-- additional include paths in case of a full native build -->
             <includePath>${project.basedir}/bazel-${project.artifactId}/external/org_tensorflow/</includePath>
+            <includePath>${project.basedir}/bazel-${project.artifactId}/external/local_tsl/</includePath>
             <includePath>${project.basedir}/bazel-bin/external/org_tensorflow/</includePath>
             <includePath>${project.basedir}/bazel-${project.artifactId}/external/com_google_absl/</includePath>
             <includePath>${project.basedir}/bazel-${project.artifactId}/external/eigen_archive/</includePath>

--- a/tensorflow-core/tensorflow-core-native/src/gen/java/org/tensorflow/internal/c_api/global/tensorflow.java
+++ b/tensorflow-core/tensorflow-core-native/src/gen/java/org/tensorflow/internal/c_api/global/tensorflow.java
@@ -11,7 +11,7 @@ import org.bytedeco.javacpp.annotation.*;
 public class tensorflow extends org.tensorflow.internal.c_api.presets.tensorflow {
     static { Loader.load(); }
 
-// Parsed from tensorflow/tsl/platform/ctstring_internal.h
+// Parsed from tsl/platform/ctstring_internal.h
 
 /* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
@@ -165,7 +165,7 @@ public static native void TF_TString_Move(TF_TString dst, TF_TString src);
 // #endif  // TENSORFLOW_TSL_PLATFORM_CTSTRING_INTERNAL_H_
 
 
-// Parsed from tensorflow/tsl/platform/ctstring.h
+// Parsed from tsl/platform/ctstring.h
 
 /* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
@@ -274,7 +274,7 @@ limitations under the License.
 // #endif  // TENSORFLOW_TSL_PLATFORM_CTSTRING_H_
 
 
-// Parsed from tensorflow/tsl/c/tsl_status.h
+// Parsed from tsl/c/tsl_status.h
 
 /* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 

--- a/tensorflow-core/tensorflow-core-native/src/main/java/org/tensorflow/internal/c_api/presets/tensorflow.java
+++ b/tensorflow-core/tensorflow-core-native/src/main/java/org/tensorflow/internal/c_api/presets/tensorflow.java
@@ -36,9 +36,11 @@ import org.bytedeco.javacpp.tools.InfoMapper;
           value = {"linux", "macosx", "windows"},
           compiler = "cpp17",
           include = {
-            "tensorflow/tsl/platform/ctstring_internal.h",
-            "tensorflow/tsl/platform/ctstring.h",
-            "tensorflow/tsl/c/tsl_status.h",
+            // TSL headers are in different places in a bazel build and the downloaded whl
+            // The lower part is still the same, so multiple roots are set in the pom file.
+            "tsl/platform/ctstring_internal.h",
+            "tsl/platform/ctstring.h",
+            "tsl/c/tsl_status.h",
             "tensorflow/c/c_api_macros.h",
             "tensorflow/c/tf_datatype.h",
             "tensorflow/c/tf_status.h",


### PR DESCRIPTION
The TSL headers are in a different source root in a Bazel build to the packaged whl files. This PR adds that source root to the JavaCPP generate task and modifies the preset to look for them in both places.

Fixes #529.

It also pulls in the start of some changes I was making to reduce the number of warnings from error prone, but I've not completed that yet.