### PR TITLE
test(ops): add integration tests for unary math ops (Square, Abs)

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/GeneratedOperationsTest.java
+++ b/tensorflow-core/tensorflow-core-api/src/test/java/org/tensorflow/op/core/GeneratedOperationsTest.java
@@ -25,6 +25,7 @@ import org.tensorflow.Session;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
 import org.tensorflow.op.Ops;
+import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt32;
 
 public final class GeneratedOperationsTest {
@@ -77,6 +78,32 @@ public final class GeneratedOperationsTest {
       sess.runner().addTarget(initVariable).run();
       try (TInt32 result = (TInt32) sess.runner().fetch(x).run().get(0)) {
         assertEquals(3, result.getInt());
+      }
+    }
+  }
+
+  /**
+   * Test for basic unary math operations. Ensures that the JNI bridge correctly handles Square and
+   * Absolute value functions.
+   */
+  @Test
+  public void testUnaryMathOps() {
+    try (Graph g = new Graph();
+        Session sess = new Session(g)) {
+      Ops ops = Ops.create(g);
+
+      Operand<TFloat32> square = ops.math.square(ops.constant(4.0f));
+      @SuppressWarnings("unchecked")
+      TFloat32 squareRaw = (TFloat32) sess.runner().fetch(square).run().get(0);
+      try (TFloat32 result = squareRaw) {
+        assertEquals(16.0f, result.getFloat(), 0.0f);
+      }
+
+      Operand<TFloat32> abs = ops.math.abs(ops.constant(-5.5f));
+      @SuppressWarnings("unchecked")
+      TFloat32 absRaw = (TFloat32) sess.runner().fetch(abs).run().get(0);
+      try (TFloat32 result = absRaw) {
+        assertEquals(5.5f, result.getFloat(), 0.0f);
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a JUnit integration test to `GeneratedOperationsTest` that verifies
two fundamental unary math operations — `Square` and `Abs` — execute
correctly end-to-end through the TensorFlow Java API and the underlying
native C++ engine.

## Motivation

While generated operation bindings exist for `math.square` and `math.abs`,
there was no test confirming that scalar `TFloat32` values round-trip
correctly through a `Session` for these ops. This test provides a basic
but meaningful regression guard for the Java ↔ native bridge.

## Changes

- **`GeneratedOperationsTest.java`**: adds `testUnaryMathOps()`, which:
  - Constructs a `Graph` and `Session` using try-with-resources for
    correct native memory management
  - Verifies `square(4.0f)` produces `16.0f`
  - Verifies `abs(-5.5f)` produces `5.5f`

## Testing

Tested locally on Apple Silicon (macOS) using:
```bash
mvn test -pl tensorflow-core/tensorflow-core-api -Dtest=GeneratedOperationsTest
```

Result: `BUILD SUCCESS`, 0 failures, 0 errors.

## Checklist

- [x] Code follows the Google Java Style Guide
- [x] `mvn spotless:apply` has been run and formatting is clean
- [x] No new production code — test only
- [x] CLA will be signed upon request