### PR TITLE
CI: add CI support for linux-arm64 platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,10 +178,32 @@ jobs:
         run: |
           call mvn -f tensorflow-core/tensorflow-core-native/pom.xml deploy:deploy-file@native-only -B -e -Djavacpp.platform=${{ github.job }} -Djavacpp.platform.extension=${{ matrix.ext }} -Durl=${{ needs.prepare.outputs.repositoryUrl }}
           if ERRORLEVEL 1 exit /b
+  linux-arm64:
+    runs-on: linux-arm64-ubuntu2204
+    needs: prepare
+    strategy:
+       matrix:
+         ext: [""]
+    steps:
+      - name: Install environment
+        run: |
+          sudo apt update
+          sudo apt install -y curl wget unzip tar git gcc g++ maven default-jdk
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Build project
+        run: |
+          gcc --version
+          mvn -version
+          echo "<settings><servers><server><id>ossrh</id><username>${{ secrets.CI_DEPLOY_USERNAME }}</username><password>${{ secrets.CI_DEPLOY_PASSWORD }}</password></server></servers></settings>" > $HOME/.m2/settings.xml
+          mvn clean install -pl '!tensorflow-framework' -B -U -e -Djavacpp.platform=${{ github.job }} -Djavacpp.platform.extension=${{ matrix.ext }}
+      - name: Deploy native artifact
+        if: env.DEPLOY_RELEASE == 'true' || env.DEPLOY_SNAPSHOT == 'true'
+        run: mvn -f tensorflow-core/tensorflow-core-native/pom.xml deploy:deploy-file@native-only -B -e -Djavacpp.platform=${{ github.job }} -Djavacpp.platform.extension=${{ matrix.ext }} -Durl=${{ needs.prepare.outputs.repositoryUrl }}
 
   deploy:
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/staging') }} # DEPLOY_SNAPSHOT (releases should be signed and deployed manually from local machine)
-    needs: [linux-x86_64, macosx-x86_64, windows-x86_64, macosx-arm64]
+    needs: [linux-x86_64, macosx-x86_64, windows-x86_64, macosx-arm64, linux-arm64]
     runs-on: ubuntu-20.04
     steps:
       - name: Configure Java


### PR DESCRIPTION
I have tested the CI workflow using self-hosted runners on AWS Graviton instances.