### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   check-format:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
       - name: Configure Java
         uses: actions/setup-java@v2
@@ -35,7 +35,7 @@ jobs:
         run: |
           mvn spotless:check -Pjdk17 -B -U -e
   prepare:
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     outputs:
       repositoryUrl: ${{ steps.repository.outputs.repositoryUrl }}
     steps:
@@ -91,7 +91,7 @@ jobs:
         if: env.DEPLOY_RELEASE == 'true' || env.DEPLOY_SNAPSHOT == 'true'
         run: mvn -f tensorflow-core/tensorflow-core-native/pom.xml deploy:deploy-file@native-only -B -e -Djavacpp.platform=${{ github.job }} -Djavacpp.platform.extension=${{ matrix.ext }} -Durl=${{ needs.prepare.outputs.repositoryUrl }}
   linux-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     needs: prepare
     strategy:
       matrix:
@@ -209,7 +209,7 @@ jobs:
   deploy:
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/staging') }} # DEPLOY_SNAPSHOT (releases should be signed and deployed manually from local machine)
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64, macosx-arm64, linux-arm64]
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
       - name: Configure Java
         uses: actions/setup-java@v2


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
