### PR TITLE
Shape proto fix

### DIFF
--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -15,7 +15,7 @@
   <description>Platform-dependent native code and pure-Java code for the TensorFlow machine intelligence library.</description>
 
   <properties>
-    <ndarray.version>1.0.0-rc.1</ndarray.version>
+    <ndarray.version>1.0.0</ndarray.version>
     <truth.version>1.1.5</truth.version>
     <test.download.skip>false</test.download.skip>
     <test.download.folder>${project.build.directory}/tf-text-download/</test.download.folder>

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Signature.java
@@ -158,11 +158,15 @@ public class Signature {
       return new Signature(key, signatureBuilder.build());
     }
 
-    private static TensorInfo toTensorInfo(Output<?> operand) {
+    static TensorInfo toTensorInfo(Output<?> operand) {
       Shape shape = operand.shape();
       TensorShapeProto.Builder tensorShapeBuilder = TensorShapeProto.newBuilder();
-      for (int i = 0; i < shape.numDimensions(); ++i) {
-        tensorShapeBuilder.addDim(Dim.newBuilder().setSize(shape.size(i)));
+      if (shape.isUnknown()) {
+        tensorShapeBuilder.setUnknownRank(true);
+      } else {
+        for (int i = 0; i < shape.numDimensions(); ++i) {
+          tensorShapeBuilder.addDim(Dim.newBuilder().setSize(shape.get(i)));
+        }
       }
       return TensorInfo.newBuilder()
           .setDtype(operand.dataType())

--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SignatureTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/SignatureTest.java
@@ -19,8 +19,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.tensorflow.Signature.TensorDescription;
+import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Placeholder;
+import org.tensorflow.op.math.Sign;
 import org.tensorflow.proto.DataType;
+import org.tensorflow.types.TInt32;
 
 public class SignatureTest {
 
@@ -79,5 +83,29 @@ public class SignatureTest {
     assertNull(signature.methodName());
     signature = Signature.builder().key("f").methodName(null).build();
     assertNull(signature.methodName());
+  }
+
+  @Test
+  public void createTensorInfoFromOperandWithUnknownShape() {
+    try (Graph g = new Graph()) {
+      var tf = Ops.create(g);
+      var placeholder = tf.placeholder(TInt32.class);
+      var tensorInfo = Signature.Builder.toTensorInfo(placeholder.asOutput());
+      assertTrue(tensorInfo.getTensorShape().getUnknownRank());
+      assertEquals(0, tensorInfo.getTensorShape().getDimCount());
+    }
+  }
+
+  @Test
+  public void createTensorInfoFromOperandWithPartiallyUnknownShape() {
+    try (Graph g = new Graph()) {
+      var tf = Ops.create(g);
+      var placeholder = tf.placeholder(TInt32.class, Placeholder.shape(Shape.of(Shape.UNKNOWN_SIZE, 10)));
+      var tensorInfo = Signature.Builder.toTensorInfo(placeholder.asOutput());
+      assertFalse(tensorInfo.getTensorShape().getUnknownRank());
+      assertEquals(2, tensorInfo.getTensorShape().getDimCount());
+      assertEquals(-1, tensorInfo.getTensorShape().getDim(0).getSize());
+      assertEquals(10, tensorInfo.getTensorShape().getDim(1).getSize());
+    }
   }
 }


### PR DESCRIPTION
Mark shape as "unknown rank" when it is completely unknown. Right now, it was behaving as a scalar (i.e. just without any dimension set).

Also update `ndarray` dependency version