### PR TITLE
linux-arm64: add build support for native and framework jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,18 @@
       </activation>
     </profile>
     <profile>
+      <id>linux-arm64</id>
+      <activation>
+        <os>
+          <name>linux</name>
+          <arch>aarch64</arch>
+        </os>
+        <property>
+          <name>!javacpp.platform.extension</name>
+        </property>
+      </activation>
+    </profile>
+    <profile>
       <id>macosx</id>
       <activation>
         <os><name>mac os x</name></os>

--- a/tensorflow-core/tensorflow-core-native/pom.xml
+++ b/tensorflow-core/tensorflow-core-native/pom.xml
@@ -131,6 +131,12 @@
                       <version>${project.version}</version>
                       <classifier>${javacpp.platform.windows-x86_64}</classifier>
                     </artifactItem>
+                    <artifactItem>
+                      <groupId>${project.groupId}</groupId>
+                      <artifactId>${project.artifactId}</artifactId>
+                      <version>${project.version}</version>
+                      <classifier>${javacpp.platform.linux-arm64}</classifier>
+                    </artifactItem>
                   </artifactItems>
                 </configuration>
               </execution>
@@ -168,6 +174,10 @@
                     <artifact>
                       <file>${project.build.directory}/${project.artifactId}-${project.version}-${javacpp.platform.windows-x86_64}.jar</file>
                       <classifier>${javacpp.platform.windows-x86_64}</classifier>
+                    </artifact>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}-${javacpp.platform.linux-arm64}.jar</file>
+                      <classifier>${javacpp.platform.linux-arm64}</classifier>
                     </artifact>
                   </artifacts>
                 </configuration>

--- a/tensorflow-core/tensorflow-core-native/scripts/dist_download.sh
+++ b/tensorflow-core/tensorflow-core-native/scripts/dist_download.sh
@@ -20,6 +20,9 @@ case ${PLATFORM:-} in
     WHEEL_URL='https://files.pythonhosted.org/packages/e0/36/6278e4e7e69a90c00e0f82944d8f2713dd85a69d1add455d9e50446837ab/tensorflow_intel-2.16.1-cp311-cp311-win_amd64.whl'
     CLIB_URL='https://storage.googleapis.com/tensorflow/versions/2.16.1/libtensorflow-cpu-windows-x86_64.zip'
     ;;
+  'linux-arm64')
+    WHEEL_URL='https://files.pythonhosted.org/packages/41/ab/e5386c722548df2043c1eaadc431ea3ba0ee42a66b3af7f8013bbbacecd3/tensorflow-2.16.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl'
+    ;;
   *)
     echo "TensorFlow distribution for ${PLATFORM} is not supported for download"
     exit 1;

--- a/tensorflow-core/tensorflow-core-native/scripts/dist_download.sh
+++ b/tensorflow-core/tensorflow-core-native/scripts/dist_download.sh
@@ -37,6 +37,9 @@ if [[ -n "$WHEEL_URL" ]]; then
     curl -L $WHEEL_URL --output 'tensorflow.whl'
   fi
   yes | unzip -q -u 'tensorflow.whl' # use 'yes' because for some reasons -u does not work on Windows
+  if [[ "$PLATFORM" == "linux-arm64" ]]; then
+    cp $DOWNLOAD_FOLDER/tensorflow.libs/*  $DOWNLOAD_FOLDER/tensorflow/
+  fi
 fi
 
 if [[ -n "$CLIB_URL" ]]; then
@@ -51,6 +54,9 @@ cd tensorflow
 if [[ "$PLATFORM" =~ "linux" ]]; then
   ln -fs libtensorflow_cc.so.2 libtensorflow_cc.so
   ln -fs libtensorflow_framework.so.2 libtensorflow_framework.so
+  if [[ "$PLATFORM" == "linux-arm64" ]]; then
+    ln -fs libomp-*.so.5 libomp.so
+  fi
 elif [[ "$PLATFORM" =~ "macosx" ]]; then
   ln -fs libtensorflow_cc.2.dylib libtensorflow_cc.dylib
   ln -fs libtensorflow_framework.2.dylib libtensorflow_framework.dylib

--- a/tensorflow-core/tensorflow-core-native/src/main/java/org/tensorflow/internal/c_api/presets/tensorflow.java
+++ b/tensorflow-core/tensorflow-core-native/src/main/java/org/tensorflow/internal/c_api/presets/tensorflow.java
@@ -63,6 +63,9 @@ import org.bytedeco.javacpp.tools.InfoMapper;
           link = {"tensorflow_cc@.2", "tensorflow_framework@.2"},
           resource = {"LICENSE", "THIRD_PARTY_TF_JNI_LICENSES"}),
       @Platform(
+          value = {"linux-arm64"},
+          link = {"tensorflow_cc@.2", "tensorflow_framework@.2", "omp@.5"}),
+      @Platform(
           value = "windows",
           preload = {
             "api-ms-win-crt-locale-l1-1-0",

--- a/tensorflow-core/tensorflow-core-platform/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform/pom.xml
@@ -47,6 +47,12 @@
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow-core-native</artifactId>
       <version>${project.version}</version>
+      <classifier>linux-arm64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-core-native</artifactId>
+      <version>${project.version}</version>
       <classifier>macosx-arm64</classifier>
     </dependency>
     <dependency>
@@ -73,7 +79,7 @@
             <configuration>
               <archive>
                 <manifestEntries>
-                  <Class-Path>tensorflow-core-api.jar tensorflow-core-native.jar tensorflow-core-native-linux-x86_64.jar tensorflow-core-native-macosx-arm64.jar tensorflow-core-native-macosx-x86_64.jar tensorflow-core-native-windows-x86_64.jar</Class-Path>
+                  <Class-Path>tensorflow-core-api.jar tensorflow-core-native.jar tensorflow-core-native-linux-x86_64.jar tensorflow-core-native-macosx-arm64.jar tensorflow-core-native-macosx-x86_64.jar tensorflow-core-native-windows-x86_64.jar tensorflow-core-native-linux-arm64.jar</Class-Path>
                   <Automatic-Module-Name>${java.module.name}</Automatic-Module-Name>
                 </manifestEntries>
               </archive>


### PR DESCRIPTION
TensorFlow v2.16.1 wheel artifacts are added
new dependencies are added for native jars
and made sure all unit tests passed.