### PR TITLE
Build custom Docker image for releases

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -45,6 +45,12 @@ then
   cp -f ~/.m2/settings.xml .
 fi
 
+docker build \
+  -f tools/Dockerfile.release \
+  -t tensorflow-java:latest \
+  --platform linux/amd64 \
+  .
+
 docker run \
   -e GPG_TTY="${GPG_TTY}" \
   -v ${PWD}:/tensorflow-java \
@@ -52,7 +58,7 @@ docker run \
   -w /tensorflow-java \
   -it \
   --platform linux/amd64 \
-  maven:3.8.6-jdk-11  \
+  tensorflow-java:latest \
   ${CMD}
 
 echo

--- a/tools/Dockerfile.release
+++ b/tools/Dockerfile.release
@@ -1,0 +1,7 @@
+FROM maven:3.8.6-jdk-11
+
+WORKDIR /root
+RUN curl -L https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_x64_linux_hotspot_17.0.13_11.tar.gz -o openjdk-17.tar.gz
+RUN tar zxvf openjdk-17.tar.gz
+ENV JAVA_HOME /root/jdk-17.0.13+11/
+


### PR DESCRIPTION
The `javadoc` binary coming in JDK11 is buggy and fails to generate documentation on valid comments (e.g. multi-line code blocks with `@annotations` in it).

All other official release of Maven docker images based on JDK17 have failed so far, for other reasons. So to unblock more easily the 1.0.0 release, we'll use a custom docker image that uses the JDK11 image as its base, then installs JDK17 on it, which is used for building the release in JDK11 compatibility mode. 

So the doc is generated properly and the compiled classes remain compatible with JDK11.