### PR TITLE
Release 1.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,7 @@ For dependencies, we can use anything compliant with [this list](https://opensou
 
 ## Building
 
-To build all the artifacts locally, simply invoke the command `mvn install` at the root of this repository (or the Maven command of your choice). It is also
-possible to build artifacts with support for CUDA® by adding the `-Djavacpp.platform.extension=-gpu` argument to the Maven command.
+To build all the artifacts locally, simply invoke the command `mvn install` at the root of this repository (or the Maven command of your choice).
 
 ### JDK 16+
 
@@ -35,7 +34,7 @@ This can be done in `.mvn/jvm.config` or `MAVEN_OPTS`.
 ### Native Builds
 
 By default, the build will attempt to download the existing TensorFlow binaries from the web for the platform it is running on (so you need to have an active internet connection).
-If such binaries are not available for your platform, you will need to build the TensorFlow runtime library from sources, by appending the `-Dnative.build` argument to your Maven
+If such binaries are not available for your platform, you will need to build the TensorFlow runtime library from sources, by appending the `-Pnative-build` argument to your Maven
 command. This requires a valid environment for building TensorFlow, including the [bazel](https://bazel.build/) build tool and a few Python dependencies
 (please read [TensorFlow documentation](https://www.tensorflow.org/install/source) for more details). Note that building from sources can take multiple hours on a regular laptop.
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -49,6 +49,24 @@ The Java Module (jigsaw) names has been updated to drop the leading `org.`, as f
 - `tensorflow-core-native` : `tensorflow.nativelib`
 - `tensorflow-framework` :  `tensorflow.framework` (was `org.tensorflow.framework` before)
 
+### GPU Support
+
+Previous versions of TF Java were building a `tensorflow-core-platform-gpu` artifact upon which application could depend
+on to include any TensorFlow native library that GPU support enabled. Since TensorFlow has removed its support of GPU
+on all platforms other that Linux, we removed our platform JAR in favour of simply adding a dependency on the
+`linux-x86_64-gpu` native artifact. 
+```xml
+<dependency>
+    <group>org.tensorflow</group>
+    <artifact>tensorflow-core-native</artifact>
+    <version>1.0.0</version>
+    <classifier>linux-x86_64-gpu</classifier>
+</dependency>
+```
+Please note that including this dependency won't work if your application also depends on `tensorflow-core-platform`. If
+you need to support more platforms that Linux, you should include the other `tensorflow-core-native` dependencies 
+separately (see the [README](README.md) file).
+
 ### Session Run Result
 
 In versions before 0.4.0 `Session.Runner.run` and `TensorFunction.call` returned a `List<Tensor>`. In newer versions

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ systems with no GPU support, you should add the following dependencies:
 <dependency>
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-core-api</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
 </dependency>
 <dependency>
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-core-native</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
   <classifier>linux-x86_64</classifier>
 </dependency>
 ```
@@ -85,24 +85,24 @@ native dependencies as follows:
 <dependency>
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-core-api</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
 </dependency>
 <dependency>
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-core-native</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
   <classifier>linux-x86_64-gpu</classifier>
 </dependency>
 <dependency>
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-core-native</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
   <classifier>macosx-arm64</classifier>
 </dependency>
 <dependency>
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-core-native</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
   <classifier>windows-x86_64</classifier>
 </dependency>
 ```
@@ -123,7 +123,7 @@ simply add this dependency to your application:
 <dependency>
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-core-platform</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 
@@ -153,7 +153,7 @@ to add Sonatype OSS repository in your pom.xml, like the following
     <dependency>
         <groupId>org.tensorflow</groupId>
         <artifactId>tensorflow-core-platform</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```
@@ -175,7 +175,8 @@ This table shows the mapping between TensorFlow, TensorFlow Java and minimum sup
 | 0.5.0                   | 2.10.1             | 11 |
 | 1.0.0-rc.1              | 2.16.1             | 11 |
 | 1.0.0-rc.2              | 2.16.2             | 11 |
-| 1.0.0-SNAPSHOT          | 2.16.2             | 11 |
+| 1.0.0                   | 2.16.2             | 11 |
+| 1.1.0-SNAPSHOT          | 2.16.2             | 11 |
 
 ## How to Contribute?
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Only one dependency can be added per platform, meaning that you cannot add nativ
 In some cases, it might be preferable to add a single dependency that includes transitively all the artifacts 
 required to run TensorFlow Java on any [supported platforms](README.md#individual-dependencies)
 
-- `tensorflow-core-platform`: Includes `tensorflow-core-api`, plus native artifacts for `linux-x86_64`, `macosx-arm64`, `macosx-x86_64` and `windows-x86_64`
+- `tensorflow-core-platform`: Includes `tensorflow-core-api`, plus native artifacts for `linux-x86_64`, `linux-x86_64-arm64`, `macosx-arm64`, `macosx-x86_64` and `windows-x86_64`
 
 For example, to run TensorFlow Java on any CPU platform for which a binary is being distributed by this project, you can 
 simply add this dependency to your application:

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,12 +13,14 @@ Caution: The TensorFlow Java API is *not* covered by the TensorFlow
 
 ## Requirements
 
-TensorFlow Java runs on Java 8 and above, and supports out-of-the-box the
+TensorFlow Java runs on Java 11 and above, and supports out-of-the-box the
 following platforms:
 
-*   Ubuntu 16.04 or higher; 64-bit, x86
-*   macOS 10.12.6 (Sierra) or higher; 64-bit, x86
-*   Windows 7 or higher; 64-bit, x86
+*   Ubuntu 20.04 or higher; 64-bit, x86
+*   Ubuntu 22.04 or higher; 64-bit, arm
+*   macOS 12 or higher; 64-bit, x86
+*   macOS 14 or higher; 64-bit, arm
+*   Windows 10 or higher; 64-bit, x86
 
 *Note: To use TensorFlow on Android, see
 [TensorFlow Lite](https://tensorflow.org/lite)*
@@ -41,8 +43,7 @@ TensorFlow Java to your project. The easiest one is to add a dependency on the
 Core API and the native dependencies it requires to run on all supported
 platforms.
 
-You can also select the `tensorflow-core-platform-gpu` extension instead, which
-supports CUDA® on Linux and Windows platforms.
+To include CUDA® support for Linux x86, select the `tensorflow-core-native:linux-x86_64-gpu` artifact.
 
 In addition, a separate dependency on the `tensorflow-framework` library can be
 added to benefit from a rich set of utilities for TensorFlow-based machine
@@ -118,7 +119,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '1.0.0-rc.1'
+    compile group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '1.0.0-rc.2'
 }
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -59,7 +59,7 @@ For example,
 <dependency>
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-core-platform</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 
@@ -102,7 +102,7 @@ snapshots repository in your `pom.xml`.
     <dependency>
         <groupId>org.tensorflow</groupId>
         <artifactId>tensorflow-core-platform</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```
@@ -119,7 +119,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '1.0.0-rc.2'
+    compile group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '1.0.0'
 }
 ```
 
@@ -165,7 +165,7 @@ add the TensorFlow dependency to the project's `pom.xml` file:
         <dependency>
             <groupId>org.tensorflow</groupId>
             <artifactId>tensorflow-core-platform</artifactId>
-            <version>1.0.0-rc.2</version>
+            <version>1.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.tensorflow</groupId>
   <artifactId>tensorflow-java</artifactId>
-  <version>1.0.0-rc.2</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
 
   <name>TensorFlow Java Parent</name>

--- a/release.sh
+++ b/release.sh
@@ -34,7 +34,7 @@ fi
 # To get a shell to poke around the maven artifacts with.
 if [[ -z "${CMD}" ]]
 then
-  CMD="mvn clean deploy -B -e --settings ./settings.xml -Pdeploying -Preleasing -DstagingRepositoryId=${STAGING_SEQ}"
+  CMD="mvn clean deploy -B -e --settings ./settings.xml -Pdeploying -Preleasing -DstagingRepositoryId=orgtensorflow-${STAGING_SEQ}"
 fi
 
 export GPG_TTY=$(tty)

--- a/tensorflow-core/pom.xml
+++ b/tensorflow-core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.tensorflow</groupId>
     <artifactId>tensorflow-java</artifactId>
-    <version>1.0.0-rc.2</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>tensorflow-core</artifactId>
   <packaging>pom</packaging>

--- a/tensorflow-core/tensorflow-core-api/pom.xml
+++ b/tensorflow-core/tensorflow-core-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.tensorflow</groupId>
     <artifactId>tensorflow-core</artifactId>
-    <version>1.0.0-rc.2</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>tensorflow-core-api</artifactId>
   <packaging>jar</packaging>

--- a/tensorflow-core/tensorflow-core-generator/pom.xml
+++ b/tensorflow-core/tensorflow-core-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.tensorflow</groupId>
     <artifactId>tensorflow-core</artifactId>
-    <version>1.0.0-rc.2</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>tensorflow-core-generator</artifactId>
   <packaging>jar</packaging>

--- a/tensorflow-core/tensorflow-core-native/pom.xml
+++ b/tensorflow-core/tensorflow-core-native/pom.xml
@@ -72,7 +72,7 @@
         <bazel.generate.skip>false</bazel.generate.skip>
         <javacpp.clean.skip>false</javacpp.clean.skip>
         <javacpp.generate.skip>false</javacpp.generate.skip>
-        <dist.download.skip>true</dist.download.skip>
+        <dist.download.skip>false</dist.download.skip> <!-- FIXME Normally we shouldn't download the wheel when doing a full native builds, but the absl headers are missing if we don't... -->
       </properties>
     </profile>
 

--- a/tensorflow-core/tensorflow-core-native/pom.xml
+++ b/tensorflow-core/tensorflow-core-native/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.tensorflow</groupId>
     <artifactId>tensorflow-core</artifactId>
-    <version>1.0.0-rc.2</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>tensorflow-core-native</artifactId>
   <packaging>jar</packaging>

--- a/tensorflow-core/tensorflow-core-platform/pom.xml
+++ b/tensorflow-core/tensorflow-core-platform/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.tensorflow</groupId>
     <artifactId>tensorflow-core</artifactId>
-    <version>1.0.0-rc.2</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>tensorflow-core-platform</artifactId>
   <name>TensorFlow API Platform</name>

--- a/tensorflow-framework/pom.xml
+++ b/tensorflow-framework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.tensorflow</groupId>
     <artifactId>tensorflow-java</artifactId>
-    <version>1.0.0-rc.2</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>tensorflow-framework</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
This PR applies small changes in order to do the TF Java 1.0.0 release. 

It also includes a small change for fixing the native builds, that was failing due to missing absl headers. For now we will download these headers from the wheel.